### PR TITLE
Fix Redis/PostgreSQL connection in support bundle troubleshoot collectors

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: OpenHands is an AI-driven autonomous software engineer
 name: openhands
 appVersion: 1.5.0
-version: 0.3.6
+version: 0.3.7
 maintainers:
   - name: rbren
   - name: xingyao
@@ -42,7 +42,7 @@ dependencies:
     condition: replicated.enabled
   - name: runtime-api
     repository: oci://ghcr.io/all-hands-ai/helm-charts
-    version: 0.2.3
+    version: 0.2.4
     condition: runtime-api.enabled
   - name: automation
     repository: oci://ghcr.io/all-hands-ai/helm-charts

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -129,19 +129,19 @@ spec:
     {{- if .Values.postgresql.enabled }}
     - postgresql:
         collectorName: postgresql
-        uri: postgresql://postgres:@{{ .Release.Name }}-postgresql:5432/openhands?sslmode=disable
+        uri: postgresql://postgres:@{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local:5432/openhands?sslmode=disable
         tls:
           disabled: true
         password:
-          secretName: {{ .Release.Name }}-postgresql
+          secretName: {{ .Values.postgresql.auth.existingSecret }}
           secretKey: postgres-password
     {{- end }}
     {{- if .Values.redis.enabled }}
     - redis:
         collectorName: redis
-        uri: redis://{{ .Release.Name }}-redis-master:6379
+        uri: redis://{{ .Release.Name }}-redis-master.{{ .Release.Namespace }}.svc.cluster.local:6379
         password:
-          secretName: {{ .Release.Name }}-redis
+          secretName: {{ .Values.redis.auth.existingSecret }}
           secretKey: redis-password
     {{- end }}
   analyzers: {{- include "troubleshoot.analyzers.shared" .  | nindent 4 }}

--- a/charts/runtime-api/Chart.yaml
+++ b/charts/runtime-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: runtime-api
 description: A Helm chart for the FastAPI application
-version: 0.2.3 # Change this to trigger a new helm chart version being published
+version: 0.2.4 # Change this to trigger a new helm chart version being published
 appVersion: "1.0.0"
 dependencies:
   - name: postgresql

--- a/charts/runtime-api/templates/troubleshoot/support-bundle.yaml
+++ b/charts/runtime-api/templates/troubleshoot/support-bundle.yaml
@@ -26,11 +26,11 @@ spec:
           maxAge: 168h
     - postgresql:
         collectorName: postgresql
-        uri: postgresql://postgres:@{{ include "runtime-api.postgresql.host" . }}:5432/{{ .Values.postgresql.auth.database | default "runtime_api" }}?sslmode=disable
+        uri: postgresql://postgres:@{{ include "runtime-api.postgresql.host" . }}.{{ .Release.Namespace }}.svc.cluster.local:5432/{{ .Values.postgresql.auth.database | default "runtime_api" }}?sslmode=disable
         tls:
           disabled: true
         password:
-          secretName: {{ .Release.Name }}-postgresql
+          secretName: {{ .Values.postgresql.auth.existingSecret }}
           secretKey: postgres-password
     {{- end }}
   analyzers: {{- include "runtime.troubleshoot.analyzers.shared" .  | nindent 4 }}


### PR DESCRIPTION
## Summary

Fixes the Redis "no such host" error in Troubleshoot support bundle collectors.

## Changes

- **Use FQDN for service URIs**: Changed Redis and PostgreSQL URIs to use fully qualified domain names (`.svc.cluster.local`) to ensure DNS resolution works regardless of where the collector runs
- **Fix Redis secret reference**: Use dynamic secret name from `Values.redis.auth.existingSecret` instead of hardcoded `{{ .Release.Name }}-redis` pattern
- **Bump chart versions**: openhands 0.3.7, runtime-api 0.2.4

## Details

The support bundle collector was failing with:
```
{"isConnected":false,"error":"dial tcp: lookup openhands-redis-master on ***:53: no such host"}
```

This was caused by:
1. Using short service names without the full Kubernetes DNS suffix
2. Redis secret name mismatch (the c2. Redis secret name mismatch (the c2. Redis secrol2. Redis secreking for `openhands-redis`)

## Testing

- [ ] Helm lint passes
- [ ] Support bundle collection succeeds with Redis/Post- [ ] Support bundl checks