### PR TITLE
fix(e2e): handle onboarding-form and 2FA auto-navigate race conditions

### DIFF
--- a/e2e_tests/utils/auth-helpers.ts
+++ b/e2e_tests/utils/auth-helpers.ts
@@ -229,9 +229,29 @@ async function handleOnboardingForm(
   // Drive each step until the form submits and the page navigates away from
   // /onboarding (redirects to "/" or "/canvas").
   while (page.url().includes("/onboarding")) {
-    await page
-      .getByTestId("onboarding-form")
-      .waitFor({ state: "visible", timeout: 15_000 });
+    // Only wait for the onboarding form while still on /onboarding. An
+    // already-onboarded user may be routed through /onboarding briefly
+    // before the app client-side redirects to "/" or "/canvas"; in that
+    // case the form never renders, so race the selector wait against that
+    // navigation and bail out when the URL moves off /onboarding.
+    const onForm = await Promise.race([
+      page
+        .getByTestId("onboarding-form")
+        .waitFor({ state: "visible", timeout: 15_000 })
+        .then(() => true)
+        .catch(() => false),
+      page
+        .waitForURL((url) => !url.toString().includes("/onboarding"), {
+          timeout: 15_000,
+        })
+        .then(() => false)
+        .catch(() => false),
+    ]);
+
+    if (!onForm) {
+      console.log("Onboarding form skipped; already onboarded.");
+      return;
+    }
 
     // Identify the current step by an element unique to it, so we can detect
     // when React swaps in the next step (the element becomes hidden).
@@ -375,17 +395,22 @@ async function handle2FA(page: Page, totpSecret: string): Promise<void> {
     const totpCode = await generateTOTP(totpSecret);
     await otpField.fill(totpCode);
 
-    // Wait briefly to see if JavaScript auto-submits the form
-    // Then check if we're still on the same page before clicking submit
+    // After filling the code, GitHub's JS usually auto-submits the form.
+    // Sometimes it does not — in that case we must click the "Verify" button
+    // ourselves. Detect the race by waiting briefly for the URL to navigate
+    // off the two-factor page; if it doesn't, click Verify. The two-factor
+    // page lives at /sessions/two-factor (e.g. /sessions/two-factor/app), so
+    // key the wait on that path rather than "authenticate".
     const isStillOn2FAPage = await page
-      .waitForURL((url) => !url.toString().includes("authenticate"), {
+      .waitForURL((url) => !url.toString().includes("/sessions/two-factor"), {
         timeout: 3_000,
       })
       .then(() => false)
       .catch(() => true);
 
     if (isStillOn2FAPage) {
-      await page.locator('input[type="submit"][value="Submit"]').click();
+      console.log("2FA page did not auto-navigate, clicking Verify...");
+      await page.getByRole("button", { name: "Verify" }).click();
     }
   }
 


### PR DESCRIPTION
## Description

Fixes two race conditions in the e2e auth setup flow that caused intermittent timeouts for already-onboarded / already-authenticated users in `e2e_tests/utils/auth-helpers.ts`.

**1. onboarding-form wait (setup-returning flow)**

For an already-onboarded returning user, the app can briefly route through `/onboarding` before client-side redirecting to `/` or `/canvas`. `completeLoginAndOnboard`'s Phase 1 URL wait accepts `/onboarding` as a "settled" destination, so `handleOnboardingForm` entered its unconditional `getByTestId("onboarding-form").waitFor()` while the page navigated to home, timing out at the "Wait for selector `getByTestId('onboarding-form')`" stage.

The selector wait is now raced against the URL moving off `/onboarding`; if the page reaches home first (already onboarded), the handler bails out cleanly instead of erroring. The wait only proceeds when the path is actually `/onboarding`.

**2. 2FA auto-navigate (handle2FA)**

After filling `app_otp`, the "still on 2FA page" check waited for the URL to stop containing `"authenticate"`, but the app-OTP page lives at `github.com/sessions/two-factor/app` — which never contains `"authenticate"`. The `waitForURL` predicate was immediately true, so `isStillOn2FAPage` was always `false` and the submit click was **always skipped** on this path. When the browser did not auto-navigate, nothing clicked Verify and the flow stalled.

The detection now keys on `/sessions/two-factor`, and when the page stays there it clicks `getByRole("button", { name: "Verify" })` (the current GitHub button) instead of the legacy `input[type=submit][value=Submit]`.

## Helm Chart Checklist

N/A — this PR modifies only the e2e test suite (`e2e_tests/utils/auth-helpers.ts`); no Helm charts are changed.

- [x] N/A (no Helm chart changes)

## Additional Notes

- `tsc --noEmit` passes on the `e2e_tests` project.
- Not run against a live environment (requires GitHub auth credentials + running deployment); happy to run a specific project/config on request.

_This pull request was created by an AI agent (OpenHands) on behalf of the user._