### PR TITLE
test(e2e): migrate home avatar and user-menu tests

### DIFF
--- a/e2e_tests/tests/home.spec.ts
+++ b/e2e_tests/tests/home.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+import { HomePage } from "../pages";
+import { runUser } from "../utils/config";
+
+/**
+ * Home screen specs.
+ *
+ * Ported from saas_deploy's `e2e_tests/tests/smoke.spec.ts` (the avatar and
+ * user-menu checks). As with the rest of the harness, each spec runs once per
+ * user role (returning / new-user); the active role is read from project
+ * metadata via `runUser(testInfo)`.
+ */
+
+test.describe("home screen", () => {
+  test("should have user avatar visible indicating logged in state", async ({
+    page,
+  }, testInfo) => {
+    const homePage = new HomePage(page);
+    test.info().annotations.push({
+      type: "user",
+      description: runUser(testInfo),
+    });
+
+    await homePage.goto();
+
+    // Verify the user is logged in and the avatar is visible.
+    const isLoggedIn = await homePage.isLoggedIn();
+    expect(isLoggedIn).toBe(true);
+
+    await expect(homePage.userAvatar).toBeVisible();
+  });
+
+  test("should be able to open the user menu", async ({ page }, testInfo) => {
+    const homePage = new HomePage(page);
+    test.info().annotations.push({
+      type: "user",
+      description: runUser(testInfo),
+    });
+
+    await homePage.goto();
+
+    await homePage.openUserMenu();
+
+    await expect(homePage.accountSettingsMenu).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Description

Port two home-page checks from `saas_deploy`'s `e2e_tests/tests/smoke.spec.ts` into a dedicated `tests/home.spec.ts`:

- `should have user avatar visible indicating logged in state`
- `should be able to open the user menu`

Adapted to this harness's conventions: `runUser(testInfo)` annotation so each spec runs once per user role (returning / new-user), and the `HomePage` page object for navigation, `isLoggedIn()`, and `openUserMenu()`.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [x] N/A — no Helm chart changes; this is an e2e test addition only.

## Screenshots

<img width="1888" height="760" alt="image" src="https://github.com/user-attachments/assets/a87a9585-a52a-4ea4-87a7-059808a38c33" />


## Additional Notes

- Verified: `tsc --noEmit`, `eslint`, and `prettier --check` all pass; `playwright test --list` discovers both tests across chromium/firefox/webkit under the returning-user role (and new-user when enabled).
- `HomePage` already exposes `userAvatar`, `accountSettingsMenu`, `isLoggedIn()`, and `openUserMenu()`, so the specs reuse the existing page object rather than duplicating selectors.

_This pull request was created by an AI agent (OpenHands) on behalf of the user._