### PR TITLE
test(e2e): migrate Stripe credit purchase into billing suite

### DIFF
--- a/e2e_tests/tests/billing.spec.ts
+++ b/e2e_tests/tests/billing.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from "../utils/billing";
+import { HomePage } from "../pages";
+import { runUser } from "../utils/config";
+
+/**
+ * Billing specs.
+ *
+ * Ported from saas_deploy's `e2e_tests/tests/smoke.spec.ts` (Stripe credit
+ * purchase flow). Every spec here is gated on `feature_flags.enable_billing`
+ * — see `utils/billing.ts`. When that flag is falsy the whole suite is
+ * skipped automatically, so these specs never run against a deployment that
+ * doesn't expose billing.
+ *
+ * As with the rest of the harness, each spec runs once per user role
+ * (returning / new-user); the active role is read from project metadata via
+ * `runUser(testInfo)`.
+ */
+
+const STRIPE_TEST_CARD = {
+  number: "5105105105105100",
+  expiry: "12/35",
+  cvc: "123",
+  name: "Testy Tester",
+  country: "US",
+  postalCode: "12345",
+} as const;
+
+const TOP_UP_AMOUNT = 10;
+
+test.describe("Billing @billing", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let homePage: HomePage;
+
+  test.beforeEach(async ({ page }) => {
+    homePage = new HomePage(page);
+  });
+
+  test("should be able to purchase $10 credits via Stripe", async ({
+    page,
+  }, testInfo) => {
+    test.info().annotations.push({
+      type: "user",
+      description: runUser(testInfo),
+    });
+
+    // Navigate to home and open the user menu to reach Billing.
+    await homePage.goto();
+    await homePage.openUserMenu();
+
+    const billingLink = page.getByRole("link", { name: /billing/i });
+    await billingLink.click();
+
+    await page.mouse.move(0, 0);
+    await page.waitForURL(/\/settings\/billing/, { timeout: 30_000 });
+    await expect(page.getByTestId("billing-settings")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Capture the balance before purchasing so we can assert it grew by $10.
+    const balanceElement = page.getByTestId("user-balance");
+    await expect(balanceElement).toBeVisible({ timeout: 10_000 });
+    const initialBalanceText = await balanceElement.textContent();
+    const initialBalance = parseFloat(
+      initialBalanceText?.replace("$", "") || "0",
+    );
+    console.log(`Initial balance: $${initialBalance.toFixed(2)}`);
+
+    // Enter the top-up amount and submit.
+    const topUpInput = page.getByTestId("top-up-input");
+    await topUpInput.fill(String(TOP_UP_AMOUNT));
+
+    const addCreditButton = page.getByRole("button", { name: /add credit/i });
+    await expect(addCreditButton).toBeEnabled({ timeout: 5_000 });
+    await addCreditButton.click();
+
+    // Stripe Checkout is an external redirect; wait for it to load.
+    await page.waitForURL(/checkout\.stripe\.com/, { timeout: 30_000 });
+    console.log("Redirected to Stripe checkout");
+
+    const payButton = page.locator(".SubmitButton");
+    await payButton.waitFor({ state: "attached", timeout: 30_000 });
+    console.log("Stripe checkout form loaded");
+
+    // Fill the test card details.
+    await page.locator("#cardNumber").fill(STRIPE_TEST_CARD.number);
+    await page.locator("#cardExpiry").fill(STRIPE_TEST_CARD.expiry);
+    await page.locator("#cardCvc").fill(STRIPE_TEST_CARD.cvc);
+    await page.locator("#billingName").fill(STRIPE_TEST_CARD.name);
+    await page
+      .locator("#billingCountry")
+      .selectOption(STRIPE_TEST_CARD.country);
+    await page.locator("#billingPostalCode").fill(STRIPE_TEST_CARD.postalCode);
+
+    await page.screenshot({
+      path: "test-results/screenshots/stripe-checkout-filled.png",
+    });
+
+    await payButton.click();
+
+    // Wait for the redirect back to the billing page after payment.
+    await page.waitForURL(/\/settings\/billing/, { timeout: 60_000 });
+    console.log("Returned to billing page after payment");
+
+    // The balance refresh is async; give it a moment before re-reading.
+    await page.waitForTimeout(2000);
+
+    await expect(balanceElement).toBeVisible({ timeout: 10_000 });
+    const newBalanceText = await balanceElement.textContent();
+    const newBalance = parseFloat(newBalanceText?.replace("$", "") || "0");
+    console.log(`New balance: $${newBalance.toFixed(2)}`);
+
+    expect(newBalance).toBeCloseTo(initialBalance + TOP_UP_AMOUNT, 2);
+    console.log(
+      `Balance increased by $${TOP_UP_AMOUNT}: $${initialBalance.toFixed(2)} -> $${newBalance.toFixed(2)}`,
+    );
+
+    await page.screenshot({
+      path: "test-results/screenshots/billing-after-payment.png",
+    });
+  });
+});

--- a/e2e_tests/utils/billing.ts
+++ b/e2e_tests/utils/billing.ts
@@ -1,0 +1,81 @@
+import { test as base, expect } from "@playwright/test";
+
+/**
+ * Billing feature-flag gating.
+ *
+ * When the app loads it makes a background request to
+ * `/api/v1/web-client/config` and exposes its `feature_flags` to the client.
+ * If `feature_flags.enable_billing` is falsy, the billing UI (and therefore
+ * any billing e2e spec) cannot run, so every spec that imports the `test`
+ * below is skipped automatically.
+ *
+ * The config is fetched once per worker and cached; the skip is applied
+ * through an auto fixture so individual specs don't have to repeat the check.
+ */
+
+/** Shape of the `feature_flags` object returned by the config endpoint. */
+export interface FeatureFlags {
+  enable_billing?: boolean;
+  [key: string]: boolean | undefined;
+}
+
+/** Parsed body of `/api/v1/web-client/config`. */
+export interface WebClientConfig {
+  feature_flags?: FeatureFlags;
+  [key: string]: unknown;
+}
+
+const CONFIG_PATH = "/api/v1/web-client/config";
+
+let cachedConfig: WebClientConfig | undefined;
+
+/**
+ * Fetch `/api/v1/web-client/config` (relative to BASE_URL) and cache the
+ * parsed body for the lifetime of the worker. Returns the full body so callers
+ * can read other fields besides the feature flags.
+ */
+export async function fetchWebClientConfig(
+  request: import("@playwright/test").APIRequestContext,
+): Promise<WebClientConfig> {
+  if (cachedConfig) {
+    return cachedConfig;
+  }
+
+  const response = await request.get(CONFIG_PATH);
+  if (!response.ok()) {
+    throw new Error(
+      `Failed to fetch web-client config (${response.status()} ${response.statusText()})`,
+    );
+  }
+
+  cachedConfig = (await response.json()) as WebClientConfig;
+  return cachedConfig;
+}
+
+/** True when billing is enabled in the fetched feature flags. */
+export function billingEnabled(config: WebClientConfig | undefined): boolean {
+  return Boolean(config?.feature_flags?.enable_billing);
+}
+
+/**
+ * Test object for billing specs. An auto fixture fetches the web-client config
+ * (cached, so only the first test in a worker pays for the request) and skips
+ * every test using this object when `feature_flags.enable_billing` is falsy.
+ * Billing specs should import `{ test, expect }` from here instead of from
+ * `@playwright/test` directly.
+ */
+export const test = base.extend<{ billingConfig: WebClientConfig }>({
+  billingConfig: [
+    async ({ request }, use) => {
+      const config = await fetchWebClientConfig(request);
+      test.skip(
+        !billingEnabled(config),
+        "billing is disabled (feature_flags.enable_billing is falsy)",
+      );
+      await use(config);
+    },
+    { auto: true },
+  ],
+});
+
+export { expect };

--- a/e2e_tests/utils/index.ts
+++ b/e2e_tests/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./test-helpers";
+export * from "./billing";


### PR DESCRIPTION
## Description

Port the `should be able to purchase $10 credits via Stripe` test from `saas_deploy`'s `e2e_tests/tests/smoke.spec.ts` into a dedicated `tests/billing.spec.ts`, adapted to this harness's conventions (`runUser` annotation, `HomePage` page object, prettier formatting, `STRIPE_TEST_CARD` constant).

Add a reusable billing feature-flag gate in `utils/billing.ts`: an auto fixture fetches `/api/v1/web-client/config` once (cached for the worker) and skips every billing spec when `body.feature_flags.enable_billing` is falsy. Billing specs import the gated `{ test, expect }` from there instead of `@playwright/test`, so the whole suite is skipped automatically on deployments that don't expose billing — no separate config flag to set, no false failures.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [x] N/A — no Helm chart changes; this is an e2e test addition only.

## Screenshots

<img width="1347" height="859" alt="image" src="https://github.com/user-attachments/assets/b2408592-2665-4d3c-9e90-6842303bc756" />

## Additional Notes

- `utils/billing.ts` exports `fetchWebClientConfig`, `billingEnabled`, plus the gated `test`/`expect`. The config is fetched once per worker and cached, so only the first test pays for the request.
- Verified: `tsc --noEmit`, `eslint`, and `prettier --check` all pass; `playwright test --list` discovers the test across chromium/firefox/webkit under the returning-user role (and new-user when enabled).
- The local `saas_deploy` checkout wasn't available in this sandbox, so the source `smoke.spec.ts` was pulled from `OpenHands/deploy` on GitHub; the ported test matches that file.

_This pull request was created by an AI agent (OpenHands) on behalf of the user._