### PR TITLE
fix(e2e): enable role during static discovery

### DIFF
--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -29,4 +29,5 @@ jobs:
       - name: Discover Chromium tests
         env:
           BASE_URL: https://release-under-test.invalid
+          RETURNING_GITHUB_USERNAME: discovery-placeholder
         run: npx playwright test --project=chromium:returning --list


### PR DESCRIPTION
## Summary
- opt the returning-user project into E2E static discovery with a non-secret placeholder username
- keep credential validation deferred because `--list` does not execute authentication
- unblock E2E spec PRs under the role-based Playwright topology

## Root cause
Role projects intentionally match no tests unless their `*_GITHUB_USERNAME` variable is set. The static workflow selected `chromium:returning` without enabling that role, so every E2E PR failed discovery with `No tests found`.

## Validation
- `npm run lint`
- `BASE_URL=https://release-under-test.invalid RETURNING_GITHUB_USERNAME=discovery-placeholder npx playwright test --project=chromium:returning --list`
- discovered setup plus all returning-user specs

_This pull request was created by an AI agent (OpenHands) on behalf of Saurya Velagapudi._