### PR TITLE
feat: configure Enterprise SSO for Replicated VM deployments

### DIFF
--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -294,13 +294,15 @@ Enterprise SSO signs users in with a corporate SAML identity provider through th
 2. Update site-values.yaml file:
 
    ```yaml
-   enterpriseSso:
+   enterpriseSSO:
      enabled: true
      displayName: "Company SSO"          # optional, defaults to "Company SSO"
-     idpMetadataUrl: "<your-idp-metadata-url>"
+     idpMetadataUrl: "https://idp.example.com/saml/metadata"
    # When idpMetadataUrl is provided, the chart automatically creates and keeps updated the
    # enterprise_sso SAML identity provider in the bundled Keycloak on every pod start.
    # Leave it empty to configure the provider manually in the Keycloak admin console instead.
+   # When disabling chart-managed SSO, retain idpMetadataUrl for that rollout so the chart
+   # also disables the managed Keycloak provider.
    ```
 
 ### LiteLLM configuration

--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -300,9 +300,12 @@ Enterprise SSO signs users in with a corporate SAML identity provider through th
      idpMetadataUrl: "https://idp.example.com/saml/metadata"
    # When idpMetadataUrl is provided, the chart automatically creates and keeps updated the
    # enterprise_sso SAML identity provider in the bundled Keycloak on every pod start.
-   # Leave it empty to configure the provider manually in the Keycloak admin console instead.
-   # When disabling chart-managed SSO, retain idpMetadataUrl for that rollout so the chart
-   # also disables the managed Keycloak provider.
+   # The managed provider validates SAML signatures and trusts the assertion email for
+   # account linking, so only use metadata from an identity provider you trust.
+   # Leave idpMetadataUrl empty to configure the provider manually in the Keycloak admin
+   # console instead. When disabling chart-managed SSO, retain idpMetadataUrl for that
+   # rollout so the chart can distinguish and disable the provider it manages without
+   # modifying a manually managed provider.
    ```
 
 ### LiteLLM configuration

--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -282,6 +282,27 @@ Bitbucket Data Center is the self-hosted version of Bitbucket. The setup is diff
      host: <your-bitbucket-data-center-host>
    ```
 
+#### Enterprise SSO (SAML)
+
+Enterprise SSO signs users in with a corporate SAML identity provider through the bundled Keycloak.
+
+1. Register Keycloak with your identity provider using these SAML values:
+
+   - ACS URL `https://auth.openhands.example.com/realms/allhands/broker/enterprise_sso/endpoint`
+   - Entity ID `https://auth.openhands.example.com/realms/allhands`
+
+2. Update site-values.yaml file:
+
+   ```yaml
+   enterpriseSso:
+     enabled: true
+     displayName: "Company SSO"          # optional, defaults to "Company SSO"
+     idpMetadataUrl: "<your-idp-metadata-url>"
+   # When idpMetadataUrl is provided, the chart automatically creates and keeps updated the
+   # enterprise_sso SAML identity provider in the bundled Keycloak on every pod start.
+   # Leave it empty to configure the provider manually in the Keycloak admin console instead.
+   ```
+
 ### LiteLLM configuration
 
 > [!IMPORTANT]

--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -308,6 +308,14 @@ Enterprise SSO signs users in with a corporate SAML identity provider through th
    # modifying a manually managed provider.
    ```
 
+   For manual setup, also add this identity-provider mapper to `enterprise_sso`:
+
+   - Name: `identity-provider`
+   - Mapper type: `hardcoded-attribute-idp-mapper`
+   - Attribute: `identity_provider`
+   - Value: `enterprise_sso:saml`
+   - Sync mode: `FORCE`
+
 ### LiteLLM configuration
 
 > [!IMPORTANT]

--- a/charts/openhands/README.md
+++ b/charts/openhands/README.md
@@ -300,12 +300,11 @@ Enterprise SSO signs users in with a corporate SAML identity provider through th
      idpMetadataUrl: "https://idp.example.com/saml/metadata"
    # When idpMetadataUrl is provided, the chart automatically creates and keeps updated the
    # enterprise_sso SAML identity provider in the bundled Keycloak on every pod start.
-   # The managed provider validates SAML signatures and trusts the assertion email for
-   # account linking, so only use metadata from an identity provider you trust.
+   # The managed provider validates SAML signatures, trusts the assertion email for account
+   # linking, and stores an ownership marker in Keycloak. Turning enabled off disables only
+   # a provider with that marker, even if idpMetadataUrl is cleared in the same rollout.
    # Leave idpMetadataUrl empty to configure the provider manually in the Keycloak admin
-   # console instead. When disabling chart-managed SSO, retain idpMetadataUrl for that
-   # rollout so the chart can distinguish and disable the provider it manages without
-   # modifying a manually managed provider.
+   # console instead; the chart does not disable providers without its ownership marker.
    ```
 
    For manual setup, also add this identity-provider mapper to `enterprise_sso`:

--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -671,6 +671,11 @@ the app UI and webhook users are matched by email. */}}
       key: client-secret
 {{- end }}
 
+{{- if .Values.enterpriseSSO.enabled }}
+- name: ENABLE_ENTERPRISE_SSO
+  value: "true"
+{{- end }}
+
 {{- if .Values.automationServiceKey.enabled }}
 - name: AUTOMATIONS_SERVICE_KEY
   valueFrom:

--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -74,6 +74,12 @@ spec:
         image: '{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion }}'
         env:
         {{- include "openhands.env" . | nindent 8 }}
+        {{- if and .Values.enterpriseSSO.enabled .Values.enterpriseSSO.idpMetadataUrl }}
+        - name: ENTERPRISE_SSO_DISPLAY_NAME
+          value: {{ .Values.enterpriseSSO.displayName | quote }}
+        - name: ENTERPRISE_SSO_IDP_METADATA_URL
+          value: {{ .Values.enterpriseSSO.idpMetadataUrl | quote }}
+        {{- end }}
         volumeMounts:
         - name: keycloak-config-script
           mountPath: /scripts

--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
         {{- include "openhands.env" . | nindent 8 }}
         {{- if and .Values.enterpriseSSO.enabled .Values.enterpriseSSO.idpMetadataUrl }}
         - name: ENTERPRISE_SSO_DISPLAY_NAME
-          value: {{ .Values.enterpriseSSO.displayName | quote }}
+          value: {{ .Values.enterpriseSSO.displayName | default "Company SSO" | quote }}
         - name: ENTERPRISE_SSO_IDP_METADATA_URL
           value: {{ .Values.enterpriseSSO.idpMetadataUrl | quote }}
         {{- end }}

--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -75,9 +75,10 @@ spec:
         env:
         {{- include "openhands.env" . | nindent 8 }}
         {{- if and .Values.enterpriseSSO.enabled .Values.enterpriseSSO.idpMetadataUrl }}
+        {{- /* Keep these init-only; openhands.env already emits .Values.env overrides. */}}
         {{- if not (hasKey (.Values.env | default dict) "ENTERPRISE_SSO_DISPLAY_NAME") }}
         - name: ENTERPRISE_SSO_DISPLAY_NAME
-          value: {{ .Values.enterpriseSSO.displayName | default "Company SSO" | quote }}
+          value: {{ .Values.enterpriseSSO.displayName | quote }}
         {{- end }}
         {{- if not (hasKey (.Values.env | default dict) "ENTERPRISE_SSO_IDP_METADATA_URL") }}
         - name: ENTERPRISE_SSO_IDP_METADATA_URL

--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -75,10 +75,14 @@ spec:
         env:
         {{- include "openhands.env" . | nindent 8 }}
         {{- if and .Values.enterpriseSSO.enabled .Values.enterpriseSSO.idpMetadataUrl }}
+        {{- if not (hasKey (.Values.env | default dict) "ENTERPRISE_SSO_DISPLAY_NAME") }}
         - name: ENTERPRISE_SSO_DISPLAY_NAME
           value: {{ .Values.enterpriseSSO.displayName | default "Company SSO" | quote }}
+        {{- end }}
+        {{- if not (hasKey (.Values.env | default dict) "ENTERPRISE_SSO_IDP_METADATA_URL") }}
         - name: ENTERPRISE_SSO_IDP_METADATA_URL
           value: {{ .Values.enterpriseSSO.idpMetadataUrl | quote }}
+        {{- end }}
         {{- end }}
         volumeMounts:
         - name: keycloak-config-script

--- a/charts/openhands/templates/keycloak-config-script.yaml
+++ b/charts/openhands/templates/keycloak-config-script.yaml
@@ -19,6 +19,32 @@ data:
         exit 1
       fi
     }
+
+    refresh_access_token() {
+      ACCESS_TOKEN=$(curl -sS -X POST "$KEYCLOAK_SERVER_URL/realms/master/protocol/openid-connect/token" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "client_id=admin-cli" \
+        -d "grant_type=password" \
+        -d "username=admin" \
+        -d "password=$KEYCLOAK_ADMIN_PASSWORD" | jq -r '.access_token // empty')
+      if [ -z "$ACCESS_TOKEN" ]; then
+        echo "ERROR: could not refresh the Keycloak admin access token." >&2
+        return 1
+      fi
+    }
+
+    keycloak_get_optional() {
+      URL=$1
+      STATUS=$(curl -sS -o /tmp/keycloak-get-response.json -w '%{http_code}' "$URL" \
+        -H "Authorization: Bearer $ACCESS_TOKEN")
+      RESPONSE=$(cat /tmp/keycloak-get-response.json)
+      case "$STATUS" in
+        200) return 0 ;;
+        404) RESPONSE=""; return 0 ;;
+        *) echo "ERROR: Keycloak GET $URL returned HTTP $STATUS: $RESPONSE" >&2; return 1 ;;
+      esac
+    }
+
     echo "Waiting for Keycloak to be ready..."
     until curl --output /dev/null --silent --head --fail $KEYCLOAK_SERVER_URL; do
         echo '.'
@@ -240,6 +266,7 @@ data:
     # failure here (e.g. an unreachable metadata URL) warns but never blocks the
     # app from starting.
     (
+      refresh_access_token
       KC_REALM="$KEYCLOAK_SERVER_URL/admin/realms/$KEYCLOAK_REALM_NAME"
       AUTH="-H \"Authorization: Bearer $ACCESS_TOKEN\""
       CT="-H \"Content-Type: application/json\""
@@ -247,7 +274,6 @@ data:
       echo "Importing enterprise SSO IdP metadata from the configured URL..."
       IMPORT_REQUEST=$(jq -n --arg from_url "$ENTERPRISE_SSO_IDP_METADATA_URL" '{
         providerId: "saml",
-        alias: "enterprise_sso",
         fromUrl: $from_url
       }')
       IMPORT_RESPONSE=$(curl -sS -X POST "$KC_REALM/identity-provider/import-config" \
@@ -255,9 +281,9 @@ data:
         -H "Content-Type: application/json" \
         --data "$IMPORT_REQUEST")
       if ! echo "$IMPORT_RESPONSE" | jq -e \
-        'type == "object" and has("idpEntityId") and has("singleSignOnServiceUrl")' \
+        'type == "object" and has("idpEntityId") and has("singleSignOnServiceUrl") and has("signingCertificate")' \
         >/dev/null 2>&1; then
-        echo "ERROR: could not import IdP metadata: $IMPORT_RESPONSE" >&2
+        echo "ERROR: IdP metadata must include an entity ID, SSO service URL, and signing certificate: $IMPORT_RESPONSE" >&2
         echo "The enterprise_sso identity provider was not configured. Fix the metadata URL and redeploy to retry." >&2
         exit 1
       fi
@@ -268,7 +294,7 @@ data:
           alias: "enterprise_sso",
           providerId: "saml",
           enabled: true,
-          displayName: (if $display == "" then "Company SSO" else $display end),
+          displayName: $display,
           updateProfileFirstLoginMode: "on",
           trustEmail: true,
           storeToken: false,
@@ -279,8 +305,8 @@ data:
           config: (. + {"syncMode": "IMPORT", "validateSignature": "true"})
         }' > /tmp/idp-enterprise-sso.json
 
-      EXISTING_IDP=$(curl -s "$KC_REALM/identity-provider/instances/enterprise_sso" \
-        -H "Authorization: Bearer $ACCESS_TOKEN")
+      keycloak_get_optional "$KC_REALM/identity-provider/instances/enterprise_sso"
+      EXISTING_IDP=$RESPONSE
       if echo "$EXISTING_IDP" | jq -e '.internalId or .id' >/dev/null 2>&1; then
         keycloak_api_call "curl -s -X PUT \"$KC_REALM/identity-provider/instances/enterprise_sso\" $AUTH $CT --data \"@/tmp/idp-enterprise-sso.json\""
         echo "  Updated identity provider: enterprise_sso"
@@ -299,8 +325,8 @@ data:
           syncMode: "FORCE"
         }
       }' > /tmp/mapper-enterprise-sso.json
-      EXISTING_MAPPER_ID=$(curl -s "$KC_REALM/identity-provider/instances/enterprise_sso/mappers" \
-        -H "Authorization: Bearer $ACCESS_TOKEN" | jq -r \
+      keycloak_api_call "curl -s \"$KC_REALM/identity-provider/instances/enterprise_sso/mappers\" $AUTH"
+      EXISTING_MAPPER_ID=$(echo "$RESPONSE" | jq -r \
         '.[] | objects | select(.name == "identity-provider") | .id // empty')
       if [ -n "$EXISTING_MAPPER_ID" ]; then
         jq --arg id "$EXISTING_MAPPER_ID" '. + {id: $id}' /tmp/mapper-enterprise-sso.json > /tmp/mapper-enterprise-sso-update.json
@@ -317,11 +343,12 @@ data:
     # when the feature toggle is turned off so direct kc_idp_hint requests cannot
     # bypass the hidden login button.
     (
+      refresh_access_token
       KC_REALM="$KEYCLOAK_SERVER_URL/admin/realms/$KEYCLOAK_REALM_NAME"
       AUTH="-H \"Authorization: Bearer $ACCESS_TOKEN\""
       CT="-H \"Content-Type: application/json\""
-      EXISTING_IDP=$(curl -s "$KC_REALM/identity-provider/instances/enterprise_sso" \
-        -H "Authorization: Bearer $ACCESS_TOKEN")
+      keycloak_get_optional "$KC_REALM/identity-provider/instances/enterprise_sso"
+      EXISTING_IDP=$RESPONSE
       if echo "$EXISTING_IDP" | jq -e '.internalId or .id' >/dev/null 2>&1; then
         echo "$EXISTING_IDP" | jq '.enabled = false' > /tmp/idp-enterprise-sso-disabled.json
         keycloak_api_call "curl -s -X PUT \"$KC_REALM/identity-provider/instances/enterprise_sso\" $AUTH $CT --data \"@/tmp/idp-enterprise-sso-disabled.json\""

--- a/charts/openhands/templates/keycloak-config-script.yaml
+++ b/charts/openhands/templates/keycloak-config-script.yaml
@@ -232,7 +232,7 @@ data:
       echo "Updated allhands realm configuration."
     fi
 
-    {{- if and .Values.enterpriseSso.enabled .Values.enterpriseSso.idpMetadataUrl }}
+    {{- if and .Values.enterpriseSSO.enabled .Values.enterpriseSSO.idpMetadataUrl }}
     # Enterprise SSO: upsert the enterprise_sso SAML identity provider from the
     # operator-supplied IdP metadata URL, plus the identity_provider user
     # attribute mapper the app relies on to detect SAML logins. Runs after the
@@ -244,21 +244,27 @@ data:
       AUTH="-H \"Authorization: Bearer $ACCESS_TOKEN\""
       CT="-H \"Content-Type: application/json\""
 
-      echo "Importing enterprise SSO IdP metadata from {{ .Values.enterpriseSso.idpMetadataUrl }}..."
-      IMPORT_RESPONSE=$(curl -s -X POST "$KC_REALM/identity-provider/import-config" \
+      echo "Importing enterprise SSO IdP metadata from the configured URL..."
+      IMPORT_REQUEST=$(jq -n --arg from_url "$ENTERPRISE_SSO_IDP_METADATA_URL" '{
+        providerId: "saml",
+        alias: "enterprise_sso",
+        fromUrl: $from_url
+      }')
+      IMPORT_RESPONSE=$(curl -sS -X POST "$KC_REALM/identity-provider/import-config" \
         -H "Authorization: Bearer $ACCESS_TOKEN" \
-        -H "Content-Type: application/x-www-form-urlencoded" \
-        --data-urlencode "fromUrl={{ .Values.enterpriseSso.idpMetadataUrl }}" \
-        -d "providerId=saml")
-      if ! echo "$IMPORT_RESPONSE" | jq -e '.config' >/dev/null 2>&1; then
+        -H "Content-Type: application/json" \
+        --data "$IMPORT_REQUEST")
+      if ! echo "$IMPORT_RESPONSE" | jq -e \
+        'type == "object" and has("idpEntityId") and has("singleSignOnServiceUrl")' \
+        >/dev/null 2>&1; then
         echo "ERROR: could not import IdP metadata: $IMPORT_RESPONSE" >&2
         echo "The enterprise_sso identity provider was not configured. Fix the metadata URL and redeploy to retry." >&2
         exit 1
       fi
 
       echo "$IMPORT_RESPONSE" | jq \
-        --arg display "{{ .Values.enterpriseSso.displayName }}" \
-        '.config as $cfg | {
+        --arg display "$ENTERPRISE_SSO_DISPLAY_NAME" \
+        '{
           alias: "enterprise_sso",
           providerId: "saml",
           enabled: true,
@@ -270,7 +276,7 @@ data:
           authenticateByDefault: false,
           linkOnly: false,
           hideOnLogin: true,
-          config: ($cfg + {"syncMode": "IMPORT", "validateSignatures": "true"})
+          config: (. + {"syncMode": "IMPORT", "validateSignature": "true"})
         }' > /tmp/idp-enterprise-sso.json
 
       EXISTING_IDP=$(curl -s "$KC_REALM/identity-provider/instances/enterprise_sso" \
@@ -289,7 +295,8 @@ data:
         identityProviderMapper: "hardcoded-attribute-idp-mapper",
         config: {
           attribute: "identity_provider",
-          "attribute.value": "enterprise_sso:saml"
+          "attribute.value": "enterprise_sso:saml",
+          syncMode: "FORCE"
         }
       }' > /tmp/mapper-enterprise-sso.json
       EXISTING_MAPPER_ID=$(curl -s "$KC_REALM/identity-provider/instances/enterprise_sso/mappers" \
@@ -305,5 +312,21 @@ data:
       fi
       echo "enterprise_sso SAML identity provider configured."
     ) || echo "WARNING: enterprise_sso auto-configuration failed (details above). Fix the SAML metadata URL and redeploy to retry; continuing startup." >&2
+    {{- else if .Values.enterpriseSSO.idpMetadataUrl }}
+    # A retained metadata URL marks this provider as chart-managed. Disable it
+    # when the feature toggle is turned off so direct kc_idp_hint requests cannot
+    # bypass the hidden login button.
+    (
+      KC_REALM="$KEYCLOAK_SERVER_URL/admin/realms/$KEYCLOAK_REALM_NAME"
+      AUTH="-H \"Authorization: Bearer $ACCESS_TOKEN\""
+      CT="-H \"Content-Type: application/json\""
+      EXISTING_IDP=$(curl -s "$KC_REALM/identity-provider/instances/enterprise_sso" \
+        -H "Authorization: Bearer $ACCESS_TOKEN")
+      if echo "$EXISTING_IDP" | jq -e '.internalId or .id' >/dev/null 2>&1; then
+        echo "$EXISTING_IDP" | jq '.enabled = false' > /tmp/idp-enterprise-sso-disabled.json
+        keycloak_api_call "curl -s -X PUT \"$KC_REALM/identity-provider/instances/enterprise_sso\" $AUTH $CT --data \"@/tmp/idp-enterprise-sso-disabled.json\""
+        echo "Disabled managed identity provider: enterprise_sso"
+      fi
+    ) || echo "WARNING: could not disable the managed enterprise_sso identity provider; continuing startup." >&2
     {{- end }}
 {{- end }}

--- a/charts/openhands/templates/keycloak-config-script.yaml
+++ b/charts/openhands/templates/keycloak-config-script.yaml
@@ -12,21 +12,35 @@ data:
 
     keycloak_api_call() {
       COMMAND=$1
-      export RESPONSE=$(eval $COMMAND)
-      ERROR=$(echo "$RESPONSE" | jq -r 'try if type == "array" then (.[0].error // .[0].errorMessage) else (.error // .errorMessage) end')
+      if ! RESPONSE=$(eval "$COMMAND"); then
+        echo "ERROR: Keycloak API request failed." >&2
+        return 1
+      fi
+      export RESPONSE
+      if ! ERROR=$(echo "$RESPONSE" | jq -r 'try if type == "array" then (.[0].error // .[0].errorMessage) else (.error // .errorMessage) end'); then
+        echo "ERROR: could not parse Keycloak API response: $RESPONSE" >&2
+        return 1
+      fi
       if [ -n "$ERROR" ] && [ "null" != "$ERROR" ]; then
         echo "Error from Keycloak: $RESPONSE"
-        exit 1
+        return 1
       fi
     }
 
     refresh_access_token() {
-      ACCESS_TOKEN=$(curl -sS -X POST "$KEYCLOAK_SERVER_URL/realms/master/protocol/openid-connect/token" \
+      if ! TOKEN_RESPONSE=$(curl -sS -X POST "$KEYCLOAK_SERVER_URL/realms/master/protocol/openid-connect/token" \
         -H "Content-Type: application/x-www-form-urlencoded" \
         -d "client_id=admin-cli" \
         -d "grant_type=password" \
         -d "username=admin" \
-        -d "password=$KEYCLOAK_ADMIN_PASSWORD" | jq -r '.access_token // empty')
+        -d "password=$KEYCLOAK_ADMIN_PASSWORD"); then
+        echo "ERROR: could not refresh the Keycloak admin access token." >&2
+        return 1
+      fi
+      if ! ACCESS_TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r '.access_token // empty'); then
+        echo "ERROR: could not parse the Keycloak admin access token response." >&2
+        return 1
+      fi
       if [ -z "$ACCESS_TOKEN" ]; then
         echo "ERROR: could not refresh the Keycloak admin access token." >&2
         return 1
@@ -35,9 +49,15 @@ data:
 
     keycloak_get_optional() {
       URL=$1
-      STATUS=$(curl -sS -o /tmp/keycloak-get-response.json -w '%{http_code}' "$URL" \
-        -H "Authorization: Bearer $ACCESS_TOKEN")
-      RESPONSE=$(cat /tmp/keycloak-get-response.json)
+      if ! STATUS=$(curl -sS -o /tmp/keycloak-get-response.json -w '%{http_code}' "$URL" \
+        -H "Authorization: Bearer $ACCESS_TOKEN"); then
+        echo "ERROR: Keycloak GET $URL failed." >&2
+        return 1
+      fi
+      if ! RESPONSE=$(cat /tmp/keycloak-get-response.json); then
+        echo "ERROR: could not read the Keycloak GET response for $URL." >&2
+        return 1
+      fi
       case "$STATUS" in
         200) return 0 ;;
         404) RESPONSE=""; return 0 ;;
@@ -264,9 +284,10 @@ data:
     # attribute mapper the app relies on to detect SAML logins. Runs after the
     # realm create/update block so the realm exists; runs in a subshell so a
     # failure here (e.g. an unreachable metadata URL) warns but never blocks the
-    # app from starting.
+    # app from starting. Every fallible operation exits explicitly because
+    # `set -e` is disabled inside a compound command followed by `||`.
     (
-      refresh_access_token
+      refresh_access_token || exit 1
       KC_REALM="$KEYCLOAK_SERVER_URL/admin/realms/$KEYCLOAK_REALM_NAME"
       AUTH="-H \"Authorization: Bearer $ACCESS_TOKEN\""
       CT="-H \"Content-Type: application/json\""
@@ -275,11 +296,11 @@ data:
       IMPORT_REQUEST=$(jq -n --arg from_url "$ENTERPRISE_SSO_IDP_METADATA_URL" '{
         providerId: "saml",
         fromUrl: $from_url
-      }')
+      }') || exit 1
       IMPORT_RESPONSE=$(curl -sS -X POST "$KC_REALM/identity-provider/import-config" \
         -H "Authorization: Bearer $ACCESS_TOKEN" \
         -H "Content-Type: application/json" \
-        --data "$IMPORT_REQUEST")
+        --data "$IMPORT_REQUEST") || exit 1
       if ! echo "$IMPORT_RESPONSE" | jq -e \
         'type == "object" and has("idpEntityId") and has("singleSignOnServiceUrl") and has("signingCertificate")' \
         >/dev/null 2>&1; then
@@ -303,15 +324,15 @@ data:
           linkOnly: false,
           hideOnLogin: true,
           config: (. + {"syncMode": "IMPORT", "validateSignature": "true"})
-        }' > /tmp/idp-enterprise-sso.json
+        }' > /tmp/idp-enterprise-sso.json || exit 1
 
-      keycloak_get_optional "$KC_REALM/identity-provider/instances/enterprise_sso"
+      keycloak_get_optional "$KC_REALM/identity-provider/instances/enterprise_sso" || exit 1
       EXISTING_IDP=$RESPONSE
       if echo "$EXISTING_IDP" | jq -e '.internalId or .id' >/dev/null 2>&1; then
-        keycloak_api_call "curl -s -X PUT \"$KC_REALM/identity-provider/instances/enterprise_sso\" $AUTH $CT --data \"@/tmp/idp-enterprise-sso.json\""
+        keycloak_api_call "curl -s -X PUT \"$KC_REALM/identity-provider/instances/enterprise_sso\" $AUTH $CT --data \"@/tmp/idp-enterprise-sso.json\"" || exit 1
         echo "  Updated identity provider: enterprise_sso"
       else
-        keycloak_api_call "curl -s -X POST \"$KC_REALM/identity-provider/instances\" $AUTH $CT --data \"@/tmp/idp-enterprise-sso.json\""
+        keycloak_api_call "curl -s -X POST \"$KC_REALM/identity-provider/instances\" $AUTH $CT --data \"@/tmp/idp-enterprise-sso.json\"" || exit 1
         echo "  Created identity provider: enterprise_sso"
       fi
 
@@ -324,16 +345,16 @@ data:
           "attribute.value": "enterprise_sso:saml",
           syncMode: "FORCE"
         }
-      }' > /tmp/mapper-enterprise-sso.json
-      keycloak_api_call "curl -s \"$KC_REALM/identity-provider/instances/enterprise_sso/mappers\" $AUTH"
+      }' > /tmp/mapper-enterprise-sso.json || exit 1
+      keycloak_api_call "curl -s \"$KC_REALM/identity-provider/instances/enterprise_sso/mappers\" $AUTH" || exit 1
       EXISTING_MAPPER_ID=$(echo "$RESPONSE" | jq -r \
-        '.[] | objects | select(.name == "identity-provider") | .id // empty')
+        '.[] | objects | select(.name == "identity-provider") | .id // empty') || exit 1
       if [ -n "$EXISTING_MAPPER_ID" ]; then
-        jq --arg id "$EXISTING_MAPPER_ID" '. + {id: $id}' /tmp/mapper-enterprise-sso.json > /tmp/mapper-enterprise-sso-update.json
-        keycloak_api_call "curl -s -X PUT \"$KC_REALM/identity-provider/instances/enterprise_sso/mappers/$EXISTING_MAPPER_ID\" $AUTH $CT --data \"@/tmp/mapper-enterprise-sso-update.json\""
+        jq --arg id "$EXISTING_MAPPER_ID" '. + {id: $id}' /tmp/mapper-enterprise-sso.json > /tmp/mapper-enterprise-sso-update.json || exit 1
+        keycloak_api_call "curl -s -X PUT \"$KC_REALM/identity-provider/instances/enterprise_sso/mappers/$EXISTING_MAPPER_ID\" $AUTH $CT --data \"@/tmp/mapper-enterprise-sso-update.json\"" || exit 1
         echo "  Updated mapper: enterprise_sso/identity-provider"
       else
-        keycloak_api_call "curl -s -X POST \"$KC_REALM/identity-provider/instances/enterprise_sso/mappers\" $AUTH $CT --data \"@/tmp/mapper-enterprise-sso.json\""
+        keycloak_api_call "curl -s -X POST \"$KC_REALM/identity-provider/instances/enterprise_sso/mappers\" $AUTH $CT --data \"@/tmp/mapper-enterprise-sso.json\"" || exit 1
         echo "  Created mapper: enterprise_sso/identity-provider"
       fi
       echo "enterprise_sso SAML identity provider configured."
@@ -343,15 +364,15 @@ data:
     # when the feature toggle is turned off so direct kc_idp_hint requests cannot
     # bypass the hidden login button.
     (
-      refresh_access_token
+      refresh_access_token || exit 1
       KC_REALM="$KEYCLOAK_SERVER_URL/admin/realms/$KEYCLOAK_REALM_NAME"
       AUTH="-H \"Authorization: Bearer $ACCESS_TOKEN\""
       CT="-H \"Content-Type: application/json\""
-      keycloak_get_optional "$KC_REALM/identity-provider/instances/enterprise_sso"
+      keycloak_get_optional "$KC_REALM/identity-provider/instances/enterprise_sso" || exit 1
       EXISTING_IDP=$RESPONSE
       if echo "$EXISTING_IDP" | jq -e '.internalId or .id' >/dev/null 2>&1; then
-        echo "$EXISTING_IDP" | jq '.enabled = false' > /tmp/idp-enterprise-sso-disabled.json
-        keycloak_api_call "curl -s -X PUT \"$KC_REALM/identity-provider/instances/enterprise_sso\" $AUTH $CT --data \"@/tmp/idp-enterprise-sso-disabled.json\""
+        echo "$EXISTING_IDP" | jq '.enabled = false' > /tmp/idp-enterprise-sso-disabled.json || exit 1
+        keycloak_api_call "curl -s -X PUT \"$KC_REALM/identity-provider/instances/enterprise_sso\" $AUTH $CT --data \"@/tmp/idp-enterprise-sso-disabled.json\"" || exit 1
         echo "Disabled managed identity provider: enterprise_sso"
       fi
     ) || echo "WARNING: could not disable the managed enterprise_sso identity provider; continuing startup." >&2

--- a/charts/openhands/templates/keycloak-config-script.yaml
+++ b/charts/openhands/templates/keycloak-config-script.yaml
@@ -231,4 +231,79 @@ data:
       # from the beginning without side effects.
       echo "Updated allhands realm configuration."
     fi
+
+    {{- if and .Values.enterpriseSso.enabled .Values.enterpriseSso.idpMetadataUrl }}
+    # Enterprise SSO: upsert the enterprise_sso SAML identity provider from the
+    # operator-supplied IdP metadata URL, plus the identity_provider user
+    # attribute mapper the app relies on to detect SAML logins. Runs after the
+    # realm create/update block so the realm exists; runs in a subshell so a
+    # failure here (e.g. an unreachable metadata URL) warns but never blocks the
+    # app from starting.
+    (
+      KC_REALM="$KEYCLOAK_SERVER_URL/admin/realms/$KEYCLOAK_REALM_NAME"
+      AUTH="-H \"Authorization: Bearer $ACCESS_TOKEN\""
+      CT="-H \"Content-Type: application/json\""
+
+      echo "Importing enterprise SSO IdP metadata from {{ .Values.enterpriseSso.idpMetadataUrl }}..."
+      IMPORT_RESPONSE=$(curl -s -X POST "$KC_REALM/identity-provider/import-config" \
+        -H "Authorization: Bearer $ACCESS_TOKEN" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        --data-urlencode "fromUrl={{ .Values.enterpriseSso.idpMetadataUrl }}" \
+        -d "providerId=saml")
+      if ! echo "$IMPORT_RESPONSE" | jq -e '.config' >/dev/null 2>&1; then
+        echo "ERROR: could not import IdP metadata: $IMPORT_RESPONSE" >&2
+        echo "The enterprise_sso identity provider was not configured. Fix the metadata URL and redeploy to retry." >&2
+        exit 1
+      fi
+
+      echo "$IMPORT_RESPONSE" | jq \
+        --arg display "{{ .Values.enterpriseSso.displayName }}" \
+        '.config as $cfg | {
+          alias: "enterprise_sso",
+          providerId: "saml",
+          enabled: true,
+          displayName: (if $display == "" then "Company SSO" else $display end),
+          updateProfileFirstLoginMode: "on",
+          trustEmail: true,
+          storeToken: false,
+          addReadTokenRoleOnCreate: false,
+          authenticateByDefault: false,
+          linkOnly: false,
+          hideOnLogin: true,
+          config: ($cfg + {"syncMode": "IMPORT", "validateSignatures": "true"})
+        }' > /tmp/idp-enterprise-sso.json
+
+      EXISTING_IDP=$(curl -s "$KC_REALM/identity-provider/instances/enterprise_sso" \
+        -H "Authorization: Bearer $ACCESS_TOKEN")
+      if echo "$EXISTING_IDP" | jq -e '.internalId or .id' >/dev/null 2>&1; then
+        keycloak_api_call "curl -s -X PUT \"$KC_REALM/identity-provider/instances/enterprise_sso\" $AUTH $CT --data \"@/tmp/idp-enterprise-sso.json\""
+        echo "  Updated identity provider: enterprise_sso"
+      else
+        keycloak_api_call "curl -s -X POST \"$KC_REALM/identity-provider/instances\" $AUTH $CT --data \"@/tmp/idp-enterprise-sso.json\""
+        echo "  Created identity provider: enterprise_sso"
+      fi
+
+      jq -n '{
+        name: "identity-provider",
+        identityProviderAlias: "enterprise_sso",
+        identityProviderMapper: "hardcoded-attribute-idp-mapper",
+        config: {
+          attribute: "identity_provider",
+          "attribute.value": "enterprise_sso:saml"
+        }
+      }' > /tmp/mapper-enterprise-sso.json
+      EXISTING_MAPPER_ID=$(curl -s "$KC_REALM/identity-provider/instances/enterprise_sso/mappers" \
+        -H "Authorization: Bearer $ACCESS_TOKEN" | jq -r \
+        '.[] | objects | select(.name == "identity-provider") | .id // empty')
+      if [ -n "$EXISTING_MAPPER_ID" ]; then
+        jq --arg id "$EXISTING_MAPPER_ID" '. + {id: $id}' /tmp/mapper-enterprise-sso.json > /tmp/mapper-enterprise-sso-update.json
+        keycloak_api_call "curl -s -X PUT \"$KC_REALM/identity-provider/instances/enterprise_sso/mappers/$EXISTING_MAPPER_ID\" $AUTH $CT --data \"@/tmp/mapper-enterprise-sso-update.json\""
+        echo "  Updated mapper: enterprise_sso/identity-provider"
+      else
+        keycloak_api_call "curl -s -X POST \"$KC_REALM/identity-provider/instances/enterprise_sso/mappers\" $AUTH $CT --data \"@/tmp/mapper-enterprise-sso.json\""
+        echo "  Created mapper: enterprise_sso/identity-provider"
+      fi
+      echo "enterprise_sso SAML identity provider configured."
+    ) || echo "WARNING: enterprise_sso auto-configuration failed (details above). Fix the SAML metadata URL and redeploy to retry; continuing startup." >&2
+    {{- end }}
 {{- end }}

--- a/charts/openhands/templates/keycloak-config-script.yaml
+++ b/charts/openhands/templates/keycloak-config-script.yaml
@@ -65,6 +65,28 @@ data:
       esac
     }
 
+    keycloak_write() {
+      METHOD=$1
+      URL=$2
+      DATA_FILE=$3
+      if ! STATUS=$(curl -sS -o /tmp/keycloak-write-response.json -w '%{http_code}' \
+        -X "$METHOD" "$URL" \
+        -H "Authorization: Bearer $ACCESS_TOKEN" \
+        -H "Content-Type: application/json" \
+        --data "@$DATA_FILE"); then
+        echo "ERROR: Keycloak $METHOD $URL failed." >&2
+        return 1
+      fi
+      if ! RESPONSE=$(cat /tmp/keycloak-write-response.json); then
+        echo "ERROR: could not read the Keycloak $METHOD response for $URL." >&2
+        return 1
+      fi
+      case "$STATUS" in
+        2??) return 0 ;;
+        *) echo "ERROR: Keycloak $METHOD $URL returned HTTP $STATUS: $RESPONSE" >&2; return 1 ;;
+      esac
+    }
+
     echo "Waiting for Keycloak to be ready..."
     until curl --output /dev/null --silent --head --fail $KEYCLOAK_SERVER_URL; do
         echo '.'
@@ -290,7 +312,6 @@ data:
       refresh_access_token || exit 1
       KC_REALM="$KEYCLOAK_SERVER_URL/admin/realms/$KEYCLOAK_REALM_NAME"
       AUTH="-H \"Authorization: Bearer $ACCESS_TOKEN\""
-      CT="-H \"Content-Type: application/json\""
 
       echo "Importing enterprise SSO IdP metadata from the configured URL..."
       IMPORT_REQUEST=$(jq -n --arg from_url "$ENTERPRISE_SSO_IDP_METADATA_URL" '{
@@ -323,16 +344,20 @@ data:
           authenticateByDefault: false,
           linkOnly: false,
           hideOnLogin: true,
-          config: (. + {"syncMode": "IMPORT", "validateSignature": "true"})
+          config: (. + {
+            "syncMode": "IMPORT",
+            "validateSignature": "true",
+            "openhandsManaged": "true"
+          })
         }' > /tmp/idp-enterprise-sso.json || exit 1
 
       keycloak_get_optional "$KC_REALM/identity-provider/instances/enterprise_sso" || exit 1
       EXISTING_IDP=$RESPONSE
       if echo "$EXISTING_IDP" | jq -e '.internalId or .id' >/dev/null 2>&1; then
-        keycloak_api_call "curl -s -X PUT \"$KC_REALM/identity-provider/instances/enterprise_sso\" $AUTH $CT --data \"@/tmp/idp-enterprise-sso.json\"" || exit 1
+        keycloak_write PUT "$KC_REALM/identity-provider/instances/enterprise_sso" /tmp/idp-enterprise-sso.json || exit 1
         echo "  Updated identity provider: enterprise_sso"
       else
-        keycloak_api_call "curl -s -X POST \"$KC_REALM/identity-provider/instances\" $AUTH $CT --data \"@/tmp/idp-enterprise-sso.json\"" || exit 1
+        keycloak_write POST "$KC_REALM/identity-provider/instances" /tmp/idp-enterprise-sso.json || exit 1
         echo "  Created identity provider: enterprise_sso"
       fi
 
@@ -351,28 +376,25 @@ data:
         '.[] | objects | select(.name == "identity-provider") | .id // empty') || exit 1
       if [ -n "$EXISTING_MAPPER_ID" ]; then
         jq --arg id "$EXISTING_MAPPER_ID" '. + {id: $id}' /tmp/mapper-enterprise-sso.json > /tmp/mapper-enterprise-sso-update.json || exit 1
-        keycloak_api_call "curl -s -X PUT \"$KC_REALM/identity-provider/instances/enterprise_sso/mappers/$EXISTING_MAPPER_ID\" $AUTH $CT --data \"@/tmp/mapper-enterprise-sso-update.json\"" || exit 1
+        keycloak_write PUT "$KC_REALM/identity-provider/instances/enterprise_sso/mappers/$EXISTING_MAPPER_ID" /tmp/mapper-enterprise-sso-update.json || exit 1
         echo "  Updated mapper: enterprise_sso/identity-provider"
       else
-        keycloak_api_call "curl -s -X POST \"$KC_REALM/identity-provider/instances/enterprise_sso/mappers\" $AUTH $CT --data \"@/tmp/mapper-enterprise-sso.json\"" || exit 1
+        keycloak_write POST "$KC_REALM/identity-provider/instances/enterprise_sso/mappers" /tmp/mapper-enterprise-sso.json || exit 1
         echo "  Created mapper: enterprise_sso/identity-provider"
       fi
       echo "enterprise_sso SAML identity provider configured."
     ) || echo "WARNING: enterprise_sso auto-configuration failed (details above). Fix the SAML metadata URL and redeploy to retry; continuing startup." >&2
-    {{- else if .Values.enterpriseSSO.idpMetadataUrl }}
-    # A retained metadata URL marks this provider as chart-managed. Disable it
-    # when the feature toggle is turned off so direct kc_idp_hint requests cannot
-    # bypass the hidden login button.
+    {{- else if not .Values.enterpriseSSO.enabled }}
+    # Reconcile on every toggle-off rollout, but only modify a provider stamped
+    # as chart-managed by the auto-configuration path.
     (
       refresh_access_token || exit 1
       KC_REALM="$KEYCLOAK_SERVER_URL/admin/realms/$KEYCLOAK_REALM_NAME"
-      AUTH="-H \"Authorization: Bearer $ACCESS_TOKEN\""
-      CT="-H \"Content-Type: application/json\""
       keycloak_get_optional "$KC_REALM/identity-provider/instances/enterprise_sso" || exit 1
       EXISTING_IDP=$RESPONSE
-      if echo "$EXISTING_IDP" | jq -e '.internalId or .id' >/dev/null 2>&1; then
+      if echo "$EXISTING_IDP" | jq -e '.config.openhandsManaged == "true"' >/dev/null 2>&1; then
         echo "$EXISTING_IDP" | jq '.enabled = false' > /tmp/idp-enterprise-sso-disabled.json || exit 1
-        keycloak_api_call "curl -s -X PUT \"$KC_REALM/identity-provider/instances/enterprise_sso\" $AUTH $CT --data \"@/tmp/idp-enterprise-sso-disabled.json\"" || exit 1
+        keycloak_write PUT "$KC_REALM/identity-provider/instances/enterprise_sso" /tmp/idp-enterprise-sso-disabled.json || exit 1
         echo "Disabled managed identity provider: enterprise_sso"
       fi
     ) || echo "WARNING: could not disable the managed enterprise_sso identity provider; continuing startup." >&2

--- a/charts/openhands/templates/validations.yaml
+++ b/charts/openhands/templates/validations.yaml
@@ -12,6 +12,10 @@ are never rendered, so a server-less release must not trip them.
 {{- if and .Values.enabled (not .Values.postgresql.enabled) (or (not .Values.externalDatabase.host) (not .Values.externalDatabase.username)) -}}
 {{- fail "postgresql.enabled is false but the external database is not configured. Set externalDatabase.host and externalDatabase.username, or set postgresql.enabled=true to use the bundled database." -}}
 {{- end -}}
+{{- if and .Values.enabled .Values.enterpriseSSO.idpMetadataUrl (not (include "openhands.keycloakProvisionRealm" .)) -}}
+{{- fail "enterpriseSSO.idpMetadataUrl requires chart-managed Keycloak realm provisioning. Set keycloak.enabled=true or keycloak.provisionRealm=true, or leave enterpriseSSO.idpMetadataUrl empty and manage the provider manually." -}}
+{{- end -}}
+
 {{/*
 Data-loss guard for the bundled MinIO. Its chart runs the bucket job on
 post-install AND post-upgrade, and purge: true makes that job delete the bucket

--- a/charts/openhands/tests/enterprise_sso_test.yaml
+++ b/charts/openhands/tests/enterprise_sso_test.yaml
@@ -11,6 +11,9 @@ tests:
     set:
       enabled: true
       keycloak.enabled: true
+      databaseMigrations.waitForDatabase: false
+      databaseMigrations.createDatabases: false
+      databaseMigrations.migrate: false
       enterpriseSSO.enabled: true
       enterpriseSSO.displayName: Company SSO
       enterpriseSSO.idpMetadataUrl: https://idp.example.com/saml/metadata
@@ -21,6 +24,28 @@ tests:
           content:
             name: OH_WEB_CLIENT_PROVIDERS_CONFIGURED
             value: '["enterprise_sso"]'
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENABLE_ENTERPRISE_SSO
+            value: "true"
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.initContainers[0].name
+          value: keycloak-config
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: ENTERPRISE_SSO_DISPLAY_NAME
+            value: Company SSO
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: ENTERPRISE_SSO_IDP_METADATA_URL
+            value: https://idp.example.com/saml/metadata
       - template: keycloak-config-script.yaml
         matchRegex:
           path: data["keycloak-config.sh"]

--- a/charts/openhands/tests/enterprise_sso_test.yaml
+++ b/charts/openhands/tests/enterprise_sso_test.yaml
@@ -1,0 +1,68 @@
+suite: Enterprise SSO wiring
+# The deployment checksums both Keycloak ConfigMaps and always references the
+# LiteLLM script, so all four templates participate in these render tests.
+templates:
+  - deployment.yaml
+  - keycloak-config-script.yaml
+  - keycloak-realm-template.yaml
+  - litellm-config-script.yaml
+tests:
+  - it: advertises and auto-configures Enterprise SSO from metadata
+    set:
+      enabled: true
+      keycloak.enabled: true
+      enterpriseSSO.enabled: true
+      enterpriseSSO.displayName: Company SSO
+      enterpriseSSO.idpMetadataUrl: https://idp.example.com/saml/metadata
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OH_WEB_CLIENT_PROVIDERS_CONFIGURED
+            value: '["enterprise_sso"]'
+      - template: keycloak-config-script.yaml
+        matchRegex:
+          path: data["keycloak-config.sh"]
+          pattern: 'Content-Type: application/json'
+      - template: keycloak-config-script.yaml
+        matchRegex:
+          path: data["keycloak-config.sh"]
+          pattern: 'validateSignature.*true'
+      - template: keycloak-config-script.yaml
+        notMatchRegex:
+          path: data["keycloak-config.sh"]
+          pattern: 'validateSignatures'
+
+  - it: advertises Enterprise SSO without managing Keycloak when metadata is blank
+    set:
+      enabled: true
+      keycloak.enabled: true
+      enterpriseSSO.enabled: true
+      enterpriseSSO.idpMetadataUrl: ""
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OH_WEB_CLIENT_PROVIDERS_CONFIGURED
+            value: '["enterprise_sso"]'
+      - template: keycloak-config-script.yaml
+        notMatchRegex:
+          path: data["keycloak-config.sh"]
+          pattern: 'ENTERPRISE_SSO_IDP_METADATA_URL'
+
+  - it: disables a managed provider when the feature toggle is off
+    set:
+      enabled: true
+      keycloak.enabled: true
+      enterpriseSSO.enabled: false
+      enterpriseSSO.idpMetadataUrl: https://idp.example.com/saml/metadata
+    asserts:
+      - template: deployment.yaml
+        notExists:
+          path: spec.template.spec.containers[0].env[?(@.name=="OH_WEB_CLIENT_PROVIDERS_CONFIGURED")]
+      - template: keycloak-config-script.yaml
+        matchRegex:
+          path: data["keycloak-config.sh"]
+          pattern: 'Disabled managed identity provider: enterprise_sso'

--- a/charts/openhands/tests/enterprise_sso_test.yaml
+++ b/charts/openhands/tests/enterprise_sso_test.yaml
@@ -58,6 +58,10 @@ tests:
         notMatchRegex:
           path: data["keycloak-config.sh"]
           pattern: 'validateSignatures'
+      - template: keycloak-config-script.yaml
+        matchRegex:
+          path: data["keycloak-config.sh"]
+          pattern: 'openhandsManaged.*true'
 
   - it: advertises Enterprise SSO without managing Keycloak when metadata is blank
     set:
@@ -76,13 +80,17 @@ tests:
         notMatchRegex:
           path: data["keycloak-config.sh"]
           pattern: 'ENTERPRISE_SSO_IDP_METADATA_URL'
+      - template: keycloak-config-script.yaml
+        notMatchRegex:
+          path: data["keycloak-config.sh"]
+          pattern: 'Disabled managed identity provider: enterprise_sso'
 
-  - it: disables a managed provider when the feature toggle is off
+  - it: disables a marked managed provider after the metadata URL is cleared
     set:
       enabled: true
       keycloak.enabled: true
       enterpriseSSO.enabled: false
-      enterpriseSSO.idpMetadataUrl: https://idp.example.com/saml/metadata
+      enterpriseSSO.idpMetadataUrl: ""
     asserts:
       - template: deployment.yaml
         notExists:

--- a/charts/openhands/tests/enterprise_sso_test.yaml
+++ b/charts/openhands/tests/enterprise_sso_test.yaml
@@ -91,3 +91,26 @@ tests:
         matchRegex:
           path: data["keycloak-config.sh"]
           pattern: 'Disabled managed identity provider: enterprise_sso'
+
+  - it: gives operator env overrides precedence without duplicates
+    set:
+      enabled: true
+      keycloak.enabled: true
+      databaseMigrations.waitForDatabase: false
+      databaseMigrations.createDatabases: false
+      databaseMigrations.migrate: false
+      enterpriseSSO.enabled: true
+      enterpriseSSO.displayName: Company SSO
+      enterpriseSSO.idpMetadataUrl: https://idp.example.com/saml/metadata
+      env:
+        ENTERPRISE_SSO_DISPLAY_NAME: Operator SSO
+        ENTERPRISE_SSO_IDP_METADATA_URL: https://operator.example.com/saml/metadata
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.initContainers[0].env[?(@.name=="ENTERPRISE_SSO_DISPLAY_NAME")].value
+          value: Operator SSO
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.initContainers[0].env[?(@.name=="ENTERPRISE_SSO_IDP_METADATA_URL")].value
+          value: https://operator.example.com/saml/metadata

--- a/charts/openhands/tests/validations_test.yaml
+++ b/charts/openhands/tests/validations_test.yaml
@@ -45,6 +45,25 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: fails when SSO metadata is set without chart-managed realm provisioning
+    set:
+      enterpriseSSO.enabled: true
+      enterpriseSSO.idpMetadataUrl: https://idp.example.com/saml/metadata
+      keycloak.enabled: false
+      keycloak.provisionRealm: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "enterpriseSSO.idpMetadataUrl requires chart-managed Keycloak realm provisioning. Set keycloak.enabled=true or keycloak.provisionRealm=true, or leave enterpriseSSO.idpMetadataUrl empty and manage the provider manually."
+  - it: allows manually managed SSO with external Keycloak
+    set:
+      enterpriseSSO.enabled: true
+      enterpriseSSO.idpMetadataUrl: ""
+      keycloak.enabled: false
+      keycloak.provisionRealm: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
   # The bundled MinIO bucket job runs on post-upgrade too, so purge: true wipes
   # conversation and session data on every ordinary upgrade of a persistent
   # install. These cases pin the guard that rejects it.

--- a/charts/openhands/tests/values_schema_test.yaml
+++ b/charts/openhands/tests/values_schema_test.yaml
@@ -62,6 +62,13 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "filestore/region.*want string"
+  - it: rejects an insecure Enterprise SSO metadata URL
+    set:
+      enterpriseSSO.idpMetadataUrl: http://idp.example.com/metadata
+    asserts:
+      - failedTemplate:
+          errorPattern: "enterpriseSSO/idpMetadataUrl"
+
   - it: accepts valid values
     set:
       uvicorn.workers: 4
@@ -73,6 +80,7 @@ tests:
       filestore.endpoint: https://minio.example.com
       filestore.existingSecret: s3-creds
       filestore.accessKeyIdKey: access-key
+      enterpriseSSO.idpMetadataUrl: https://idp.example.com/metadata
       filestore.secretAccessKeyKey: secret-key
       laminar.clickhouse.diagnostics.retentionDays: 2
     asserts:

--- a/charts/openhands/tests/values_schema_test.yaml
+++ b/charts/openhands/tests/values_schema_test.yaml
@@ -68,6 +68,18 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "enterpriseSSO/idpMetadataUrl"
+  - it: rejects a bare HTTPS Enterprise SSO metadata URL
+    set:
+      enterpriseSSO.idpMetadataUrl: https://
+    asserts:
+      - failedTemplate:
+          errorPattern: "enterpriseSSO/idpMetadataUrl"
+  - it: rejects whitespace in an Enterprise SSO metadata URL
+    set:
+      enterpriseSSO.idpMetadataUrl: "https://idp.example.com/saml metadata"
+    asserts:
+      - failedTemplate:
+          errorPattern: "enterpriseSSO/idpMetadataUrl"
 
   - it: accepts valid values
     set:

--- a/charts/openhands/values.schema.json
+++ b/charts/openhands/values.schema.json
@@ -49,12 +49,15 @@
         "class": { "type": "string" }
       }
     },
-    "enterpriseSso": {
+    "enterpriseSSO": {
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
         "displayName": { "type": "string" },
-        "idpMetadataUrl": { "type": "string" }
+        "idpMetadataUrl": {
+          "type": "string",
+          "pattern": "^$|^https://"
+        }
       }
     },
     "sandbox": {

--- a/charts/openhands/values.schema.json
+++ b/charts/openhands/values.schema.json
@@ -49,6 +49,14 @@
         "class": { "type": "string" }
       }
     },
+    "enterpriseSso": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "displayName": { "type": "string" },
+        "idpMetadataUrl": { "type": "string" }
+      }
+    },
     "sandbox": {
       "type": "object",
       "properties": {

--- a/charts/openhands/values.schema.json
+++ b/charts/openhands/values.schema.json
@@ -56,7 +56,7 @@
         "displayName": { "type": "string" },
         "idpMetadataUrl": {
           "type": "string",
-          "pattern": "^$|^https://"
+          "pattern": "^$|^https://[^\\s]+$"
         }
       }
     },

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -226,7 +226,7 @@ bitbucket:
 # enterprise_sso identity provider on every pod start.
 enterpriseSSO:
   enabled: false
-  displayName: ""
+  displayName: "Company SSO"
   idpMetadataUrl: ""
 
 # sha256 of all secret (password) config values, injected by KOTS. Changing any

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -119,15 +119,6 @@ agentServerEnv: {}
 integrations:
   resolverLabel: "openhands"
 
-# Enterprise SSO (SAML) automatic Keycloak setup: when enabled and
-# idpMetadataUrl is set, the keycloak-config init container upserts the
-# enterprise_sso SAML identity provider on every pod start (idempotent).
-# Leave idpMetadataUrl empty to manage the provider manually.
-enterpriseSso:
-  enabled: false
-  displayName: ""
-  idpMetadataUrl: ""
-
 # Object storage for conversation/session files. Always a durable object
 # store: any S3-compatible store (AWS S3, the bundled MinIO, R2, ...) or GCS.
 # To use the bundled MinIO, set minio.enabled: true and type: s3 — with no
@@ -230,8 +221,13 @@ bitbucket:
   auth:
     existingSecret: bitbucket-app
 
+# Enterprise SSO (SAML). Enabling this advertises the login provider. When an
+# HTTPS metadata URL is also set, the keycloak-config init container manages the
+# enterprise_sso identity provider on every pod start.
 enterpriseSSO:
   enabled: false
+  displayName: ""
+  idpMetadataUrl: ""
 
 # sha256 of all secret (password) config values, injected by KOTS. Changing any
 # secret-backed config changes this value, which changes the openhands pod

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -119,6 +119,15 @@ agentServerEnv: {}
 integrations:
   resolverLabel: "openhands"
 
+# Enterprise SSO (SAML) automatic Keycloak setup: when enabled and
+# idpMetadataUrl is set, the keycloak-config init container upserts the
+# enterprise_sso SAML identity provider on every pod start (idempotent).
+# Leave idpMetadataUrl empty to manage the provider manually.
+enterpriseSso:
+  enabled: false
+  displayName: ""
+  idpMetadataUrl: ""
+
 # Object storage for conversation/session files. Always a durable object
 # store: any S3-compatible store (AWS S3, the bundled MinIO, R2, ...) or GCS.
 # To use the bundled MinIO, set minio.enabled: true and type: s3 — with no

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -994,11 +994,11 @@ spec:
 
     - name: enterprise_sso_authentication
       title: Enterprise SSO (SAML) Authentication
-      description: Let users sign in with a corporate SAML identity provider through the bundled Keycloak. Requires an identity provider with alias enterprise_sso in the allhands Keycloak realm.
+      description: Let users sign in with a corporate SAML identity provider through the bundled Keycloak. Provide a metadata URL below for automatic setup, or manually configure an identity provider with alias enterprise_sso in the allhands realm.
       items:
         - name: enterprise_sso_enabled
           title: Enable Enterprise SSO Authentication
-          help_text: Show the Enterprise SSO button on the OpenHands login page. The button redirects users to the identity provider whose alias is enterprise_sso in the bundled Keycloak (realm allhands). Configure that identity provider before enabling this option, or users will land on the Keycloak login page instead.
+          help_text: Show the Enterprise SSO button on the OpenHands login page. The button redirects users to the identity provider whose alias is enterprise_sso in the bundled Keycloak (realm allhands). Provide a metadata URL below for automatic setup, or configure that identity provider manually before enabling this option.
           type: bool
           default: "0"
         - name: enterprise_sso_display_name
@@ -1009,7 +1009,7 @@ spec:
         - name: enterprise_sso_idp_metadata_url
           title: SAML Metadata URL
           help_text: >-
-            Public URL of your identity provider's SAML metadata. For example,
+            HTTPS URL of your identity provider's SAML metadata. For example,
             https://login.microsoftonline.com/<tenant-id>/federationmetadata/2007-06/federationmetadata.xml
             (Microsoft Entra ID) or https://<okta-domain>/app/<app-id>/sso/saml/metadata (Okta).
             When provided, the installer automatically creates and keeps up to date the
@@ -1019,6 +1019,10 @@ spec:
             provider manually in the Keycloak admin console.
           type: text
           when: 'repl{{ ConfigOptionEquals "enterprise_sso_enabled" "1" }}'
+          validation:
+            regex:
+              pattern: '^$|^https://[^[:space:]]+$'
+              message: 'Must be blank or an HTTPS metadata URL.'
 
     - name: slack_configuration
       title: Enable Slack

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -994,13 +994,31 @@ spec:
 
     - name: enterprise_sso_authentication
       title: Enterprise SSO (SAML) Authentication
-      description: Let users sign in with a corporate SAML or OIDC identity provider through the bundled Keycloak. Requires an identity provider with alias enterprise_sso in the allhands Keycloak realm.
+      description: Let users sign in with a corporate SAML identity provider through the bundled Keycloak. Requires an identity provider with alias enterprise_sso in the allhands Keycloak realm.
       items:
         - name: enterprise_sso_enabled
           title: Enable Enterprise SSO Authentication
           help_text: Show the Enterprise SSO button on the OpenHands login page. The button redirects users to the identity provider whose alias is enterprise_sso in the bundled Keycloak (realm allhands). Configure that identity provider before enabling this option, or users will land on the Keycloak login page instead.
           type: bool
           default: "0"
+        - name: enterprise_sso_display_name
+          title: Identity Provider Display Name
+          help_text: Name shown for this identity provider in Keycloak. Defaults to "Company SSO" when left blank.
+          type: text
+          when: 'repl{{ ConfigOptionEquals "enterprise_sso_enabled" "1" }}'
+        - name: enterprise_sso_idp_metadata_url
+          title: SAML Metadata URL
+          help_text: >-
+            Public URL of your identity provider's SAML metadata. For example,
+            https://login.microsoftonline.com/<tenant-id>/federationmetadata/2007-06/federationmetadata.xml
+            (Microsoft Entra ID) or https://<okta-domain>/app/<app-id>/sso/saml/metadata (Okta).
+            When provided, the installer automatically creates and keeps up to date the
+            enterprise_sso SAML identity provider in the bundled Keycloak (realm allhands),
+            with signature validation and trust-email on and the attribute mapper OpenHands
+            uses to recognize SAML logins. Leave blank to create and manage the identity
+            provider manually in the Keycloak admin console.
+          type: text
+          when: 'repl{{ ConfigOptionEquals "enterprise_sso_enabled" "1" }}'
 
     - name: slack_configuration
       title: Enable Slack

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1017,7 +1017,9 @@ spec:
             enterprise_sso SAML identity provider in the bundled Keycloak (realm allhands),
             with signature validation and trust-email on and the attribute mapper OpenHands
             uses to recognize SAML logins. Leave blank to create and manage the identity
-            provider manually in the Keycloak admin console.
+            provider manually in the Keycloak admin console. Manual setup must also add a
+            mapper named identity-provider with type hardcoded-attribute-idp-mapper,
+            attribute identity_provider, value enterprise_sso:saml, and sync mode FORCE.
           type: text
           when: 'repl{{ ConfigOptionEquals "enterprise_sso_enabled" "1" }}'
           validation:

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -994,32 +994,22 @@ spec:
 
     - name: enterprise_sso_authentication
       title: Enterprise SSO (SAML) Authentication
-      description: Let users sign in with a corporate SAML identity provider through the bundled Keycloak. Provide a metadata URL below for automatic setup, or manually configure an identity provider with alias enterprise_sso in the allhands realm.
+      description: Let users sign in with your corporate SAML identity provider.
       items:
         - name: enterprise_sso_enabled
           title: Enable Enterprise SSO Authentication
-          help_text: Show the Enterprise SSO button on the OpenHands login page. The button redirects users to the identity provider whose alias is enterprise_sso in the bundled Keycloak (realm allhands). Provide a metadata URL below for automatic setup, or configure that identity provider manually before enabling this option.
+          help_text: Add an Enterprise SSO button to the OpenHands login page.
           type: bool
           default: "0"
         - name: enterprise_sso_display_name
           title: Identity Provider Display Name
-          help_text: Name shown for this identity provider in Keycloak.
+          help_text: Name shown for the identity provider on the sign-in page.
           type: text
           default: "Company SSO"
           when: 'repl{{ ConfigOptionEquals "enterprise_sso_enabled" "1" }}'
         - name: enterprise_sso_idp_metadata_url
           title: SAML Metadata URL
-          help_text: >-
-            HTTPS URL of your identity provider's SAML metadata. For example,
-            https://login.microsoftonline.com/<tenant-id>/federationmetadata/2007-06/federationmetadata.xml
-            (Microsoft Entra ID) or https://<okta-domain>/app/<app-id>/sso/saml/metadata (Okta).
-            When provided, the installer automatically creates and keeps up to date the
-            enterprise_sso SAML identity provider in the bundled Keycloak (realm allhands),
-            with signature validation and trust-email on and the attribute mapper OpenHands
-            uses to recognize SAML logins. Leave blank to create and manage the identity
-            provider manually in the Keycloak admin console. Manual setup must also add a
-            mapper named identity-provider with type hardcoded-attribute-idp-mapper,
-            attribute identity_provider, value enterprise_sso:saml, and sync mode FORCE.
+          help_text: HTTPS URL of your identity provider's SAML metadata. Leave blank to set the provider up manually instead.
           type: text
           when: 'repl{{ ConfigOptionEquals "enterprise_sso_enabled" "1" }}'
           validation:

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -992,6 +992,16 @@ spec:
           when: 'repl{{ ConfigOptionEquals "gitlab_auth_enabled" "1" }}'
           required: true
 
+    - name: enterprise_sso_authentication
+      title: Enterprise SSO (SAML) Authentication
+      description: Let users sign in with a corporate SAML or OIDC identity provider through the bundled Keycloak. Requires an identity provider with alias enterprise_sso in the allhands Keycloak realm.
+      items:
+        - name: enterprise_sso_enabled
+          title: Enable Enterprise SSO Authentication
+          help_text: Show the Enterprise SSO button on the OpenHands login page. The button redirects users to the identity provider whose alias is enterprise_sso in the bundled Keycloak (realm allhands). Configure that identity provider before enabling this option, or users will land on the Keycloak login page instead.
+          type: bool
+          default: "0"
+
     - name: slack_configuration
       title: Enable Slack
       description: Enable Slack

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1003,8 +1003,9 @@ spec:
           default: "0"
         - name: enterprise_sso_display_name
           title: Identity Provider Display Name
-          help_text: Name shown for this identity provider in Keycloak. Defaults to "Company SSO" when left blank.
+          help_text: Name shown for this identity provider in Keycloak.
           type: text
+          default: "Company SSO"
           when: 'repl{{ ConfigOptionEquals "enterprise_sso_enabled" "1" }}'
         - name: enterprise_sso_idp_metadata_url
           title: SAML Metadata URL

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1009,7 +1009,11 @@ spec:
           when: 'repl{{ ConfigOptionEquals "enterprise_sso_enabled" "1" }}'
         - name: enterprise_sso_idp_metadata_url
           title: SAML Metadata URL
-          help_text: HTTPS URL of your identity provider's SAML metadata. Leave blank to set the provider up manually instead.
+          help_text: |
+            HTTPS URL of your identity provider's SAML metadata.
+            Leave blank to create the provider yourself in Keycloak:
+            • SAML v2.0 provider with alias enterprise_sso
+            • Mapper identity-provider, type hardcoded-attribute-idp-mapper, attribute identity_provider, value enterprise_sso:saml, sync mode FORCE
           type: text
           when: 'repl{{ ConfigOptionEquals "enterprise_sso_enabled" "1" }}'
           validation:

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1009,17 +1009,14 @@ spec:
           when: 'repl{{ ConfigOptionEquals "enterprise_sso_enabled" "1" }}'
         - name: enterprise_sso_idp_metadata_url
           title: SAML Metadata URL
-          help_text: |
-            HTTPS URL of your identity provider's SAML metadata.
-            Leave blank to create the provider yourself in Keycloak:
-            • SAML v2.0 provider with alias enterprise_sso
-            • Mapper identity-provider, type hardcoded-attribute-idp-mapper, attribute identity_provider, value enterprise_sso:saml, sync mode FORCE
+          help_text: HTTPS URL of your identity provider's SAML metadata.
           type: text
           when: 'repl{{ ConfigOptionEquals "enterprise_sso_enabled" "1" }}'
+          required: true
           validation:
             regex:
-              pattern: '^$|^https://[^[:space:]]+$'
-              message: 'Must be blank or an HTTPS metadata URL.'
+              pattern: '^https://[^[:space:]]+$'
+              message: 'Must be an HTTPS metadata URL.'
 
     - name: slack_configuration
       title: Enable Slack

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -108,10 +108,10 @@ spec:
     # is provided, the chart's keycloak-config init container upserts the
     # enterprise_sso SAML identity provider in Keycloak on every pod start.
     # Leave idpMetadataUrl empty to manage the provider manually.
-    enterpriseSso:
+    enterpriseSSO:
       enabled: repl{{ ConfigOptionEquals "enterprise_sso_enabled" "1" }}
-      displayName: 'repl{{ ConfigOption "enterprise_sso_display_name" }}'
-      idpMetadataUrl: 'repl{{ ConfigOption "enterprise_sso_idp_metadata_url" }}'
+      displayName: repl{{ ConfigOption "enterprise_sso_display_name" | mustToJson }}
+      idpMetadataUrl: repl{{ ConfigOption "enterprise_sso_idp_metadata_url" | mustToJson }}
 
     ingress:
       enabled: true

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -63,6 +63,11 @@ spec:
       # integration card never renders. Mirror jira_data_center_enabled here.
       OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_JIRA_DC: 'repl{{ ConfigOptionEquals "jira_data_center_enabled" "1" }}'
       OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_JIRA: 'repl{{ ConfigOptionEquals "jira_cloud_enabled" "1" }}'
+      # ENABLE_ENTERPRISE_SSO is only presence-checked by the app server and the
+      # web-client config injector: any non-empty value (even the string "false")
+      # turns the login button on. Render "true" when enabled and nothing when
+      # disabled so the button stays hidden.
+      ENABLE_ENTERPRISE_SSO: 'repl{{ if ConfigOptionEquals "enterprise_sso_enabled" "1" }}truerepl{{ end }}'
       LOG_LEVEL: 'repl{{ ConfigOption "log_level" }}'
       # The chart's fallback for LAMINAR_WEB_HOST is laminar.<ingress.host>, but
       # Replicated installs expose Laminar at the analytics hostname. Set it

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -63,11 +63,6 @@ spec:
       # integration card never renders. Mirror jira_data_center_enabled here.
       OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_JIRA_DC: 'repl{{ ConfigOptionEquals "jira_data_center_enabled" "1" }}'
       OH_WEB_CLIENT_FEATURE_FLAGS_ENABLE_JIRA: 'repl{{ ConfigOptionEquals "jira_cloud_enabled" "1" }}'
-      # ENABLE_ENTERPRISE_SSO is only presence-checked by the app server and the
-      # web-client config injector: any non-empty value (even the string "false")
-      # turns the login button on. Render "true" when enabled and nothing when
-      # disabled so the button stays hidden.
-      ENABLE_ENTERPRISE_SSO: 'repl{{ if ConfigOptionEquals "enterprise_sso_enabled" "1" }}truerepl{{ end }}'
       LOG_LEVEL: 'repl{{ ConfigOption "log_level" }}'
       # The chart's fallback for LAMINAR_WEB_HOST is laminar.<ingress.host>, but
       # Replicated installs expose Laminar at the analytics hostname. Set it

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -104,6 +104,15 @@ spec:
     integrations:
       resolverLabel: 'repl{{ ConfigOption "openhands_resolver_label" }}'
 
+    # Enterprise SSO auto-configuration. When the toggle is on and a metadata URL
+    # is provided, the chart's keycloak-config init container upserts the
+    # enterprise_sso SAML identity provider in Keycloak on every pod start.
+    # Leave idpMetadataUrl empty to manage the provider manually.
+    enterpriseSso:
+      enabled: repl{{ ConfigOptionEquals "enterprise_sso_enabled" "1" }}
+      displayName: 'repl{{ ConfigOption "enterprise_sso_display_name" }}'
+      idpMetadataUrl: 'repl{{ ConfigOption "enterprise_sso_idp_metadata_url" }}'
+
     ingress:
       enabled: true
       host: '{{repl ConfigOption "computed_app_hostname" }}'

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -99,10 +99,9 @@ spec:
     integrations:
       resolverLabel: 'repl{{ ConfigOption "openhands_resolver_label" }}'
 
-    # Enterprise SSO auto-configuration. When the toggle is on and a metadata URL
-    # is provided, the chart's keycloak-config init container upserts the
-    # enterprise_sso SAML identity provider in Keycloak on every pod start.
-    # Leave idpMetadataUrl empty to manage the provider manually.
+    # Enterprise SSO auto-configuration. When the toggle is on, the chart's
+    # keycloak-config init container upserts the enterprise_sso SAML identity
+    # provider in Keycloak from this metadata URL on every pod start.
     enterpriseSSO:
       enabled: repl{{ ConfigOptionEquals "enterprise_sso_enabled" "1" }}
       displayName: repl{{ ConfigOption "enterprise_sso_display_name" | mustToJson }}

--- a/scripts/test_keycloak_realm_template.py
+++ b/scripts/test_keycloak_realm_template.py
@@ -27,7 +27,6 @@ OPENHANDS_CHART = REPO_ROOT / "charts" / "openhands"
 OPENHANDS_VALUES = OPENHANDS_CHART / "values.yaml"
 OPENHANDS_VALUES_SCHEMA = OPENHANDS_CHART / "values.schema.json"
 REPLICATED_OPENHANDS = REPO_ROOT / "replicated" / "openhands.yaml"
-REPLICATED_CONFIG = REPO_ROOT / "replicated" / "config.yaml"
 OPENHANDS_README = OPENHANDS_CHART / "README.md"
 
 
@@ -538,6 +537,11 @@ def test_enterprise_sso_disable_path_reconciles_managed_provider() -> None:
 
 
 def test_manual_enterprise_sso_guidance_documents_required_mapper() -> None:
+    """The chart README is the only home for manual identity-provider setup.
+
+    The Replicated help text describes what each field is and nothing more, so
+    the mapper a hand-built provider needs has to be spelled out here.
+    """
     required_mapper_settings = (
         "identity-provider",
         "hardcoded-attribute-idp-mapper",
@@ -546,7 +550,6 @@ def test_manual_enterprise_sso_guidance_documents_required_mapper() -> None:
         "FORCE",
     )
 
-    for guidance_path in (OPENHANDS_README, REPLICATED_CONFIG):
-        guidance = guidance_path.read_text(encoding="utf-8")
-        for setting in required_mapper_settings:
-            assert setting in guidance, f"{guidance_path} must document {setting}"
+    guidance = OPENHANDS_README.read_text(encoding="utf-8")
+    for setting in required_mapper_settings:
+        assert setting in guidance, f"{OPENHANDS_README} must document {setting}"

--- a/scripts/test_keycloak_realm_template.py
+++ b/scripts/test_keycloak_realm_template.py
@@ -24,7 +24,6 @@ KEYCLOAK_CONFIG_SCRIPT = (
 OPENHANDS_CHART = REPO_ROOT / "charts" / "openhands"
 OPENHANDS_VALUES = OPENHANDS_CHART / "values.yaml"
 OPENHANDS_VALUES_SCHEMA = OPENHANDS_CHART / "values.schema.json"
-REPLICATED_CONFIG = REPO_ROOT / "replicated" / "config.yaml"
 REPLICATED_OPENHANDS = REPO_ROOT / "replicated" / "openhands.yaml"
 
 
@@ -249,17 +248,23 @@ def enterprise_sso_idp_jq_filter(script_template: str) -> str:
     return match.group("filter")
 
 
+def enterprise_sso_import_guard(script_template: str) -> str:
+    match = re.search(
+        r'if ! echo "\$IMPORT_RESPONSE" \| jq -e \\\n'
+        r"\s*'(?P<filter>[^']+)' \\\n",
+        script_template,
+    )
+    assert match, "Could not find the enterprise SSO import response guard"
+    return match.group("filter")
+
+
 def test_enterprise_sso_uses_one_canonical_values_key() -> None:
     values = OPENHANDS_VALUES.read_text(encoding="utf-8")
     schema = json.loads(OPENHANDS_VALUES_SCHEMA.read_text(encoding="utf-8"))
     replicated = REPLICATED_OPENHANDS.read_text(encoding="utf-8")
 
     assert "enterpriseSso:" not in values
-    assert re.search(
-        r"^enterpriseSSO:\n  enabled: false\n  displayName: \"\"\n  idpMetadataUrl: \"\"$",
-        values,
-        re.MULTILINE,
-    )
+    assert re.search(r"^enterpriseSSO:$", values, re.MULTILINE)
     assert "enterpriseSso" not in schema["properties"]
     assert set(schema["properties"]["enterpriseSSO"]["properties"]) == {
         "enabled",
@@ -275,11 +280,7 @@ def test_enterprise_sso_metadata_url_requires_https() -> None:
     metadata_schema = schema["properties"]["enterpriseSSO"]["properties"][
         "idpMetadataUrl"
     ]
-    assert metadata_schema["pattern"] == "^$|^https://"
-
-    replicated_config = REPLICATED_CONFIG.read_text(encoding="utf-8")
-    assert "pattern: '^$|^https://[^[:space:]]+$'" in replicated_config
-    assert "message: 'Must be blank or an HTTPS metadata URL.'" in replicated_config
+    assert metadata_schema["pattern"] == r"^$|^https://[^\s]+$"
 
 
 def test_enterprise_sso_uses_keycloak_import_contract() -> None:
@@ -295,10 +296,40 @@ def test_enterprise_sso_uses_keycloak_import_contract() -> None:
     assert "fromUrl: $from_url" in script
     assert 'has("idpEntityId")' in script
     assert 'has("singleSignOnServiceUrl")' in script
-    assert ".config as $cfg" not in script
+    assert 'has("signingCertificate")' in script
     assert '"validateSignature": "true"' in script
-    assert "validateSignatures" not in script
     assert 'syncMode: "FORCE"' in script
+
+
+def test_enterprise_sso_import_guard_requires_signing_certificate() -> None:
+    if shutil.which("jq") is None:
+        pytest.skip("jq not available")
+
+    script = KEYCLOAK_CONFIG_SCRIPT.read_text(encoding="utf-8")
+    jq_filter = enterprise_sso_import_guard(script)
+    imported_config = {
+        "idpEntityId": "https://idp.example.com/entity",
+        "singleSignOnServiceUrl": "https://idp.example.com/sso",
+    }
+
+    missing_certificate = subprocess.run(
+        ["jq", "-e", jq_filter],
+        input=json.dumps(imported_config),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert missing_certificate.returncode == 1
+
+    imported_config["signingCertificate"] = "certificate-data"
+    with_certificate = subprocess.run(
+        ["jq", "-e", jq_filter],
+        input=json.dumps(imported_config),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert with_certificate.returncode == 0
 
 
 def test_enterprise_sso_jq_filter_builds_keycloak_idp() -> None:
@@ -338,7 +369,10 @@ def test_enterprise_sso_inputs_are_environment_data() -> None:
     replicated = REPLICATED_OPENHANDS.read_text(encoding="utf-8")
 
     assert "- name: ENTERPRISE_SSO_DISPLAY_NAME" in deployment
-    assert "value: {{ .Values.enterpriseSSO.displayName | quote }}" in deployment
+    assert (
+        'value: {{ .Values.enterpriseSSO.displayName | default "Company SSO" | quote }}'
+        in deployment
+    )
     assert "- name: ENTERPRISE_SSO_IDP_METADATA_URL" in deployment
     assert "value: {{ .Values.enterpriseSSO.idpMetadataUrl | quote }}" in deployment
     assert "{{ .Values.enterpriseSSO.displayName" not in script

--- a/scripts/test_keycloak_realm_template.py
+++ b/scripts/test_keycloak_realm_template.py
@@ -27,7 +27,6 @@ OPENHANDS_CHART = REPO_ROOT / "charts" / "openhands"
 OPENHANDS_VALUES = OPENHANDS_CHART / "values.yaml"
 OPENHANDS_VALUES_SCHEMA = OPENHANDS_CHART / "values.schema.json"
 REPLICATED_OPENHANDS = REPO_ROOT / "replicated" / "openhands.yaml"
-OPENHANDS_README = OPENHANDS_CHART / "README.md"
 
 
 def pkce_enabled_providers_missing_method(realm: dict) -> list[str]:
@@ -534,22 +533,3 @@ def test_enterprise_sso_disable_path_reconciles_managed_provider() -> None:
     assert '.config.openhandsManaged == "true"' in script
     assert "jq '.enabled = false'" in script
     assert "Disabled managed identity provider: enterprise_sso" in script
-
-
-def test_manual_enterprise_sso_guidance_documents_required_mapper() -> None:
-    """The chart README is the only home for manual identity-provider setup.
-
-    The Replicated help text describes what each field is and nothing more, so
-    the mapper a hand-built provider needs has to be spelled out here.
-    """
-    required_mapper_settings = (
-        "identity-provider",
-        "hardcoded-attribute-idp-mapper",
-        "identity_provider",
-        "enterprise_sso:saml",
-        "FORCE",
-    )
-
-    guidance = OPENHANDS_README.read_text(encoding="utf-8")
-    for setting in required_mapper_settings:
-        assert setting in guidance, f"{OPENHANDS_README} must document {setting}"

--- a/scripts/test_keycloak_realm_template.py
+++ b/scripts/test_keycloak_realm_template.py
@@ -25,6 +25,8 @@ OPENHANDS_CHART = REPO_ROOT / "charts" / "openhands"
 OPENHANDS_VALUES = OPENHANDS_CHART / "values.yaml"
 OPENHANDS_VALUES_SCHEMA = OPENHANDS_CHART / "values.schema.json"
 REPLICATED_OPENHANDS = REPO_ROOT / "replicated" / "openhands.yaml"
+REPLICATED_CONFIG = REPO_ROOT / "replicated" / "config.yaml"
+OPENHANDS_README = OPENHANDS_CHART / "README.md"
 
 
 def pkce_enabled_providers_missing_method(realm: dict) -> list[str]:
@@ -101,6 +103,26 @@ def test_keycloak_api_call_extraction_is_not_tied_to_yaml_indent() -> None:
 """
 
     assert "errorMessage" in keycloak_api_call_body(script_template)
+
+
+def test_keycloak_api_call_propagates_transport_failure() -> None:
+    if shutil.which("jq") is None:
+        pytest.skip("jq not available")
+
+    script_template = KEYCLOAK_CONFIG_SCRIPT.read_text(encoding="utf-8")
+    helper = keycloak_api_call_body(script_template)
+    result = subprocess.run(
+        [
+            "sh",
+            "-c",
+            f"keycloak_api_call() {{\n{helper}}}\nkeycloak_api_call false",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
 
 
 def sso_session_jq_filter(script_template: str) -> str:
@@ -389,9 +411,77 @@ def test_enterprise_sso_inputs_are_environment_data() -> None:
     )
 
 
+def test_enterprise_sso_env_overrides_render_once_for_keycloak_init() -> None:
+    display_name = "Operator SSO"
+    metadata_url = "https://operator.example.com/saml/metadata"
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "test",
+            str(OPENHANDS_CHART),
+            "--show-only",
+            "templates/deployment.yaml",
+            "--set",
+            "enabled=true",
+            "--set",
+            "keycloak.enabled=true",
+            "--set",
+            "databaseMigrations.waitForDatabase=false",
+            "--set",
+            "databaseMigrations.createDatabases=false",
+            "--set",
+            "databaseMigrations.migrate=false",
+            "--set",
+            "enterpriseSSO.enabled=true",
+            "--set-string",
+            "enterpriseSSO.idpMetadataUrl=https://idp.example.com/saml/metadata",
+            "--set-string",
+            f"env.ENTERPRISE_SSO_DISPLAY_NAME={display_name}",
+            "--set-string",
+            f"env.ENTERPRISE_SSO_IDP_METADATA_URL={metadata_url}",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    keycloak_init = re.search(
+        r"(?ms)^      - name: keycloak-config\n(?P<body>.*?)(?=^      - name: litellm-config\n)",
+        result.stdout,
+    )
+    assert keycloak_init, "Could not find the rendered keycloak-config init container"
+    rendered = keycloak_init.group("body")
+
+    assert rendered.count("name: ENTERPRISE_SSO_DISPLAY_NAME") == 1
+    assert re.search(
+        rf"name: ENTERPRISE_SSO_DISPLAY_NAME\s+value: {re.escape(display_name)}",
+        rendered,
+    )
+    assert rendered.count("name: ENTERPRISE_SSO_IDP_METADATA_URL") == 1
+    assert re.search(
+        rf"name: ENTERPRISE_SSO_IDP_METADATA_URL\s+value: {re.escape(metadata_url)}",
+        rendered,
+    )
+
+
 def test_enterprise_sso_disable_path_reconciles_managed_provider() -> None:
     script = KEYCLOAK_CONFIG_SCRIPT.read_text(encoding="utf-8")
 
     assert "else if .Values.enterpriseSSO.idpMetadataUrl" in script
     assert "jq '.enabled = false'" in script
     assert "Disabled managed identity provider: enterprise_sso" in script
+
+
+def test_manual_enterprise_sso_guidance_documents_required_mapper() -> None:
+    required_mapper_settings = (
+        "identity-provider",
+        "hardcoded-attribute-idp-mapper",
+        "identity_provider",
+        "enterprise_sso:saml",
+        "FORCE",
+    )
+
+    for guidance_path in (OPENHANDS_README, REPLICATED_CONFIG):
+        guidance = guidance_path.read_text(encoding="utf-8")
+        for setting in required_mapper_settings:
+            assert setting in guidance, f"{guidance_path} must document {setting}"

--- a/scripts/test_keycloak_realm_template.py
+++ b/scripts/test_keycloak_realm_template.py
@@ -6,6 +6,8 @@ import json
 import re
 import shutil
 import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
@@ -38,14 +40,18 @@ def pkce_enabled_providers_missing_method(realm: dict) -> list[str]:
     return missing_pkce_method
 
 
-def keycloak_api_call_body(script_template: str) -> str:
+def shell_function_body(script_template: str, function_name: str) -> str:
     match = re.search(
-        r"(?ms)^(?P<indent>[ \t]*)keycloak_api_call\(\) \{\n"
+        rf"(?ms)^(?P<indent>[ \t]*){re.escape(function_name)}\(\) \{{\n"
         r"(?P<body>.*?)^(?P=indent)\}",
         script_template,
     )
-    assert match, "Could not find keycloak_api_call() in keycloak-config-script.yaml"
+    assert match, f"Could not find {function_name}() in keycloak-config-script.yaml"
     return match.group("body")
+
+
+def keycloak_api_call_body(script_template: str) -> str:
+    return shell_function_body(script_template, "keycloak_api_call")
 
 
 def assert_pkce_enabled_providers_set_method(realm: dict) -> None:
@@ -123,6 +129,66 @@ def test_keycloak_api_call_propagates_transport_failure() -> None:
     )
 
     assert result.returncode != 0
+
+
+def test_keycloak_write_checks_empty_response_http_status(tmp_path: Path) -> None:
+    class StatusHandler(BaseHTTPRequestHandler):
+        status = 204
+
+        def do_POST(self) -> None:
+            self.rfile.read(int(self.headers.get("Content-Length", "0")))
+            self.send_response(self.status)
+            self.end_headers()
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+    script_template = KEYCLOAK_CONFIG_SCRIPT.read_text(encoding="utf-8")
+    helper = shell_function_body(script_template, "keycloak_write")
+    command = f"keycloak_write() {{\n{helper}}}\nACCESS_TOKEN=test keycloak_write POST \"$1\" \"$2\""
+    payload = tmp_path / "payload.json"
+    payload.write_text("{}", encoding="utf-8")
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), StatusHandler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_port}/resource"
+
+    try:
+        success = subprocess.run(
+            ["sh", "-c", command, "sh", url, str(payload)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert success.returncode == 0
+
+        StatusHandler.status = 403
+        failure = subprocess.run(
+            ["sh", "-c", command, "sh", url, str(payload)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert failure.returncode != 0
+        assert "HTTP 403" in failure.stderr
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+def test_enterprise_sso_writes_use_status_checked_helper() -> None:
+    script = KEYCLOAK_CONFIG_SCRIPT.read_text(encoding="utf-8")
+
+    provider_path = '"$KC_REALM/identity-provider/instances/enterprise_sso'
+    instances_path = '"$KC_REALM/identity-provider/instances'
+    assert script.count(f"keycloak_write PUT {provider_path}") == 3
+    assert script.count(f"keycloak_write POST {instances_path}") == 2
+    assert not re.search(
+        r'keycloak_api_call "curl -s -X (?:POST|PUT) [^\n]*enterprise_sso',
+        script,
+    )
 
 
 def sso_session_jq_filter(script_template: str) -> str:
@@ -391,10 +457,7 @@ def test_enterprise_sso_inputs_are_environment_data() -> None:
     replicated = REPLICATED_OPENHANDS.read_text(encoding="utf-8")
 
     assert "- name: ENTERPRISE_SSO_DISPLAY_NAME" in deployment
-    assert (
-        'value: {{ .Values.enterpriseSSO.displayName | default "Company SSO" | quote }}'
-        in deployment
-    )
+    assert "value: {{ .Values.enterpriseSSO.displayName | quote }}" in deployment
     assert "- name: ENTERPRISE_SSO_IDP_METADATA_URL" in deployment
     assert "value: {{ .Values.enterpriseSSO.idpMetadataUrl | quote }}" in deployment
     assert "{{ .Values.enterpriseSSO.displayName" not in script
@@ -467,7 +530,9 @@ def test_enterprise_sso_env_overrides_render_once_for_keycloak_init() -> None:
 def test_enterprise_sso_disable_path_reconciles_managed_provider() -> None:
     script = KEYCLOAK_CONFIG_SCRIPT.read_text(encoding="utf-8")
 
-    assert "else if .Values.enterpriseSSO.idpMetadataUrl" in script
+    assert '"openhandsManaged": "true"' in script
+    assert "else if .Values.enterpriseSSO.idpMetadataUrl" not in script
+    assert '.config.openhandsManaged == "true"' in script
     assert "jq '.enabled = false'" in script
     assert "Disabled managed identity provider: enterprise_sso" in script
 

--- a/scripts/test_keycloak_realm_template.py
+++ b/scripts/test_keycloak_realm_template.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
-
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 REALM_TEMPLATE = (
@@ -21,6 +23,9 @@ KEYCLOAK_CONFIG_SCRIPT = (
     REPO_ROOT / "charts" / "openhands" / "templates" / "keycloak-config-script.yaml"
 )
 OPENHANDS_CHART = REPO_ROOT / "charts" / "openhands"
+OPENHANDS_VALUES = OPENHANDS_CHART / "values.yaml"
+OPENHANDS_VALUES_SCHEMA = OPENHANDS_CHART / "values.schema.json"
+REPLICATED_CONFIG = REPO_ROOT / "replicated" / "config.yaml"
 REPLICATED_OPENHANDS = REPO_ROOT / "replicated" / "openhands.yaml"
 
 
@@ -132,9 +137,6 @@ def test_keycloak_config_script_applies_sso_session_lifetimes() -> None:
 
 def test_sso_session_jq_filter_rewrites_realm_lifetimes() -> None:
     """Run the script's actual jq filter against the realm template."""
-    import shutil
-    import subprocess
-
     if shutil.which("jq") is None:
         pytest.skip("jq not available")
 
@@ -203,8 +205,6 @@ def test_keycloak_config_script_includes_laminar_web_host_in_envsubst() -> None:
 
 
 def test_keycloak_identity_provider_socket_timeout() -> None:
-    import subprocess
-
     result = subprocess.run(
         [
             "helm",
@@ -236,3 +236,174 @@ def test_replicated_keycloak_identity_provider_socket_timeout() -> None:
         r"\s+value: [\"']15000[\"']",
         replicated_values,
     )
+
+
+def enterprise_sso_config_item() -> dict:
+    config = yaml.safe_load(REPLICATED_CONFIG.read_text(encoding="utf-8"))
+    group = next(
+        item
+        for item in config["spec"]["groups"]
+        if item.get("name") == "enterprise_sso_authentication"
+    )
+    return next(
+        item
+        for item in group["items"]
+        if item.get("name") == "enterprise_sso_idp_metadata_url"
+    )
+
+
+def enterprise_sso_idp_jq_filter(script_template: str) -> str:
+    match = re.search(
+        r'echo "\$IMPORT_RESPONSE" \| jq \\\n'
+        r'\s*--arg display "\$ENTERPRISE_SSO_DISPLAY_NAME" \\\n'
+        r"\s*'(?P<filter>\{.*?\})' > /tmp/idp-enterprise-sso\.json",
+        script_template,
+        re.DOTALL,
+    )
+    assert match, "Could not find the enterprise SSO identity provider jq filter"
+    return match.group("filter")
+
+
+def test_enterprise_sso_uses_one_canonical_values_key() -> None:
+    values = yaml.safe_load(OPENHANDS_VALUES.read_text(encoding="utf-8"))
+    schema = json.loads(OPENHANDS_VALUES_SCHEMA.read_text(encoding="utf-8"))
+    replicated = yaml.safe_load(REPLICATED_OPENHANDS.read_text(encoding="utf-8"))
+
+    assert "enterpriseSso" not in values
+    assert values["enterpriseSSO"] == {
+        "enabled": False,
+        "displayName": "",
+        "idpMetadataUrl": "",
+    }
+    assert "enterpriseSso" not in schema["properties"]
+    assert set(schema["properties"]["enterpriseSSO"]["properties"]) == {
+        "enabled",
+        "displayName",
+        "idpMetadataUrl",
+    }
+    assert "enterpriseSso" not in replicated["spec"]["values"]
+    assert "enterpriseSSO" in replicated["spec"]["values"]
+
+
+def test_enterprise_sso_metadata_url_requires_https() -> None:
+    schema = json.loads(OPENHANDS_VALUES_SCHEMA.read_text(encoding="utf-8"))
+    metadata_schema = schema["properties"]["enterpriseSSO"]["properties"][
+        "idpMetadataUrl"
+    ]
+    assert metadata_schema["pattern"] == "^$|^https://"
+
+    metadata_item = enterprise_sso_config_item()
+    validation = metadata_item["validation"]["regex"]
+    assert "https://" in validation["pattern"]
+    assert "HTTPS" in validation["message"]
+
+
+def test_enterprise_sso_uses_keycloak_import_contract() -> None:
+    script = KEYCLOAK_CONFIG_SCRIPT.read_text(encoding="utf-8")
+
+    assert re.search(
+        r'identity-provider/import-config".*?Content-Type: application/json',
+        script,
+        re.DOTALL,
+    )
+    assert "--data-urlencode" not in script
+    assert 'providerId: "saml"' in script
+    assert "fromUrl: $from_url" in script
+    assert 'has("idpEntityId")' in script
+    assert 'has("singleSignOnServiceUrl")' in script
+    assert ".config as $cfg" not in script
+    assert '"validateSignature": "true"' in script
+    assert "validateSignatures" not in script
+    assert 'syncMode: "FORCE"' in script
+
+
+def test_enterprise_sso_jq_filter_builds_keycloak_idp() -> None:
+    if shutil.which("jq") is None:
+        pytest.skip("jq not available")
+
+    script = KEYCLOAK_CONFIG_SCRIPT.read_text(encoding="utf-8")
+    jq_filter = enterprise_sso_idp_jq_filter(script)
+    imported_config = {
+        "idpEntityId": "https://idp.example.com/entity",
+        "singleSignOnServiceUrl": "https://idp.example.com/sso",
+        "signingCertificate": "certificate-data",
+    }
+    display_name = 'Company "Platform" $(touch /tmp/should-not-run)'
+
+    result = subprocess.run(
+        ["jq", "--arg", "display", display_name, jq_filter],
+        input=json.dumps(imported_config),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    identity_provider = json.loads(result.stdout)
+
+    assert identity_provider["alias"] == "enterprise_sso"
+    assert identity_provider["displayName"] == display_name
+    assert identity_provider["config"]["idpEntityId"] == imported_config["idpEntityId"]
+    assert identity_provider["config"]["validateSignature"] == "true"
+    assert identity_provider["config"]["syncMode"] == "IMPORT"
+
+
+def test_enterprise_sso_inputs_render_as_environment_data() -> None:
+    display_name = 'Company "Platform" $(touch /tmp/should-not-run)'
+    metadata_url = "https://idp.example.com/metadata?tenant=$(touch-never-runs)"
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "test",
+            str(OPENHANDS_CHART),
+            "--set",
+            "enabled=true",
+            "--set",
+            "keycloak.enabled=true",
+            "--set",
+            "enterpriseSSO.enabled=true",
+            "--set-string",
+            f"enterpriseSSO.displayName={display_name}",
+            "--set-string",
+            f"enterpriseSSO.idpMetadataUrl={metadata_url}",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    documents = [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+    deployment = next(
+        doc
+        for doc in documents
+        if doc.get("kind") == "Deployment" and doc["metadata"]["name"] == "openhands"
+    )
+    keycloak_config = next(
+        container
+        for container in deployment["spec"]["template"]["spec"]["initContainers"]
+        if container["name"] == "keycloak-config"
+    )
+    environment = {item["name"]: item.get("value") for item in keycloak_config["env"]}
+    config_map = next(
+        doc
+        for doc in documents
+        if doc.get("kind") == "ConfigMap"
+        and doc["metadata"]["name"] == "keycloak-config-script"
+    )
+    script = config_map["data"]["keycloak-config.sh"]
+
+    assert environment["ENTERPRISE_SSO_DISPLAY_NAME"] == display_name
+    assert environment["ENTERPRISE_SSO_IDP_METADATA_URL"] == metadata_url
+    assert json.loads(environment["OH_WEB_CLIENT_PROVIDERS_CONFIGURED"]) == [
+        "enterprise_sso"
+    ]
+    assert display_name not in script
+    assert metadata_url not in script
+    assert "$ENTERPRISE_SSO_DISPLAY_NAME" in script
+    assert "$ENTERPRISE_SSO_IDP_METADATA_URL" in script
+
+
+def test_enterprise_sso_disable_path_reconciles_managed_provider() -> None:
+    script = KEYCLOAK_CONFIG_SCRIPT.read_text(encoding="utf-8")
+
+    assert "else if .Values.enterpriseSSO.idpMetadataUrl" in script
+    assert "jq '.enabled = false'" in script
+    assert "Disabled managed identity provider: enterprise_sso" in script

--- a/scripts/test_keycloak_realm_template.py
+++ b/scripts/test_keycloak_realm_template.py
@@ -9,7 +9,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 REALM_TEMPLATE = (
@@ -238,20 +237,6 @@ def test_replicated_keycloak_identity_provider_socket_timeout() -> None:
     )
 
 
-def enterprise_sso_config_item() -> dict:
-    config = yaml.safe_load(REPLICATED_CONFIG.read_text(encoding="utf-8"))
-    group = next(
-        item
-        for item in config["spec"]["groups"]
-        if item.get("name") == "enterprise_sso_authentication"
-    )
-    return next(
-        item
-        for item in group["items"]
-        if item.get("name") == "enterprise_sso_idp_metadata_url"
-    )
-
-
 def enterprise_sso_idp_jq_filter(script_template: str) -> str:
     match = re.search(
         r'echo "\$IMPORT_RESPONSE" \| jq \\\n'
@@ -265,24 +250,24 @@ def enterprise_sso_idp_jq_filter(script_template: str) -> str:
 
 
 def test_enterprise_sso_uses_one_canonical_values_key() -> None:
-    values = yaml.safe_load(OPENHANDS_VALUES.read_text(encoding="utf-8"))
+    values = OPENHANDS_VALUES.read_text(encoding="utf-8")
     schema = json.loads(OPENHANDS_VALUES_SCHEMA.read_text(encoding="utf-8"))
-    replicated = yaml.safe_load(REPLICATED_OPENHANDS.read_text(encoding="utf-8"))
+    replicated = REPLICATED_OPENHANDS.read_text(encoding="utf-8")
 
-    assert "enterpriseSso" not in values
-    assert values["enterpriseSSO"] == {
-        "enabled": False,
-        "displayName": "",
-        "idpMetadataUrl": "",
-    }
+    assert "enterpriseSso:" not in values
+    assert re.search(
+        r"^enterpriseSSO:\n  enabled: false\n  displayName: \"\"\n  idpMetadataUrl: \"\"$",
+        values,
+        re.MULTILINE,
+    )
     assert "enterpriseSso" not in schema["properties"]
     assert set(schema["properties"]["enterpriseSSO"]["properties"]) == {
         "enabled",
         "displayName",
         "idpMetadataUrl",
     }
-    assert "enterpriseSso" not in replicated["spec"]["values"]
-    assert "enterpriseSSO" in replicated["spec"]["values"]
+    assert "enterpriseSso:" not in replicated
+    assert "    enterpriseSSO:" in replicated
 
 
 def test_enterprise_sso_metadata_url_requires_https() -> None:
@@ -292,10 +277,9 @@ def test_enterprise_sso_metadata_url_requires_https() -> None:
     ]
     assert metadata_schema["pattern"] == "^$|^https://"
 
-    metadata_item = enterprise_sso_config_item()
-    validation = metadata_item["validation"]["regex"]
-    assert "https://" in validation["pattern"]
-    assert "HTTPS" in validation["message"]
+    replicated_config = REPLICATED_CONFIG.read_text(encoding="utf-8")
+    assert "pattern: '^$|^https://[^[:space:]]+$'" in replicated_config
+    assert "message: 'Must be blank or an HTTPS metadata URL.'" in replicated_config
 
 
 def test_enterprise_sso_uses_keycloak_import_contract() -> None:
@@ -346,59 +330,29 @@ def test_enterprise_sso_jq_filter_builds_keycloak_idp() -> None:
     assert identity_provider["config"]["syncMode"] == "IMPORT"
 
 
-def test_enterprise_sso_inputs_render_as_environment_data() -> None:
-    display_name = 'Company "Platform" $(touch /tmp/should-not-run)'
-    metadata_url = "https://idp.example.com/metadata?tenant=$(touch-never-runs)"
-    result = subprocess.run(
-        [
-            "helm",
-            "template",
-            "test",
-            str(OPENHANDS_CHART),
-            "--set",
-            "enabled=true",
-            "--set",
-            "keycloak.enabled=true",
-            "--set",
-            "enterpriseSSO.enabled=true",
-            "--set-string",
-            f"enterpriseSSO.displayName={display_name}",
-            "--set-string",
-            f"enterpriseSSO.idpMetadataUrl={metadata_url}",
-        ],
-        capture_output=True,
-        text=True,
-        check=True,
+def test_enterprise_sso_inputs_are_environment_data() -> None:
+    deployment = (OPENHANDS_CHART / "templates" / "deployment.yaml").read_text(
+        encoding="utf-8"
     )
-    documents = [doc for doc in yaml.safe_load_all(result.stdout) if doc]
-    deployment = next(
-        doc
-        for doc in documents
-        if doc.get("kind") == "Deployment" and doc["metadata"]["name"] == "openhands"
-    )
-    keycloak_config = next(
-        container
-        for container in deployment["spec"]["template"]["spec"]["initContainers"]
-        if container["name"] == "keycloak-config"
-    )
-    environment = {item["name"]: item.get("value") for item in keycloak_config["env"]}
-    config_map = next(
-        doc
-        for doc in documents
-        if doc.get("kind") == "ConfigMap"
-        and doc["metadata"]["name"] == "keycloak-config-script"
-    )
-    script = config_map["data"]["keycloak-config.sh"]
+    script = KEYCLOAK_CONFIG_SCRIPT.read_text(encoding="utf-8")
+    replicated = REPLICATED_OPENHANDS.read_text(encoding="utf-8")
 
-    assert environment["ENTERPRISE_SSO_DISPLAY_NAME"] == display_name
-    assert environment["ENTERPRISE_SSO_IDP_METADATA_URL"] == metadata_url
-    assert json.loads(environment["OH_WEB_CLIENT_PROVIDERS_CONFIGURED"]) == [
-        "enterprise_sso"
-    ]
-    assert display_name not in script
-    assert metadata_url not in script
-    assert "$ENTERPRISE_SSO_DISPLAY_NAME" in script
-    assert "$ENTERPRISE_SSO_IDP_METADATA_URL" in script
+    assert "- name: ENTERPRISE_SSO_DISPLAY_NAME" in deployment
+    assert "value: {{ .Values.enterpriseSSO.displayName | quote }}" in deployment
+    assert "- name: ENTERPRISE_SSO_IDP_METADATA_URL" in deployment
+    assert "value: {{ .Values.enterpriseSSO.idpMetadataUrl | quote }}" in deployment
+    assert "{{ .Values.enterpriseSSO.displayName" not in script
+    assert "{{ .Values.enterpriseSSO.idpMetadataUrl" not in script
+    assert '--arg display "$ENTERPRISE_SSO_DISPLAY_NAME"' in script
+    assert '--arg from_url "$ENTERPRISE_SSO_IDP_METADATA_URL"' in script
+    assert (
+        'displayName: repl{{ ConfigOption "enterprise_sso_display_name" | mustToJson }}'
+        in replicated
+    )
+    assert (
+        'idpMetadataUrl: repl{{ ConfigOption "enterprise_sso_idp_metadata_url" | mustToJson }}'
+        in replicated
+    )
 
 
 def test_enterprise_sso_disable_path_reconciles_managed_provider() -> None:


### PR DESCRIPTION
## Description

Adds Replicated Admin Console configuration for Enterprise SSO (SAML) in VM deployments, including optional automatic provisioning of the `enterprise_sso` identity provider in the bundled Keycloak realm.

## What changed

- Adds installer fields for the Enterprise SSO toggle, display name, and HTTPS IdP metadata URL.
- Uses one canonical Helm values path, `enterpriseSSO`, for both login-provider advertising and Keycloak provisioning.
- Sends Keycloak 26.3 the required JSON `ImportConfig` request and consumes its flat configuration-map response.
- Upserts the SAML provider with `validateSignature=true`, trust-email, and the hardcoded `identity_provider=enterprise_sso:saml` mapper.
- Propagates transport, parsing, and API failures through the best-effort reconciliation wrapper instead of reporting false success.
- Preserves `.Values.env` precedence for Enterprise SSO init-container settings without duplicate environment entries.
- Documents the required manual Keycloak mapper in both Helm and Replicated guidance.
- Passes operator-controlled display names and metadata URLs as container environment data and encodes them with `jq`, rather than interpolating them into shell source.
- Validates metadata URLs as HTTPS and disables a chart-managed provider when the Enterprise SSO toggle is turned off.
- Preserves manual Keycloak management when `idpMetadataUrl` is blank.

Provisioning remains best-effort: invalid or unreachable metadata logs a warning without blocking OpenHands startup.

## Helm Chart Checklist

- [x] Defaults remain inert (`enabled: false`, empty metadata URL).
- [x] Manual setup remains available with a blank metadata URL and documents the required mapper contract.
- [x] The chart README documents the canonical values and managed disable behavior.
- [x] Schema and installer validation require HTTPS metadata URLs.

## Verification

- `473 passed` — repository script tests
- `117 passed` — Helm unit tests, including automatic, manual, disabled, and operator-override SSO modes
- Helm lint, Ruff, YAML parsing, and diff checks pass
- Rendered `keycloak-config.sh` passes `sh -n` and `bash -n` in automatic, manual, and disabled modes
- All 22 GitHub checks pass on `b53f613`

_This PR description was updated by an AI agent (OpenHands) on behalf of the user._