### PR TITLE
fix: wire installer SMTP config into Keycloak realm email

### DIFF
--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -377,16 +377,20 @@
   value: {{ .Values.smtp.useSsl | default false | quote }}
 - name: SMTP_USE_TLS
   value: {{ .Values.smtp.useTls | default true | quote }}
+{{- /* Optional: the smtp-credentials secret only renders the keys that were
+       provided, and servers that accept unauthenticated relay need neither. */}}
 - name: SMTP_USERNAME
   valueFrom:
     secretKeyRef:
       name: {{ .Values.smtp.auth.existingSecret }}
       key: smtp-username
+      optional: true
 - name: SMTP_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ .Values.smtp.auth.existingSecret }}
       key: smtp-password
+      optional: true
 {{- end }}
 {{- if .Values.tavily.enabled }}
 - name: TAVILY_API_KEY

--- a/charts/openhands/templates/keycloak-config-script.yaml
+++ b/charts/openhands/templates/keycloak-config-script.yaml
@@ -110,6 +110,27 @@ data:
       /tmp/allhands-realm-github-provider.json > /tmp/allhands-realm-with-sessions.json
     mv /tmp/allhands-realm-with-sessions.json /tmp/allhands-realm-github-provider.json
     REALM_JSON=/tmp/allhands-realm-github-provider.json
+    {{- if .Values.smtp.enabled }}
+    # Point the realm's outgoing email at the deployment's configured SMTP
+    # server instead of the template's built-in default, so installer-configured
+    # SMTP also drives Keycloak's account emails (verification, account linking,
+    # password reset). Applies on both the create and update paths below.
+    SMTP_AUTH="false"
+    if [ -n "$SMTP_USERNAME" ]; then
+      SMTP_AUTH="true"
+    fi
+    jq --arg host "$SMTP_HOST" --arg port "$SMTP_PORT" \
+       --arg from "$SMTP_FROM_EMAIL" --arg ssl "$SMTP_USE_SSL" \
+       --arg starttls "$SMTP_USE_TLS" --arg auth "$SMTP_AUTH" \
+       --arg user "${SMTP_USERNAME:-}" --arg password "${SMTP_PASSWORD:-}" \
+       '.smtpServer = {host: $host, port: $port, from: $from,
+         fromDisplayName: "", replyTo: "", replyToDisplayName: "",
+         envelopeFrom: "", ssl: $ssl, starttls: $starttls, auth: $auth,
+         user: $user, password: $password}' \
+       $REALM_JSON > /tmp/allhands-realm-with-smtp.json
+    mv /tmp/allhands-realm-with-smtp.json $REALM_JSON
+    echo "Applied deployment SMTP settings to realm smtpServer."
+    {{- end }}
 
     if [ "$ERROR_MESSAGE" = "Realm not found." ]; then
       echo "Creating allhands realm..."

--- a/charts/openhands/tests/smtp_env_test.yaml
+++ b/charts/openhands/tests/smtp_env_test.yaml
@@ -55,6 +55,7 @@ tests:
               secretKeyRef:
                 name: smtp-credentials
                 key: smtp-username
+                optional: true
       - template: deployment.yaml
         contains:
           path: spec.template.spec.containers[0].env
@@ -64,6 +65,7 @@ tests:
               secretKeyRef:
                 name: smtp-credentials
                 key: smtp-password
+                optional: true
 
   - it: reads credentials from an overridden existing secret
     set:
@@ -81,6 +83,7 @@ tests:
               secretKeyRef:
                 name: custom-smtp-secret
                 key: smtp-username
+                optional: true
       - template: deployment.yaml
         contains:
           path: spec.template.spec.containers[0].env
@@ -90,6 +93,7 @@ tests:
               secretKeyRef:
                 name: custom-smtp-secret
                 key: smtp-password
+                optional: true
 
   - it: falls back to SSL and defaults useTls when unset
     set:

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -996,11 +996,11 @@ spec:
 
     - name: smtp_configuration
       title: SMTP Email Delivery
-      description: Configure SMTP for OpenHands email notifications
+      description: Configure SMTP for OpenHands email notifications and Keycloak sign-in emails (email verification, account linking, password reset)
       items:
         - name: smtp_enabled
           title: Enable SMTP
-          help_text: Enable SMTP email delivery for budget alerts and admin notifications
+          help_text: Enable SMTP email delivery for budget alerts and admin notifications, and for Keycloak account emails (email verification, account linking, password reset)
           type: bool
           default: "0"
         - name: smtp_host
@@ -1036,7 +1036,7 @@ spec:
           when: 'repl{{ ConfigOptionEquals "smtp_enabled" "1" }}'
         - name: smtp_username
           title: SMTP Username
-          help_text: Username for SMTP authentication
+          help_text: Username for SMTP authentication. Leave blank if your SMTP server does not require authentication.
           type: text
           when: 'repl{{ ConfigOptionEquals "smtp_enabled" "1" }}'
         - name: smtp_password


### PR DESCRIPTION
## Description

Fixes [OHE-3061](https://linear.app/all-hands-ai/issue/OHE-3061) (part of the BuildOne lockout report [OHE-3063](https://linear.app/all-hands-ai/issue/OHE-3063)).

**Root cause.** On Replicated installs, Keycloak email could never work. The realm template (`charts/openhands/files/allhands-realm-github-provider.json.tmpl`) hard-codes All Hands' SaaS email provider (`smtp.resend.com`, user `resend`, from `admin@all-hands.dev`), with only the password substituted from `$KEYCLOAK_SMTP_PASSWORD`. On Replicated that value comes from the hidden KOTS item `keycloak_smtp_password`, seeded with `{{repl RandomString 32}}` — random garbage — so every Keycloak email flow (identity-link verification, email verification, password reset) failed with `535 Authentication credentials invalid`. The customer-visible **SMTP Email Delivery** config group only fed the app's notification emails, and `keycloak-config-script` re-applies the realm's `smtpServer` via PUT on every app-pod start, so manual admin-console corrections were reverted. (The hard-coded block is correct for SaaS, where the real Resend password comes from the SOPS-encrypted `keycloak-realm` secret in saas-deploy.)

**Fix.** Make the installer's existing SMTP configuration the source of truth for the realm's outgoing email:

- `charts/openhands/templates/keycloak-config-script.yaml` — new block, rendered only when `.Values.smtp.enabled`, that jq-overrides `.smtpServer` in the rendered realm JSON using the `SMTP_*` env vars the `keycloak-config` init container already receives via the shared `openhands.env` helper. `auth` is set from username presence; the override flows through both the realm-create and realm-update paths, so the restart-reapply behavior now _keeps_ the realm correct instead of reverting fixes, and enabling SMTP in the KOTS Admin Console repairs Keycloak email on the next deploy automatically.
- `charts/openhands/templates/_env.yaml` — `optional: true` on the `SMTP_USERNAME`/`SMTP_PASSWORD` secretKeyRefs. The `smtp-credentials` secret only renders keys that were provided, so an unauthenticated relay (blank username/password, which the KOTS config allows) previously left every pod in `CreateContainerConfigError`.
- `replicated/config.yaml` — help-text only: the SMTP group now states it also drives Keycloak sign-in emails (email verification, account linking, password reset), and the username field notes it may be left blank.
- `charts/openhands/tests/smtp_env_test.yaml` — existing assertions updated for the `optional: true` refs (no new tests).

**Deliberately unchanged:** the hidden `keycloak_smtp_password` item, the `keycloak-realm` secret's `smtp-password` key, and the realm template's Resend block — SaaS depends on all three, and they remain the fallback when SMTP is not configured (same non-functional state as today; no regression).

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

**Verification performed:**

- Simulated the script's full render path (envsubst → SSO-session jq → new SMTP jq) with `jq`: correct `smtpServer` for both authenticated and no-auth cases, special characters in passwords properly JSON-escaped, rest of the realm untouched; `auth: "false"` with empty user/password when no username is set.
- `helm template` with `smtp.enabled=true` shows the block correctly placed after the realm render; with `smtp.enabled=false` the rendered script is byte-identical to before (SaaS parity). Both extracted scripts pass `sh -n`.
- `helm unittest charts/openhands` (81 tests) and `helm unittest charts/openhands-secrets` (4 tests): all pass.
- `python3 -m pytest scripts/ -q`: all 451 pass, including the CI realm-template invariants.

**Not yet done (why the upgrade-path box is unchecked):** no live KOTS upgrade was executed. Upgrade safety was assessed statically: no values were added/renamed/removed, no stored KOTS config items changed (help text only), and the existing `checksum/keycloak-config` pod annotation forces a rollout that re-runs the idempotent config script. Recommend one smoke upgrade of a Replicated install with SMTP enabled before release.

**Follow-up out of scope:** OHE-3063 issue 2 — `provision-user` creates accounts with no federated identity link on SSO-only installs (enterprise server, not this repo). This PR restores the email-verification escape hatch for that flow but does not fix provisioning itself.

**Behavioral notes for reviewers:**

- If a customer later disables SMTP, the next restart reverts the realm to the (non-functional) Resend defaults — identical to the pre-fix state.
- The `from` address must be one the customer's SMTP provider permits; display-name form (`Team <a@b.c>`) is parsed fine by Keycloak's jakarta-mail.