### PR TITLE
feat(chart): OHE-3021 : expose OH_SANDBOX_MAX_NUM_SANDBOXES as a ConfigOption

### DIFF
--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -88,6 +88,11 @@ env:
   # each sandbox ingress. The default nests sandboxes under the runtime base,
   # matching the runtime-api's own "." separator.
   RUNTIME_URL_PATTERN: "https://{runtime_id}.runtime.app.example.com"
+  # Maximum number of concurrent sandboxes the app will start (0 = no cap).
+  # The Replicated installer exposes this as the sandbox_max_num_sandboxes
+  # ConfigOption; leave at 0 here so non-Replicated installs are uncapped by
+  # default and operators opt in to a limit.
+  OH_SANDBOX_MAX_NUM_SANDBOXES: "0"
   # replace prod/claude-3-7-sonnet-20250219 with your LLM model and uncomment or override this variable
   # LITELLM_DEFAULT_MODEL: "litellm_proxy/prod/claude-3-7-sonnet-20250219"
 

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1239,6 +1239,20 @@ spec:
             regex:
               pattern: ^(0|[1-9][0-9]*)$
               message: Must be a non-negative integer
+        - name: sandbox_max_num_sandboxes
+          title: Max Concurrent Sandboxes
+          help_text: >-
+            Maximum number of concurrent sandboxes the app will start across the
+            cluster. Set to 0 (default) for no cap. Use this to bound resource
+            consumption on shared or memory-constrained clusters; once the cap is
+            reached, new conversations wait for an existing sandbox to be freed
+            rather than spawning a new one.
+          type: text
+          default: "0"
+          validation:
+            regex:
+              pattern: ^(0|[1-9][0-9]*)$
+              message: Must be a non-negative integer
         - name: custom_sandbox_image_enabled
           title: Use a Custom Sandbox Image
           help_text: Use this if you bundle a custom agent-server image.

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -72,6 +72,7 @@ spec:
       # example.com, so this has to be set explicitly. The path-routing block
       # further down replaces it with the <base>/{runtime_id} form.
       RUNTIME_URL_PATTERN: 'https://{runtime_id}{{repl ConfigOption "computed_runtime_hostname_separator" }}{{repl ConfigOption "computed_runtime_base_hostname" }}'
+      OH_SANDBOX_MAX_NUM_SANDBOXES: 'repl{{ ConfigOption "sandbox_max_num_sandboxes" }}'
       # OH_AGENT_SERVER_ENV is assembled by the chart from
       # spec.values.global.agentServerEnv, not hand-written here.
       OPENHANDS_DEFAULT_ORG_ENABLED: 'repl{{ ConfigOptionEquals "default_openhands_org_enabled" "1" }}'


### PR DESCRIPTION
## Description

Exposes `OH_SANDBOX_MAX_NUM_SANDBOXES` as a configurable value, letting operators cap the number of concurrent sandboxes the app will start. This bounds resource consumption on shared or memory-constrained clusters; once the cap is reached, new conversations wait for an existing sandbox to be freed rather than spawning a new one.

The change follows the same plumbing path as the existing `RUNTIME_URL_PATTERN` variable, applied in three coordinated places:

- **`charts/openhands/values.yaml`** — added the env var to the `env:` block (default `"0"` = no cap), so non-Replicated installs are uncapped unless an operator opts in.
- **`replicated/config.yaml`** — added a `sandbox_max_num_sandboxes` ConfigOption in the `sandbox_configuration` group, modeled on the adjacent `sandbox_warm_runtime_count` (text type with a `^(0|[1-9][0-9]*)$` non-negative-integer regex validation). Default `"0"`.
- **`replicated/openhands.yaml`** — wired the ConfigOption into the app-server env block. The path-routing `optionalValues` block uses `recursiveMerge: true` and only overrides `RUNTIME_URL_PATTERN`, so the new var is inherited there automatically — no repetition needed.

## Helm Chart Checklist

- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

- The default of `"0"` (uncapped) preserves the chart's prior behavior — no cap existed before — so this is a pure opt-in addition with no behavioral change for existing installs.
- Verification: `helm template` renders `OH_SANDBOX_MAX_NUM_SANDBOXES` in the app-server, runtime-api, and warm-runtime envs (mirrored everywhere `RUNTIME_URL_PATTERN` goes). All existing env-wiring test suites pass (`filestore env`, `smtp env`, `valkey env`, `sandbox hostname layout`). The 4 pre-existing subchart test failures (missing `device-plugin` daemonset templates) are unrelated and present on `main` without these changes.

_This PR was created by an AI agent (OpenHands) on behalf of the user._