### PR TITLE
feat: wire Jira Cloud email-match integration for Replicated installs

### DIFF
--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -584,6 +584,9 @@
 {{- if .Values.jira.enabled }}
 - name: ENABLE_JIRA
   value: "true"
+{{- if eq .Values.jira.linkMethod "oauth" }}
+- name: JIRA_ENABLE_OAUTH
+  value: "1"
 - name: JIRA_CLIENT_ID
   valueFrom:
     secretKeyRef:
@@ -594,6 +597,14 @@
     secretKeyRef:
       name: jira-app
       key: client-secret
+{{- else }}
+{{- /* Email match: no Atlassian OAuth app; admins configure the workspace in
+the app UI and webhook users are matched by email. */}}
+- name: JIRA_ENABLE_OAUTH
+  value: "0"
+- name: JIRA_WEBHOOKS_ENABLED
+  value: "1"
+{{- end }}
 {{- end }}
 
 {{- if .Values.jiraDc.enabled }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1013,6 +1013,7 @@ device-plugin:
 
 jira:
   enabled: false
+  linkMethod: oauth
 
 jiraDc:
   enabled: false

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -887,6 +887,22 @@ spec:
           when: 'repl{{ and (ConfigOptionEquals "jira_data_center_enabled" "1") (ConfigOptionEquals "jira_data_center_link_method" "oauth") }}'
           required: true
 
+    - name: jira_cloud_integration
+      title: Jira Cloud Integration
+      description: Enable the Jira Cloud issue integration. An organization admin finishes setup inside OpenHands and registers the webhook in Jira Cloud.
+      items:
+        - name: jira_cloud_enabled
+          title: Enable Jira Cloud Integration
+          help_text: >-
+            Enable the Jira Cloud issue integration. Users are linked by matching their
+            Jira email to their OpenHands email (their Atlassian profile email must be
+            visible). After enabling, an organization admin opens Settings > Integrations
+            > Jira in OpenHands to enter the Jira service account email, API token, and a
+            webhook secret, then registers the displayed events URL as a webhook in Jira
+            Cloud using that secret.
+          type: bool
+          default: "0"
+
     - name: github_authentication
       title: GitHub Authentication
       description: Configure GitHub App integration for user authentication. Note that this is a GitHub App and NOT a GitHub OAuth app.

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -895,8 +895,8 @@ spec:
           title: Enable Jira Cloud Integration
           help_text: >-
             Enable the Jira Cloud issue integration. Users are linked by matching their
-            Jira email to their OpenHands email (their Atlassian profile email must be
-            visible). After enabling, an organization admin opens Settings > Integrations
+            Jira email to their OpenHands email (their Atlassian profile email visibility
+            must be set to Anyone). After enabling, an organization admin opens Settings > Integrations
             > Jira in OpenHands to enter the Jira service account email, API token, and a
             webhook secret, then registers the displayed events URL as a webhook in Jira
             Cloud using that secret.

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -60,6 +60,7 @@ spec:
       # ignored, so the flag falls back to the model default (false) and the Jira DC
       # integration card never renders. Mirror jira_data_center_enabled here.
       OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_JIRA_DC: 'repl{{ ConfigOptionEquals "jira_data_center_enabled" "1" }}'
+      OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_JIRA: 'repl{{ ConfigOptionEquals "jira_cloud_enabled" "1" }}'
       LOG_LEVEL: 'repl{{ ConfigOption "log_level" }}'
       # The chart's fallback for LAMINAR_WEB_HOST is laminar.<ingress.host>, but
       # Replicated installs expose Laminar at the analytics hostname. Set it
@@ -494,6 +495,11 @@ spec:
     jiraDc:
       enabled: repl{{ ConfigOptionEquals "jira_data_center_enabled" "1" }}
       linkMethod: 'repl{{ ConfigOption "jira_data_center_link_method" }}'
+    # Jira Cloud in OHE is email-match only: OAuth linking needs an Atlassian
+    # OAuth app, which self-hosted installs don't have.
+    jira:
+      enabled: repl{{ ConfigOptionEquals "jira_cloud_enabled" "1" }}
+      linkMethod: 'email'
     github:
       enabled: repl{{ ConfigOptionEquals "github_auth_enabled" "1" }}
     gitlab:


### PR DESCRIPTION
## Why

OpenHands/enterprise#192 org-scoped the Jira Cloud resolver and added an email-match mode so self-hosted installs can use Jira Cloud without an Atlassian OAuth app. Nothing in the Replicated/chart layer exposes it yet: there is no KOTS toggle, the chart's `jira.enabled` block only supports the SaaS OAuth mode (client id/secret from a `jira-app` secret), and the `OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_JIRA` mirror is missing, so the integration card can never render on an OHE install.

## Summary

- Chart: `jira.linkMethod` (`oauth` | `email`) mirroring `jiraDc.linkMethod`. `oauth` (default) keeps today's env byte-identical; `email` sets `JIRA_ENABLE_OAUTH=0` + `JIRA_WEBHOOKS_ENABLED=1` with no OAuth-app secret needed.
- KOTS: `jira_cloud_enabled` checkbox (Jira Cloud Integration group). Wires `jira.enabled`/`linkMethod=email` helm values and the `OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_JIRA` web-client mirror (same pattern as `ENABLE_JIRA_DC`). Admins finish setup in the app UI (service account email, API token, webhook secret) and register the displayed events URL as a webhook in Jira Cloud — no KOTS-level secrets.

**Depends on enterprise-server >= 1.54.0** (first release containing enterprise#192; release PR OpenHands/enterprise#195). Do not merge before the chart's enterprise pin reaches that version — with 1.53.0 the checkbox would enable a UI flow the backend doesn't have.

## How to test

Validated live on a Replicated embedded-cluster instance (channel `alona/jira-cloud-replicated`, release 1470, enterprise image pinned to post-#192 main sha for validation only):
- Upgrade 0.36.0 → 0.48.0 + `jira_cloud_enabled=1` deployed clean; migrations 146/147 applied (`alembic current` = 147).
- `openhands` + `openhands-integrations` deployments render `ENABLE_JIRA=true`, `JIRA_ENABLE_OAUTH=0`, `JIRA_WEBHOOKS_ENABLED=1`, `OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_JIRA=true`.
- `GET /api/v1/web-client/config` → `feature_flags.enable_jira=true`, `jira_oauth_enabled=false`.
- `POST /integration/jira/events` with a dummy signature → 403 from signature verification (route mounted, webhooks enabled).
- Chart render checks: email/oauth/disabled modes each produce the expected env set on all app deployments; oauth mode output is unchanged from main.


---

**Update 2026-08-21**: the merge precondition is met — chart main now pins enterprise **1.54.0**, which contains the Jira Cloud email-match backend (enterprise PR #192). Marking ready for review.

**Live validation** (Replicated R03, channel `alona/jira-cloud-replicated`): full E2E click test passed against a real Jira Cloud site — KOTS enable → in-app workspace configure (service account validated live) → manual webhook registration → `@openhands` mention → email match + auto-enroll → conversation created → bot reply on the issue; repo-task flow verified with a GitLab repo (clone + merge-request preparation). Companion PRs found during validation: enterprise#216 (repo provider fix), enterprise#222 (email-visibility error copy), enterprise#223 (picker mentions), docs#742 (customer setup guide).