### PR TITLE
fix(e2e): isolate setup storage state

### DIFF
--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -26,6 +26,8 @@ jobs:
         run: npm ci
       - name: Lint and type-check
         run: npm run lint
+      - name: Validate Playwright configuration
+        run: npm run test:config
       - name: Discover Chromium tests
         env:
           BASE_URL: https://release-under-test.invalid

--- a/e2e_tests/package.json
+++ b/e2e_tests/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "playwright test",
     "test:chromium": "playwright test --project=chromium",
+    "test:config": "node scripts/check-playwright-config.mjs",
     "test:headed": "playwright test --headed",
     "test:debug": "playwright test --debug",
     "test:ui": "playwright test --ui",

--- a/e2e_tests/playwright.config.ts
+++ b/e2e_tests/playwright.config.ts
@@ -70,7 +70,7 @@ export default defineConfig({
       name: "setup",
       testMatch: /global-setup\.ts/,
       use: {
-        storageState: undefined, // Don't use existing auth for setup
+        storageState: { cookies: [], origins: [] },
       },
     },
 

--- a/e2e_tests/scripts/check-playwright-config.mjs
+++ b/e2e_tests/scripts/check-playwright-config.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+const playwrightRoot = path.dirname(require.resolve("playwright/package.json"));
+const { loadConfigFromFile } = require(
+  path.join(playwrightRoot, "lib/common/configLoader.js"),
+);
+
+process.env.BASE_URL ??= "https://release-under-test.invalid";
+
+const packageRoot = path.resolve(import.meta.dirname, "..");
+const config = await loadConfigFromFile(
+  path.join(packageRoot, "playwright.config.ts"),
+);
+const projects = new Map(
+  config.projects.map(({ project }) => [project.name, project]),
+);
+
+assert.deepEqual(projects.get("setup")?.use.storageState, {
+  cookies: [],
+  origins: [],
+});
+
+const authFile = path.join(packageRoot, "fixtures/auth.json");
+for (const browser of ["chromium", "firefox", "webkit"]) {
+  assert.equal(projects.get(browser)?.use.storageState, authFile);
+}


### PR DESCRIPTION
## Summary
- start the Playwright authentication setup project with an explicit empty storage state
- preserve the generated auth state for Chromium, Firefox, and WebKit projects
- add a resolved-config contract and run it in E2E static CI

## Root cause
The setup project used `storageState: undefined`, which did not override the top-level `fixtures/auth.json` path after Playwright resolved project settings. The setup worker therefore tried to read the file before `global-setup.ts` could create it.

## Validation
- `npm run test:config`
- `npm run lint`
- `BASE_URL=https://release-under-test.invalid npx playwright test --project=chromium --list`
- `npx prettier --check "scripts/**/*.mjs"`

_This pull request was created by an AI agent (OpenHands) on behalf of Saurya Velagapudi._