### PR TITLE
fix(automation): keep events service available during node drains

### DIFF
--- a/charts/openhands/charts/automation/templates/events-deployment.yaml
+++ b/charts/openhands/charts/automation/templates/events-deployment.yaml
@@ -20,6 +20,10 @@ spec:
         app: automation-events
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.events.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/openhands/charts/automation/templates/events-pdb.yaml
+++ b/charts/openhands/charts/automation/templates/events-pdb.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.events.enabled .Values.events.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: automation-events
+  labels:
+    {{- include "automation.labels" . | nindent 4 }}
+    app.kubernetes.io/component: events
+    app: automation-events
+spec:
+  {{- if .Values.events.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.events.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.events.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.events.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: automation-events
+{{- end }}

--- a/charts/openhands/charts/automation/templates/events-pdb.yaml
+++ b/charts/openhands/charts/automation/templates/events-pdb.yaml
@@ -1,4 +1,10 @@
-{{- if and .Values.events.enabled .Values.events.podDisruptionBudget.enabled }}
+{{- /*
+Only rendered above one replica: at replicas=1 a minAvailable=1 budget makes the
+single pod unevictable, so the node drain this is meant to survive hangs forever
+instead. On a single-node cluster the same stall is possible at any replica count
+(nowhere to reschedule the evicted pod) — turn the budget off there.
+*/}}
+{{- if and .Values.events.enabled .Values.events.podDisruptionBudget.enabled (gt (int .Values.events.deployment.replicas) 1) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -8,11 +14,7 @@ metadata:
     app.kubernetes.io/component: events
     app: automation-events
 spec:
-  {{- if .Values.events.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.events.podDisruptionBudget.minAvailable }}
-  {{- else if .Values.events.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ .Values.events.podDisruptionBudget.maxUnavailable }}
-  {{- end }}
   selector:
     matchLabels:
       app: automation-events

--- a/charts/openhands/charts/automation/tests/events_pdb_test.yaml
+++ b/charts/openhands/charts/automation/tests/events_pdb_test.yaml
@@ -1,0 +1,48 @@
+suite: events PodDisruptionBudget
+templates:
+  - templates/events-pdb.yaml
+tests:
+  - it: renders nothing at the chart default (events deployment disabled)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: keeps one events pod during voluntary disruption
+    set:
+      events.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: automation-events
+
+  # A minAvailable=1 budget on a single replica makes the pod unevictable, so the
+  # node drain never completes — the opposite of what this exists for.
+  - it: does not block the drain when there is only one replica
+    set:
+      events.enabled: true
+      events.deployment.replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: honours a custom budget, including zero
+    set:
+      events.enabled: true
+      events.podDisruptionBudget.minAvailable: 0
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 0
+
+  - it: renders nothing when the budget is turned off
+    set:
+      events.enabled: true
+      events.podDisruptionBudget.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/openhands/charts/automation/tests/events_topology_test.yaml
+++ b/charts/openhands/charts/automation/tests/events_topology_test.yaml
@@ -1,0 +1,27 @@
+suite: events topology spread
+templates:
+  - templates/events-deployment.yaml
+tests:
+  - it: spreads replicas across nodes by default
+    set:
+      events.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints
+          value:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              # ScheduleAnyway, not DoNotSchedule: on a small cluster the second
+              # replica must still schedule even when the spread is imperfect.
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app: automation-events
+
+  - it: omits topology spread when unset
+    set:
+      events.enabled: true
+      events.topologySpreadConstraints: []
+    asserts:
+      - notExists:
+          path: spec.template.spec.topologySpreadConstraints

--- a/charts/openhands/charts/automation/values.yaml
+++ b/charts/openhands/charts/automation/values.yaml
@@ -48,11 +48,12 @@ events:
   # Keep at least one events pod serving during voluntary disruptions (node
   # drains / rotations). Without this, a single node drain can evict every
   # replica at once and take /v1/events/* to zero healthy backends.
-  # Set either minAvailable or maxUnavailable (minAvailable wins if both set).
+  # Only rendered when deployment.replicas > 1 — at one replica the budget would
+  # make the pod unevictable and stall the drain instead. Set enabled=false on a
+  # single-node cluster, where an evicted pod has nowhere else to land.
   podDisruptionBudget:
     enabled: true
     minAvailable: 1
-    maxUnavailable: ""
   # Spread replicas across nodes so a single node failure/drain cannot take out
   # the whole deployment. ScheduleAnyway keeps scheduling best-effort even when
   # a perfect spread is not possible (e.g. small clusters).

--- a/charts/openhands/charts/automation/values.yaml
+++ b/charts/openhands/charts/automation/values.yaml
@@ -45,6 +45,24 @@ events:
         cpu: 500m
   uvicorn:
     workers: 2
+  # Keep at least one events pod serving during voluntary disruptions (node
+  # drains / rotations). Without this, a single node drain can evict every
+  # replica at once and take /v1/events/* to zero healthy backends.
+  # Set either minAvailable or maxUnavailable (minAvailable wins if both set).
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+    maxUnavailable: ""
+  # Spread replicas across nodes so a single node failure/drain cannot take out
+  # the whole deployment. ScheduleAnyway keeps scheduling best-effort even when
+  # a perfect spread is not possible (e.g. small clusters).
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app: automation-events
 
 securityContext:
   runAsUser: 42420

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1148,6 +1148,24 @@ automation:
           cpu: 500m
     uvicorn:
       workers: 2
+    # Keep at least one events pod serving during voluntary disruptions (node
+    # drains / rotations). Only rendered when deployment.replicas > 1 — at one
+    # replica the budget would make the pod unevictable and stall the drain.
+    # Set enabled=false on a single-node cluster, where an evicted pod has
+    # nowhere else to land.
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+    # Spread replicas across nodes so a single node failure/drain cannot take
+    # out the whole deployment. ScheduleAnyway keeps scheduling best-effort when
+    # a perfect spread is not possible (e.g. small clusters).
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: automation-events
   
   securityContext:
     runAsUser: 42420


### PR DESCRIPTION
## Description
The automation-events deployment runs two replicas with no PodDisruptionBudget and nothing spreading them across nodes, so a single node drain — such as a node-pool rotation — can evict both pods at once and leave `/v1/events/*` with no healthy backend, the failure mode that recently took the route to zero backends and served ~1505 HTTP 503s. This adds a PodDisruptionBudget (`minAvailable: 1`) and hostname topology spread to the events pods, both gated on `events.enabled`, so installs that don't run the events deployment (the chart default) render exactly as before.

## Helm Chart Checklist

- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

- **Upgrade is additive** — rendering the chart on `main` against this branch with `events.enabled=true` yields a single delta: the new PodDisruptionBudget and the deployment's `topologySpreadConstraints`. No other object or field changes, and the new values keys all default, so existing `values.yaml` overrides keep working and there are no new required values.

This PR was drafted by an AI agent on behalf of the user.