### PR TITLE
test(e2e): cover org admin rename via 006 admin fixture

### DIFF
--- a/e2e_tests/tests/006-org-management.spec.ts
+++ b/e2e_tests/tests/006-org-management.spec.ts
@@ -69,9 +69,14 @@ test.describe.serial("org management", () => {
     // 2. Provision the New User into the new org. The endpoint is idempotent:
     //    if the user already exists (e.g. from a prior GitHub login), this
     //    only ensures org membership and returns the existing API key.
+    // Admin role so the new user can exercise org-management UI (e.g. the
+    // org-rename spec 008). The endpoint is idempotent: if the user already
+    // exists, this only ensures org membership and returns the existing API
+    // key. The role is only set on first add; an existing member's role is
+    // left untouched, so the org must be freshly created by the prior step.
     provisioned = await provisionUser(baseURL || "", apiKey, org.id, {
       email,
-      role: "member",
+      role: "admin",
     });
 
     console.log(

--- a/e2e_tests/tests/008-org-admin-rename.spec.ts
+++ b/e2e_tests/tests/008-org-admin-rename.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test, type Page } from "@playwright/test";
+import { runUser } from "../utils/config";
+
+/**
+ * Org admin rename spec.
+ *
+ * This suite proves an organization admin can rename the selected
+ * non-personal organization and restore the original name. It runs **only
+ * for the "new-user" role**: the returning-user role is skipped inside
+ * each test (via ``runUser``) so a run without ``NEW_GITHUB_USERNAME`` is
+ * unaffected.
+ *
+ * The new user is provisioned as an ``admin`` of a fresh, non-personal
+ * organization by the org-management spec (``006-org-management``), which
+ * leaves the org in place as a fixture for subsequent specs. This spec
+ * re-derives that org at runtime via ``GET /api/organizations`` so it does
+ * not depend on cross-file state.
+ *
+ * Cleanup: restores the original organization name in the UI and again
+ * through the API in ``finally``.
+ *
+ * Risk: medium — temporarily changes the organization name. The org is
+ * dedicated to e2e runs, so avoid concurrent organization-setting tests.
+ */
+test.beforeEach(({ page: _page }, testInfo) => {
+  test.skip(
+    runUser(testInfo) !== "new-user",
+    "Requires the new-user role provisioned as an org admin.",
+  );
+});
+
+test.use({
+  screenshot: "off",
+  trace: "off",
+  video: "off",
+});
+
+type Organization = {
+  id: string;
+  name: string;
+  is_personal?: boolean;
+};
+
+async function requireAdminOrganization(page: Page): Promise<Organization> {
+  const organizationsResponse = await page.request.get("/api/organizations");
+  expect(organizationsResponse.ok()).toBe(true);
+  const organizations = (await organizationsResponse.json()) as {
+    items: Organization[];
+    current_org_id: string | null;
+  };
+  const organization = organizations.items.find(
+    ({ id }) => id === organizations.current_org_id,
+  );
+
+  if (!organization || organization.is_personal) {
+    throw new Error(
+      "The new-user fixture must select a non-personal organization.",
+    );
+  }
+
+  const meResponse = await page.request.get(
+    `/api/organizations/${organization.id}/me`,
+    { headers: { "X-Org-Id": organization.id } },
+  );
+  expect(meResponse.ok()).toBe(true);
+  const me = (await meResponse.json()) as { role?: string };
+  if (me.role !== "admin" && me.role !== "owner") {
+    throw new Error(
+      `This test requires an organization admin or owner; received role "${me.role ?? "unknown"}".`,
+    );
+  }
+
+  return organization;
+}
+
+test("organization admin can change the organization name and restore it", async ({
+  page,
+}) => {
+  const organization = await requireAdminOrganization(page);
+  const originalName = organization.name;
+  const temporaryName = `${originalName.slice(0, 42)} e2e ${Date.now()}`;
+  const headers = { "X-Org-Id": organization.id };
+
+  try {
+    await page.goto("/settings/org");
+    await expect(page.getByTestId("manage-org-screen")).toBeVisible();
+
+    const nameSection = page.getByTestId("org-name").first();
+    await nameSection.getByRole("button", { name: "Change" }).click();
+    const updateForm = page.getByTestId("update-org-name-form");
+    await updateForm.getByTestId("org-name").fill(temporaryName);
+    await updateForm.getByRole("button", { name: "Save" }).click();
+    await expect(nameSection).toContainText(temporaryName);
+
+    await nameSection.getByRole("button", { name: "Change" }).click();
+    await updateForm.getByTestId("org-name").fill(originalName);
+    await updateForm.getByRole("button", { name: "Save" }).click();
+    await expect(nameSection).toContainText(originalName);
+  } finally {
+    const restoreResponse = await page.request.patch(
+      `/api/organizations/${organization.id}`,
+      { data: { name: originalName }, headers },
+    );
+    expect
+      .soft(
+        restoreResponse.ok(),
+        `Failed to restore organization name (HTTP ${restoreResponse.status()}).`,
+      )
+      .toBe(true);
+  }
+});

--- a/e2e_tests/tests/008-org-admin-rename.spec.ts
+++ b/e2e_tests/tests/008-org-admin-rename.spec.ts
@@ -1,20 +1,21 @@
 import { expect, test, type Page } from "@playwright/test";
 import { runUser } from "../utils/config";
+import { HomePage } from "../pages";
 
 /**
  * Org admin rename spec.
  *
- * This suite proves an organization admin can rename the selected
- * non-personal organization and restore the original name. It runs **only
- * for the "new-user" role**: the returning-user role is skipped inside
- * each test (via ``runUser``) so a run without ``NEW_GITHUB_USERNAME`` is
- * unaffected.
+ * This suite proves an organization admin can rename a non-personal
+ * organization and restore the original name. It runs **only for the
+ * "new-user" role**: the returning-user role is skipped inside each test
+ * (via ``runUser``) so a run without ``NEW_GITHUB_USERNAME`` is unaffected.
  *
  * The new user is provisioned as an ``admin`` of a fresh, non-personal
  * organization by the org-management spec (``006-org-management``), which
  * leaves the org in place as a fixture for subsequent specs. This spec
- * re-derives that org at runtime via ``GET /api/organizations`` so it does
- * not depend on cross-file state.
+ * re-derives that org at runtime via ``GET /api/organizations`` and selects
+ * it through the user-context-menu org-selector if it is not already active,
+ * so it does not depend on cross-file state or a pre-selected org.
  *
  * Cleanup: restores the original organization name in the UI and again
  * through the API in ``finally``.
@@ -41,26 +42,71 @@ type Organization = {
   is_personal?: boolean;
 };
 
-async function requireAdminOrganization(page: Page): Promise<Organization> {
+type OrganizationsResponse = {
+  items: Organization[];
+  current_org_id: string | null;
+};
+
+/**
+ * Resolve and select the non-personal organization the new user was
+ * provisioned into. If it is not already the active org, switch to it via
+ * the user-context-menu org-selector so the org-settings page reflects it.
+ * Then verify the caller is an admin/owner of that org.
+ */
+async function selectAdminOrganization(page: Page): Promise<Organization> {
   const organizationsResponse = await page.request.get("/api/organizations");
   expect(organizationsResponse.ok()).toBe(true);
-  const organizations = (await organizationsResponse.json()) as {
-    items: Organization[];
-    current_org_id: string | null;
-  };
-  const organization = organizations.items.find(
-    ({ id }) => id === organizations.current_org_id,
-  );
+  const organizations =
+    (await organizationsResponse.json()) as OrganizationsResponse;
 
-  if (!organization || organization.is_personal) {
+  const target = organizations.items.find((org) => !org.is_personal);
+  if (!target) {
     throw new Error(
-      "The new-user fixture must select a non-personal organization.",
+      "No non-personal organization found for the new-user fixture. " +
+        "Ensure 006-org-management runs before this spec.",
     );
   }
 
+  // Switch to the target org via the UI org-selector if it is not already
+  // active. The org-settings page reflects the currently selected org, so
+  // we must be on the target org before navigating there.
+  if (organizations.current_org_id !== target.id) {
+    const homePage = new HomePage(page);
+    await homePage.goto();
+    await homePage.openUserMenu();
+
+    const orgSelector =
+      homePage.accountSettingsMenu.getByTestId("org-selector");
+    await expect(orgSelector).toBeVisible({ timeout: 10_000 });
+
+    const trigger = orgSelector.getByTestId("dropdown-trigger");
+    await expect(trigger).toBeEnabled({ timeout: 10_000 });
+    await trigger.click();
+
+    const listbox = orgSelector.getByRole("listbox");
+    await expect(listbox).toBeVisible({ timeout: 10_000 });
+    const option = listbox.getByRole("option", { name: target.name });
+    await expect(option).toBeVisible({ timeout: 10_000 });
+    await option.click();
+
+    // Wait for the selection to propagate so subsequent API/UI calls see
+    // the updated current_org_id.
+    await expect
+      .poll(
+        async () => {
+          const res = await page.request.get("/api/organizations");
+          const body = (await res.json()) as OrganizationsResponse;
+          return body.current_org_id;
+        },
+        { timeout: 10_000 },
+      )
+      .toBe(target.id);
+  }
+
+  // Verify admin/owner role within the target org.
   const meResponse = await page.request.get(
-    `/api/organizations/${organization.id}/me`,
-    { headers: { "X-Org-Id": organization.id } },
+    `/api/organizations/${target.id}/me`,
+    { headers: { "X-Org-Id": target.id } },
   );
   expect(meResponse.ok()).toBe(true);
   const me = (await meResponse.json()) as { role?: string };
@@ -70,13 +116,13 @@ async function requireAdminOrganization(page: Page): Promise<Organization> {
     );
   }
 
-  return organization;
+  return target;
 }
 
 test("organization admin can change the organization name and restore it", async ({
   page,
 }) => {
-  const organization = await requireAdminOrganization(page);
+  const organization = await selectAdminOrganization(page);
   const originalName = organization.name;
   const temporaryName = `${originalName.slice(0, 42)} e2e ${Date.now()}`;
   const headers = { "X-Org-Id": organization.id };


### PR DESCRIPTION
## Summary

Replaces the original approach (which mutated the returning user's shared org) with one that runs against the dedicated e2e org created by `006-org-management`.

### Changes

- **`006-org-management.spec.ts`** — provision the new user as an org `admin` (was `member`) so the ephemeral org it creates can back specs that need an admin session. The provision-user endpoint only sets the role on first add, so the org must be freshly created — which 006 already guarantees.
- **`008-org-admin-rename.spec.ts`** (new) — self-contained spec that re-derives that org at runtime via `GET /api/organizations`, verifies the caller is an admin/owner, renames the org, restores the name, and restores again via API in `finally` as a safety net.

### Why not promote via superadmin API key?

The role-change endpoint (`PATCH /{org_id}/members/{user_id}`) checks the requester's **org membership**, not super-role. A superadmin who is not a member of the org gets `403`. Re-provisioning an existing member does not update their role either (the endpoint is idempotent and leaves existing roles untouched). So the only reliable way to get an admin session for the rename spec is to provision as `admin` at creation time.

### Test plan

- [x] `npx tsc --noEmit`
- [x] `npx eslint tests/008-org-admin-rename.spec.ts tests/006-org-management.spec.ts`
- [x] `npx prettier --check` (both files)
- [x] `npx playwright test tests/008-org-admin-rename.spec.ts --list --project=chromium:new-user` (1 test discovered)
- [ ] Live run against a release environment with `NEW_GITHUB_USERNAME` + `SUPER_ADMIN_API_KEY` set

_Note: the UI selectors (`manage-org-screen`, `update-org-name-form`, etc.) live in the private enterprise frontend repo, so live execution requires a full deployment._

---

_This PR was updated by an AI agent (OpenHands) on behalf of the user._