### PR TITLE
Bump agent-server from 1.39.1 to 1.41.0

### DIFF
--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -1,7 +1,7 @@
 # Agent-server image the loader pre-pulls onto nodes; keep tag in sync with the sandbox runtime.
 image:
   repository: ghcr.io/openhands/agent-server
-  tag: 1.39.1-python
+  tag: 1.41.0-python
   pullPolicy: Always
 
 resources:

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -317,7 +317,7 @@ global:
   # global wins; this default only applies when rendering the subchart alone.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.39.1-python
+    tag: 1.41.0-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1272,7 +1272,7 @@ global:
   # either of those for per-use exceptions; set it here to move them together.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.39.1-python
+    tag: 1.41.0-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1266,9 +1266,9 @@ spec:
           required: true
         - name: custom_sandbox_image_tag
           title: Sandbox Image Tag
-          help_text: Image tag, e.g. 1.39.1-python
+          help_text: Image tag, e.g. 1.41.0-python
           type: text
-          default: "1.39.1-python"
+          default: "1.41.0-python"
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: true
         - name: custom_sandbox_image_registry_server


### PR DESCRIPTION
## Description

Bumps the agent-server image tag from `1.39.1-python` to `1.41.0-python` across all locations that reference it:

- `charts/image-loader/values.yaml` — image-loader pre-pull tag
- `charts/openhands/values.yaml` — global `agentServerImage` tag
- `charts/openhands/charts/runtime-api/values.yaml` — runtime-api subchart default tag
- `replicated/config.yaml` — Replicated config default and help text for the sandbox image tag

## Helm Chart Checklist

- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

This is a routine version bump of the agent-server image. No values schema or breaking changes are introduced — the tag is the only field modified. Existing `values.yaml` overrides for the image tag continue to take precedence over these defaults.

_This PR was created by an AI agent (OpenHands) on behalf of the user._