### PR TITLE
feat: add configurable daily conversation limit to chart

### DIFF
--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -30,6 +30,10 @@
   value: {{ .Values.appConfig.OPENHANDS_CONVERSATION_VALIDATOR_CLS }}
 - name: OPENHANDS_EXPERIMENT_MANAGER_CLS
   value: {{ .Values.appConfig.OPENHANDS_EXPERIMENT_MANAGER_CLS }}
+{{- if ne .Values.dailyConversationLimit nil }}
+- name: OH_DAILY_CONVERSATION_LIMIT
+  value: {{ .Values.dailyConversationLimit | quote }}
+{{- end }}
 - name: OH_RESOLVER_LABEL
   value: {{ get $integrations "resolverLabel" | default "openhands" | quote }}
 - name: LOG_JSON # Configure structured logging for Google Cloud

--- a/charts/openhands/tests/daily_conversation_limit_test.yaml
+++ b/charts/openhands/tests/daily_conversation_limit_test.yaml
@@ -1,0 +1,50 @@
+suite: daily conversation limit env wiring
+templates:
+  - deployment.yaml
+  # deployment.yaml unconditionally checksums this ConfigMap into its pod
+  # annotations, so it must be compiled alongside it for the render to succeed.
+  - litellm-config-script.yaml
+tests:
+  - it: leaves the enterprise application unlimited by default
+    set:
+      enabled: true
+    asserts:
+      - template: deployment.yaml
+        notExists:
+          path: spec.template.spec.containers[0].env[?(@.name=="OH_DAILY_CONVERSATION_LIMIT")]
+
+  - it: wires a configured daily conversation limit
+    set:
+      enabled: true
+      dailyConversationLimit: 20
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OH_DAILY_CONVERSATION_LIMIT
+            value: "20"
+
+  - it: preserves a zero operator override
+    set:
+      enabled: true
+      dailyConversationLimit: 0
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OH_DAILY_CONVERSATION_LIMIT
+            value: "0"
+
+  - it: preserves a negative operator override
+    set:
+      enabled: true
+      dailyConversationLimit: -1
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OH_DAILY_CONVERSATION_LIMIT
+            value: "-1"

--- a/charts/openhands/tests/values_schema_test.yaml
+++ b/charts/openhands/tests/values_schema_test.yaml
@@ -20,6 +20,12 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "ingress/enabled.*want boolean"
+  - it: rejects a non-integer daily conversation limit
+    set:
+      dailyConversationLimit: "twenty"
+    asserts:
+      - failedTemplate:
+          errorPattern: "dailyConversationLimit"
   - it: rejects a storage backend the app does not support
     set:
       filestore.type: local

--- a/charts/openhands/values.schema.json
+++ b/charts/openhands/values.schema.json
@@ -6,6 +6,7 @@
   "required": ["image"],
   "properties": {
     "enabled": { "type": "boolean" },
+    "dailyConversationLimit": { "type": ["integer", "null"] },
     "image": {
       "type": "object",
       "required": ["repository", "tag"],

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -33,6 +33,10 @@ appConfig:
   OPENHANDS_EXPERIMENT_MANAGER_CLS: "experiments.experiment_manager.SaaSExperimentManager"
   POSTHOG_CLIENT_KEY: "1234abcd"
 
+# Maximum conversations a user may start per UTC day. null leaves the
+# enterprise application default unlimited; set an integer to enforce a limit.
+dailyConversationLimit: null
+
 datadog:
   enabled: false
   env: "dev" # Default environment, can be overridden


### PR DESCRIPTION
Adds an optional dailyConversationLimit Helm value, defaulting to null/unlimited, and wires it to OH_DAILY_CONVERSATION_LIMIT. Includes schema and chart tests.

Coordinates with OpenHands/enterprise#179 and OpenHands/saas-deploy#639.

This pull request was created by an AI agent (OpenHands) on behalf of the user.