### PR TITLE
test(e2e): migrate legacy conversation control tests

### DIFF
--- a/e2e_tests/pages/ConversationPage.ts
+++ b/e2e_tests/pages/ConversationPage.ts
@@ -2,6 +2,16 @@ import { Page, Locator, expect } from "@playwright/test";
 import { BasePage } from "./BasePage";
 
 /**
+ * Budget given to the error-banner watch inside the readiness/message races.
+ *
+ * On a genuinely failed conversation the error banner appears quickly, so a
+ * short fixed budget is enough to fail fast. Keeping this small also stops the
+ * losing branch of Promise.race from polling for the full readiness timeout
+ * (which otherwise leaves a ~60s dangling wait in the trace even on success).
+ */
+const ERROR_BANNER_WAIT_MS = 5_000;
+
+/**
  * Agent states that can be observed during conversation
  */
 export enum AgentState {
@@ -98,7 +108,7 @@ export class ConversationPage extends BasePage {
         .then(() => "ready" as const)
         .catch(() => "timeout" as const),
       this.errorBanner
-        .waitFor({ state: "visible", timeout })
+        .waitFor({ state: "visible", timeout: ERROR_BANNER_WAIT_MS })
         .then(() => "error" as const)
         .catch(() => "timeout" as const),
     ]);
@@ -335,7 +345,7 @@ export class ConversationPage extends BasePage {
         .then(() => "match" as const)
         .catch(() => "timeout" as const),
       this.errorBanner
-        .waitFor({ state: "visible", timeout })
+        .waitFor({ state: "visible", timeout: ERROR_BANNER_WAIT_MS })
         .then(() => "error" as const)
         .catch(() => "timeout" as const),
     ]);

--- a/e2e_tests/tests/conversations-legacy.spec.ts
+++ b/e2e_tests/tests/conversations-legacy.spec.ts
@@ -1,0 +1,241 @@
+import { test, expect } from "@playwright/test";
+import { HomePage, ConversationPage } from "../pages";
+import { runUser } from "../utils/config";
+
+/**
+ * Legacy conversation controls specs.
+ *
+ * Ported from saas_deploy's `e2e_tests/tests/smoke.spec.ts` (the conversation
+ * launch, repository/VSCode, navigation, and Tavily search flows). These
+ * exercise the legacy chat controls — launch button, repo selector, recent
+ * conversations list, and the agent's prompt/response loop — rather than the
+ * newer canvas UI.
+ *
+ * The suite runs serially within a role because several tests depend on a
+ * conversation created by an earlier one (e.g. "navigate to a running
+ * conversation" and "Tavily search" both click the first recent conversation,
+ * which only exists once a launch has happened). As with the rest of the
+ * harness, each spec runs once per user role (returning / new-user); the
+ * active role is read from project metadata via `runUser(testInfo)`.
+ */
+
+test.describe("legacy conversations @conversations", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let homePage: HomePage;
+
+  let conversationPage: ConversationPage;
+
+  test.beforeEach(async ({ page }) => {
+    homePage = new HomePage(page);
+    conversationPage = new ConversationPage(page);
+  });
+
+  test("should be able to start a conversation via launch button and reverse a string", async ({
+    page,
+  }, testInfo) => {
+    test.info().annotations.push({
+      type: "user",
+      description: runUser(testInfo),
+    });
+
+    // Sandbox cold-start can push conversation readiness past the global
+    // per-test cap, so lift the timeout to give waitForConversationReady's
+    // budget room to apply. See issue #4556.
+    test.setTimeout(240_000);
+
+    await homePage.goto();
+
+    // Start a new conversation using the launch button.
+    await homePage.startNewConversation("launch-new-conversation-button");
+
+    // Allow navigation to complete.
+    await page.waitForTimeout(2000);
+    conversationPage = new ConversationPage(page);
+
+    await conversationPage.waitForConversationReady();
+
+    await page.screenshot({
+      path: "test-results/screenshots/conversation-ready.png",
+    });
+
+    const prompt = "Reverse the word 'hello'";
+    console.log(`Sending prompt: "${prompt}"`);
+    await conversationPage.executePrompt(prompt, 120_000);
+
+    const message = await conversationPage.waitForMessageContaining(
+      "olleh",
+      120_000,
+    );
+    console.log(
+      `Found expected response containing 'olleh': "${message.substring(0, 100)}..."`,
+    );
+
+    await page.screenshot({
+      path: "test-results/screenshots/agent-response.png",
+    });
+
+    console.log(
+      "Legacy conversation launch test passed: agent reversed the word",
+    );
+  });
+
+  test("should be able to select repository and use VSCode integration", async ({
+    page,
+  }, testInfo) => {
+    test.info().annotations.push({
+      type: "user",
+      description: runUser(testInfo),
+    });
+
+    // Cloning the repo and editing the README is multi-minute work, so lift
+    // the timeout to give waitForTaskCompleteMessage's budget room to apply.
+    test.setTimeout(240_000);
+
+    const TEST_REPO_URL = "https://github.com/OpenHands/OpenHands";
+
+    await homePage.goto();
+
+    await homePage.selectRepository(TEST_REPO_URL);
+    console.log(`Selected repository: ${TEST_REPO_URL}`);
+
+    // Start a new conversation with the repo launch button.
+    await homePage.startNewConversation("repo-launch-button");
+
+    await page.waitForTimeout(2000);
+    conversationPage = new ConversationPage(page);
+
+    await conversationPage.waitForConversationReady();
+
+    const prompt = "Add a poem about developers to the end of the readme!";
+    console.log(`Sending prompt: "${prompt}"`);
+    await conversationPage.sendMessage(prompt);
+
+    // Wait for the task to start.
+    const waitingForTaskText = conversationPage.page.getByText("Running task");
+    await expect(waitingForTaskText).toBeVisible({ timeout: 30_000 });
+
+    await conversationPage.waitForTaskCompleteMessage();
+    console.log(
+      "Status is 'Agent has finished the task' - poem task completed",
+    );
+
+    await page.screenshot({
+      path: "test-results/screenshots/conversation-with-repo.png",
+    });
+
+    // The README should have been updated and appear in the diff viewer.
+    const readMe = conversationPage.page
+      .getByTestId("file-diff-viewer-outer")
+      .locator("div")
+      .filter({ hasText: /^README\.md$/ });
+    await expect(readMe).toBeVisible();
+    await readMe.click();
+
+    // Adding a poem should have inserted at least one new line.
+    await expect(page.locator(".cdr.line-insert").first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Open the VSCode tab.
+    const vscodeTabButton = page.getByTestId("conversation-tab-vscode");
+    await vscodeTabButton.click();
+    console.log("Clicked VSCode tab button");
+
+    // Wait for the VS Code iframe and the explorer viewlet (combined 30s).
+    // The iframe may not be visible initially, and the explorer viewlet can
+    // take additional time to appear after the iframe loads.
+    const vsCodeFrameLocator = page.locator('iframe[title="VS Code"]');
+    const startTime = Date.now();
+    const totalTimeout = 30_000;
+
+    await expect(vsCodeFrameLocator).toBeVisible({ timeout: totalTimeout });
+
+    const elapsed = Date.now() - startTime;
+    const remainingTimeout = Math.max(totalTimeout - elapsed, 0);
+
+    const vsCodeFrame = vsCodeFrameLocator.contentFrame();
+    const explorerViewlet = vsCodeFrame
+      .locator("a")
+      .filter({ hasText: "OpenHands" });
+    await expect(explorerViewlet).toBeVisible({ timeout: remainingTimeout });
+    console.log("VSCode loaded with OpenHands repository");
+
+    await page.screenshot({
+      path: "test-results/screenshots/vscode-openhands.png",
+    });
+
+    console.log(
+      "VSCode integration test passed: repository loaded successfully",
+    );
+  });
+
+  test("should be able to navigate to a running conversation", async ({
+    page,
+  }, testInfo) => {
+    test.info().annotations.push({
+      type: "user",
+      description: runUser(testInfo),
+    });
+
+    await homePage.goto();
+
+    // Click on the first conversation in the recent conversations list.
+    await homePage.clickFirstConversation();
+
+    conversationPage = new ConversationPage(page);
+
+    // The conversation should still be in a finished state from the prior test.
+    await conversationPage.waitForTaskCompleteMessage();
+
+    await page.screenshot({
+      path: "test-results/screenshots/navigated-conversation.png",
+    });
+
+    console.log("Successfully navigated to running conversation");
+  });
+
+  test("should be able to use Tavily search and get accurate response", async ({
+    page,
+  }, testInfo) => {
+    test.info().annotations.push({
+      type: "user",
+      description: runUser(testInfo),
+    });
+
+    // External search can be slow, so lift the timeout to give the 180s waits
+    // room to apply.
+    test.setTimeout(240_000);
+
+    await homePage.goto();
+
+    await homePage.clickFirstConversation();
+
+    conversationPage = new ConversationPage(page);
+
+    await conversationPage.waitForTaskCompleteMessage();
+
+    const prompt =
+      "Using Tavily search, please tell me who is the prime minister of Ireland.";
+    console.log(`Sending prompt: "${prompt}"`);
+    await conversationPage.executePrompt(prompt, 180_000);
+
+    // Match the name with a regex so accent ("Micheál" vs "Micheal") and casing
+    // variants in the agent's response don't cause spurious failures.
+    const message = await conversationPage.waitForMessageContaining(
+      /miche[aá]l martin/i,
+      180_000,
+    );
+    console.log(
+      `Found expected response containing 'Micheál Martin': "${message.substring(0, 100)}..."`,
+    );
+
+    await page.screenshot({
+      path: "test-results/screenshots/tavily-search-response.png",
+    });
+
+    console.log(
+      "Tavily search test passed: agent correctly identified the Prime Minister of Ireland",
+    );
+  });
+});


### PR DESCRIPTION
## Description

Migrates the legacy chat-control flows from `saas_deploy`'s `smoke.spec.ts` into a new `e2e_tests/tests/conversations-legacy.spec.ts`:

- **start a conversation via the launch button and reverse a string** — launches via `launch-new-conversation-button`, waits for readiness, prompts to reverse "hello", asserts `olleh` appears.
- **select repository and use VSCode integration** — selects `OpenHands/OpenHands`, launches via `repo-launch-button`, prompts to add a poem to the README, asserts the diff viewer shows `README.md` with inserted lines, then switches to the VSCode tab and verifies the explorer viewlet loads the repo.
- **navigate to a running conversation** — opens the first recent conversation from the home screen and asserts it reaches the finished state.
- **use Tavily search and get accurate response** — reuses the running conversation, asks for the prime minister of Ireland, and asserts a response matching `/miche[aá]l martin/i` (regex tolerates accent/casing variants).

The suite runs serially within a role since the navigation and Tavily tests reuse a conversation created by the launch test. As with the rest of the harness, each spec runs once per user role (returning / new-user) via `runUser(testInfo)`, and it's tagged `@conversations` to match the `@billing` convention. Verified via `playwright test --list` that all 4 tests are discovered across each browser × user-role project; `tsc --noEmit` and ESLint pass.

## Screenshots

(Heads up - the tests are failing due to the actual classic functionality being broken.)
<img width="1922" height="921" alt="image" src="https://github.com/user-attachments/assets/f7ab84f0-43c5-4ed9-ab23-a1f8c3006573" />

## Helm Chart Checklist

N/A — this change is limited to the Playwright e2e harness under `e2e_tests/`; no Helm charts are modified.

- [x] N/A (no Helm chart changes)

## Additional Notes

Follows the existing harness conventions (page objects, `runUser`, project metadata, tag style) established by the previously-ported specs (`home.spec.ts`, `billing.spec.ts`, `api-keys.spec.ts`).

_This pull request was created by an AI agent (OpenHands) on behalf of the user._