### PR TITLE
fix: repair PR 1031 ClickHouse retention validation

### DIFF
--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -136,7 +136,7 @@ spec:
               fi
               echo
             }
-            run "system diagnostic table sizes and ttl" "SELECT database, name, total_rows, formatReadableSize(total_bytes) AS size, metadata_modification_time, if(position(create_table_query, 'TTL') = 0, 'none', substring(create_table_query, position(create_table_query, 'TTL'), 160)) AS ttl FROM system.tables WHERE database = 'system' AND name IN ('asynchronous_metric_log','metric_log','query_log','query_thread_log','query_views_log','part_log','session_log','text_log','trace_log','crash_log','opentelemetry_span_log','zookeeper_log','blob_storage_log','processors_profile_log') ORDER BY total_bytes DESC FORMAT JSONEachRow"
+            run "system diagnostic table sizes and ttl" "SELECT database, name, total_rows, formatReadableSize(total_bytes) AS size, metadata_modification_time, if(position(engine_full, 'TTL ') = 0, 'none', substring(engine_full, position(engine_full, 'TTL '), 160)) AS ttl FROM system.tables WHERE database = 'system' AND name IN ('asynchronous_metric_log','metric_log','query_log','query_thread_log','query_views_log','part_log','session_log','text_log','trace_log','crash_log','opentelemetry_span_log','zookeeper_log','blob_storage_log','processors_profile_log') ORDER BY total_bytes DESC FORMAT JSONEachRow"
             run "recent trace_log rows" "SELECT event_time, trace_type, thread_name, query_id FROM system.trace_log ORDER BY event_time DESC LIMIT 50 FORMAT JSONEachRow"
             run "recent text_log rows" "SELECT event_time, level, logger_name, message FROM system.text_log ORDER BY event_time DESC LIMIT 50 FORMAT JSONEachRow"
         timeout: 30s

--- a/charts/openhands/tests/laminar_clickhouse_support_bundle_test.yaml
+++ b/charts/openhands/tests/laminar_clickhouse_support_bundle_test.yaml
@@ -1,0 +1,26 @@
+suite: laminar clickhouse support bundle diagnostics
+templates:
+  - troubleshoot/secrets.yaml
+  - troubleshoot/preflights.yaml
+  - troubleshoot/support-bundle.yaml
+  - troubleshoot/_shared.tpl
+  - troubleshoot/_sysbox.tpl
+  - troubleshoot/_tls-hostname.tpl
+release:
+  name: openhands
+tests:
+  - it: reads table TTLs from engine metadata without matching column comments
+    set:
+      laminar.enabled: true
+      replicated.enabled: true
+    asserts:
+      - template: troubleshoot/secrets.yaml
+        documentIndex: 1
+        matchRegex:
+          path: stringData.support-bundle-spec
+          pattern: "position\\(engine_full, 'TTL '\\)"
+      - template: troubleshoot/secrets.yaml
+        documentIndex: 1
+        notMatchRegex:
+          path: stringData.support-bundle-spec
+          pattern: "position\\(create_table_query, 'TTL'\\)"

--- a/charts/openhands/tests/values_schema_test.yaml
+++ b/charts/openhands/tests/values_schema_test.yaml
@@ -37,13 +37,13 @@ tests:
       laminar.clickhouse.diagnostics.retentionDays: 4
     asserts:
       - failedTemplate:
-          errorPattern: "laminar/clickhouse/diagnostics/retentionDays.*Must be less than or equal to 3"
+          errorPattern: "laminar/clickhouse/diagnostics/retentionDays.*maximum: got 4, want 3"
   - it: rejects ClickHouse diagnostic retention below the supported bound
     set:
       laminar.clickhouse.diagnostics.retentionDays: 0
     asserts:
       - failedTemplate:
-          errorPattern: "laminar/clickhouse/diagnostics/retentionDays.*Must be greater than or equal to 1"
+          errorPattern: "laminar/clickhouse/diagnostics/retentionDays.*minimum: got 0, want 1"
   - it: rejects a non-string filestore.region
     set:
       filestore.region: true

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -1083,7 +1083,7 @@ spec:
             cloudProvider: "aws"
           clickhouse:
             diagnostics:
-              retentionDays: {{repl ConfigOption "clickhouse_diagnostic_log_retention_days" }}
+              retentionDays: repl{{ ConfigOption "clickhouse_diagnostic_log_retention_days" }}
             persistence:
               storageClass: "openebs-hostpath" # default storage class for the k0s embededed cluster
             s3:


### PR DESCRIPTION
## Summary

Follow-up for #1031 that fixes the blockers found during customer-instance QA without competing with or replacing the original PR.

- render the Replicated retention value with the manifest's established `repl{{ ... }}` numeric scalar form
- align the Helm schema assertions with the errors emitted by Helm
- read ClickHouse TTL metadata from `system.tables.engine_full` so column comments such as `TTLRecompressMerge` do not create false positives
- add regression coverage for the support-bundle TTL query

## Evidence

The original TTL hook was validated against disposable ClickHouse 25.10: a one-day TTL removed a four-day-old diagnostic row after merge while preserving a current row.

The corrected support-bundle query was also exercised against two representative tables:

```text
metric_log                    none
processors_profile_log        TTL event_date + toIntervalDay(30) ...
```

This proves that column-comment text is ignored while a real engine TTL is reported.

## Testing

- raw YAML parse: passed
- `python3 scripts/check_secret_checksum.py`: passed
- CI script suite: **451 passed**
- Helm unittest with CI versions (Helm 3.18.4, plugin 1.1.1): **86 passed**
- retention Job render and extracted Bash `-n`: passed
- disposable ClickHouse 25.10 TTL diagnostic behavior: passed
- `git diff --check`: passed

GitHub Advanced Security secret scanning is not enabled for this repository; the four-file patch was manually reviewed and contains no credentials.

Once merged into `fix-clickhouse-diagnostic-log-retention`, the original PR title still needs a conventional prefix such as `fix:`.

_This pull request was created by an AI agent (OpenHands) on behalf of Rajiv Shah._