### PR TITLE
ci: auto-deploy Replicated releases to internal instances

### DIFF
--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -1,7 +1,9 @@
 name: Replicated deploy status
 
-# Visibility only, not a merge gate: reports whether the last Replicated deploy
-# on main succeeded, so a broken instance is visible before merging on top of it.
+# Visibility only, not a merge gate. Asserts the invariant behind the README
+# badges: whatever should have triggered a deploy actually got a run, and that
+# run succeeded. The "no run" case is what a badge cannot show -- GitHub renders
+# the last real conclusion forever, so a workflow that stopped firing stays green.
 #
 # To make it blocking, add the check context `last-deploy` to the `main` ruleset
 # under Settings -> Rules -> Rulesets. No change to this file needed.
@@ -15,35 +17,86 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
+      contents: read
     steps:
-      - name: Check the last deploy on main
+      # Repo idiom: release-replicated.yml installs yq the same way.
+      - name: Install yq
+        uses: mikefarah/yq@v4
+
+      - name: Assert both lanes deployed their newest trigger
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          RUN=$(gh api \
-            "repos/${REPO}/actions/workflows/release-replicated.yml/runs?branch=main&status=completed&per_page=1" \
-            --jq '.workflow_runs[0] | {id, conclusion, html_url, head_sha}')
-          if [ -z "$RUN" ] || [ "$RUN" = "null" ]; then
-            echo "No completed run to report on."
-            exit 0
-          fi
-          CONCLUSION=$(jq -r .conclusion <<<"$RUN")
-          URL=$(jq -r .html_url <<<"$RUN")
-          SHA=$(jq -r .head_sha <<<"$RUN")
-
+          FAILED=0
           {
-            echo "### Last Replicated deploy on \`main\`: ${CONCLUSION}"
+            echo "### Replicated deploy status"
             echo ""
-            echo "- Commit: \`${SHA:0:8}\`"
-            echo "- Run: ${URL}"
+            echo "| Lane | Trigger | State | Run |"
+            echo "| --- | --- | --- | --- |"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          [ "$CONCLUSION" = "success" ] && { echo "Last deploy on main succeeded."; exit 0; }
+          check() {   # <lane> <workflow file> <runs query> <trigger description>
+            local lane=$1 wf=$2 q=$3 trigger=$4 runs count run status conclusion url
+            runs=$(gh api "repos/${REPO}/actions/workflows/${wf}/runs?${q}")
+            count=$(jq -r .total_count <<<"$runs")
+            run=$(jq -c '.workflow_runs[0] // {}' <<<"$runs")
+            status=$(jq -r '.status // ""' <<<"$run")
+            conclusion=$(jq -r '.conclusion // ""' <<<"$run")
+            url=$(jq -r '.html_url // ""' <<<"$run")
 
-          # Name the failing job: "release" and "deploy" are different problems.
-          gh api "repos/${REPO}/actions/runs/$(jq -r .id <<<"$RUN")/jobs" \
-            --jq '.jobs[] | select(.conclusion != "success" and .conclusion != null) | "  failed job: \(.name) (\(.conclusion))"'
+            if [ "$count" = 0 ]; then
+              echo "| ${lane} | ${trigger} | **no run** | — |" >> "$GITHUB_STEP_SUMMARY"
+              echo "::error::${lane}: no run of ${wf} for ${trigger} — the workflow never fired"
+              FAILED=1; return
+            fi
+            echo "| ${lane} | ${trigger} | ${status}/${conclusion:-n/a} | ${url} |" >> "$GITHUB_STEP_SUMMARY"
+            [ "$status" != completed ] && { echo "${lane}: still ${status}"; return; }
+            [ "$conclusion" = success ] && { echo "${lane}: ok"; return; }
+            gh api "repos/${REPO}/actions/runs/$(jq -r .id <<<"$run")/jobs" \
+              --jq '.jobs[] | select(.conclusion != "success" and .conclusion != null) | "  failed job: \(.name) (\(.conclusion))"'
+            echo "::error::${lane}: ${conclusion} — ${url}"
+            FAILED=1
+          }
 
-          echo "::error::Last Replicated deploy on main did not succeed (${CONCLUSION}): ${URL}"
-          exit 1
+          # Read the trigger paths from release-replicated.yml on main -- that
+          # workflow is the single definition. Read via yq, not python/PyYAML:
+          # YAML 1.1 parses a bare `on:` key as the boolean True.
+          gh api "repos/${REPO}/contents/.github/workflows/release-replicated.yml?ref=main" \
+            -H "Accept: application/vnd.github.raw" > /tmp/release-replicated.yml
+          # `replicated/**` -> `replicated`: the commits API takes a path prefix,
+          # not a glob. A surviving `*` would silently match nothing.
+          PATHS=$(yq -r '.on.push.paths[]' /tmp/release-replicated.yml | sed -E 's#/\*+$##; s#^\./##')
+          [ -n "$PATHS" ] || { echo "::error::could not read on.push.paths from release-replicated.yml"; exit 1; }
+          case "$PATHS" in
+            *'*'*) echo "::error::unsupported glob in on.push.paths: $PATHS"; exit 1 ;;
+          esac
+          echo "trigger paths: $(echo $PATHS)"
+
+          NEWEST=$(for P in $PATHS; do
+            gh api "repos/${REPO}/commits?sha=main&path=${P}&per_page=1" \
+              --jq '.[0] | "\(.commit.committer.date)\t\(.sha)"' 2>/dev/null || true
+          done | sort -r | head -1)
+          U_SHA=${NEWEST##*$'\t'}
+          if [ -n "$U_SHA" ]; then
+            check unstable release-replicated.yml "branch=main&head_sha=${U_SHA}" "commit \`${U_SHA:0:8}\`"
+          else
+            echo "| unstable | no commit under $(echo $PATHS) | skipped | — |" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # Beta fires on the openhands/* tag release-please creates. Tag refs sort
+          # alphabetically (0.9.0 > 0.49.0), so anchor on the newest *release*
+          # instead, and match runs by branch -- tag runs carry the tag as
+          # head_branch.
+          # per_page=100: three sibling release lines (crd-check, image-loader,
+          # openhands-secrets) interleave here. `openhands/` includes the slash,
+          # so it cannot match openhands-secrets/.
+          B_TAG=$(gh api "repos/${REPO}/releases?per_page=100" \
+            --jq 'map(select(.tag_name | startswith("openhands/"))) | .[0].tag_name // empty')
+          if [ -n "$B_TAG" ]; then
+            check beta release-replicated-beta.yml "branch=${B_TAG}" "tag \`${B_TAG}\`"
+          else
+            echo "| beta | no openhands/* release | skipped | — |" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          exit "$FAILED"

--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -1,0 +1,49 @@
+name: Replicated deploy status
+
+# Visibility only, not a merge gate: reports whether the last Replicated deploy
+# on main succeeded, so a broken instance is visible before merging on top of it.
+#
+# To make it blocking, add the check context `last-deploy` to the `main` ruleset
+# under Settings -> Rules -> Rulesets. No change to this file needed.
+
+on:
+  pull_request:
+
+jobs:
+  last-deploy:
+    name: last-deploy
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Check the last deploy on main
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          RUN=$(gh api \
+            "repos/${REPO}/actions/workflows/release-replicated.yml/runs?branch=main&status=completed&per_page=1" \
+            --jq '.workflow_runs[0] | {id, conclusion, html_url, head_sha}')
+          if [ -z "$RUN" ] || [ "$RUN" = "null" ]; then
+            echo "No completed run to report on."
+            exit 0
+          fi
+          CONCLUSION=$(jq -r .conclusion <<<"$RUN")
+          URL=$(jq -r .html_url <<<"$RUN")
+          SHA=$(jq -r .head_sha <<<"$RUN")
+
+          {
+            echo "### Last Replicated deploy on \`main\`: ${CONCLUSION}"
+            echo ""
+            echo "- Commit: \`${SHA:0:8}\`"
+            echo "- Run: ${URL}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          [ "$CONCLUSION" = "success" ] && { echo "Last deploy on main succeeded."; exit 0; }
+
+          # Name the failing job: "release" and "deploy" are different problems.
+          gh api "repos/${REPO}/actions/runs/$(jq -r .id <<<"$RUN")/jobs" \
+            --jq '.jobs[] | select(.conclusion != "success" and .conclusion != null) | "  failed job: \(.name) (\(.conclusion))"'
+
+          echo "::error::Last Replicated deploy on main did not succeed (${CONCLUSION}): ${URL}"
+          exit 1

--- a/.github/workflows/deploy-replicated.yml
+++ b/.github/workflows/deploy-replicated.yml
@@ -1,0 +1,76 @@
+name: Deploy Replicated
+
+# Deploys one release to the internal instance tracking that channel, by driving
+# the KOTS upgrade-service API (scripts/replicated_deploy.sh). Embedded Cluster
+# has no supported auto-update, so there is no lighter mechanism.
+#
+# Called as a `needs:` job rather than via workflow_run: the deploy must be
+# pinned to the release the caller built, and a failure has to turn that run red.
+
+on:
+  workflow_call:
+    inputs:
+      instance:
+        description: "Instance to deploy to (unstable | beta | stable)"
+        type: string
+        required: true
+      kots_cursor:
+        description: "KOTS updateCursor (= Replicated channelSequence) to deploy"
+        type: string
+        required: true
+    secrets:
+      kots_password:
+        required: true
+  workflow_dispatch:
+    inputs:
+      instance:
+        description: "Instance to deploy to"
+        type: choice
+        options: [unstable, beta, stable]
+        required: true
+      kots_cursor:
+        description: "KOTS updateCursor (= Replicated channelSequence) to deploy"
+        type: string
+        required: true
+
+# One run pending per instance; GitHub cancels older pending runs, so
+# intermediate releases are skipped and the newest still lands.
+concurrency:
+  group: replicated-deploy-${{ inputs.instance }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to ${{ inputs.instance }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy
+        env:
+          # Public external IP + firewall rule on tcp:30000, so no tunnel or
+          # GCP credential is needed.
+          KOTS_BASE: https://admin.${{ inputs.instance }}.staging.all-hands-testing.dev:30000
+          # workflow_dispatch has no passed-in secret, so fall back to the repo one.
+          KOTS_PASSWORD: ${{ secrets.kots_password || secrets[format('KOTS_PASSWORD_{0}', inputs.instance)] }}
+          KOTS_CURSOR: ${{ inputs.kots_cursor }}
+        run: scripts/replicated_deploy.sh
+
+      - name: Summary
+        if: always()
+        env:
+          INSTANCE: ${{ inputs.instance }}
+          CURSOR: ${{ inputs.kots_cursor }}
+          RESULT: ${{ job.status }}
+        run: |
+          {
+            echo "### Replicated deploy: \`${INSTANCE}\` — ${RESULT}"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Instance | ${INSTANCE} |"
+            echo "| KOTS cursor | ${CURSOR} |"
+            echo "| Admin console | https://admin.${INSTANCE}.staging.all-hands-testing.dev:30000 |"
+            echo "| App | https://app.${INSTANCE}.staging.all-hands-testing.dev |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-replicated.yml
+++ b/.github/workflows/deploy-replicated.yml
@@ -18,6 +18,11 @@ on:
         description: "KOTS updateCursor (= Replicated channelSequence) to deploy"
         type: string
         required: true
+      timeout_minutes:
+        description: "Whole-deploy budget in minutes (script fails at this; job is killed 5m later)"
+        type: string
+        required: false
+        default: "25"
     secrets:
       kots_password:
         required: true
@@ -32,6 +37,11 @@ on:
         description: "KOTS updateCursor (= Replicated channelSequence) to deploy"
         type: string
         required: true
+      timeout_minutes:
+        description: "Whole-deploy budget in minutes (script fails at this; job is killed 5m later)"
+        type: string
+        required: false
+        default: "25"
 
 # One run pending per instance; GitHub cancels older pending runs, so
 # intermediate releases are skipped and the newest still lands.
@@ -43,7 +53,8 @@ jobs:
   deploy:
     name: Deploy to ${{ inputs.instance }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # +5 so the script's own timeout error lands before the runner kills the job.
+    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) + 5 }}
     steps:
       - uses: actions/checkout@v4
 
@@ -55,6 +66,7 @@ jobs:
           # workflow_dispatch has no passed-in secret, so fall back to the repo one.
           KOTS_PASSWORD: ${{ secrets.kots_password || secrets[format('KOTS_PASSWORD_{0}', inputs.instance)] }}
           KOTS_CURSOR: ${{ inputs.kots_cursor }}
+          TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
         run: scripts/replicated_deploy.sh
 
       - name: Summary

--- a/.github/workflows/release-replicated-beta.yml
+++ b/.github/workflows/release-replicated-beta.yml
@@ -148,14 +148,19 @@ jobs:
           SEQUENCE: ${{ steps.release.outputs.sequence }}
         run: |
           # KOTS selects by channelSequence (404); the CLI's `sequence` is the
-          # app-level release sequence (1451). Join them to pin this build.
+          # app-level release sequence (1451). Join them to pin the deploy to
+          # this build -- a channel can gain releases while one is deploying.
+          # Channel comes from the Makefile, which derives it from the branch:
+          # a dispatch on a feature branch publishes to that branch's channel,
+          # not Beta.
           # Newest first, paginated; the release just created is on page 0.
-          CURSOR=$(replicated channel releases Beta --app "$REPLICATED_APP" --output json --page 0 --page-size 20 \
+          CHANNEL=$(make -s print-channel CHANNEL=Beta)
+          CURSOR=$(replicated channel releases "$CHANNEL" --app "$REPLICATED_APP" --output json --page 0 --page-size 20 \
             | jq -r --argjson rs "$SEQUENCE" \
                 'map(select(.sequence == $rs)) | max_by(.channelSequence) | .channelSequence // empty')
-          [ -n "$CURSOR" ] || { echo "::error::no channelSequence on Beta for release $SEQUENCE"; exit 1; }
+          [ -n "$CURSOR" ] || { echo "::error::no channelSequence on $CHANNEL for release $SEQUENCE"; exit 1; }
           echo "kots_cursor=${CURSOR}" >> "$GITHUB_OUTPUT"
-          echo "release ${SEQUENCE} is channelSequence ${CURSOR} on Beta"
+          echo "release ${SEQUENCE} is channelSequence ${CURSOR} on $CHANNEL"
 
   deploy:
     needs: beta

--- a/.github/workflows/release-replicated-beta.yml
+++ b/.github/workflows/release-replicated-beta.yml
@@ -37,6 +37,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+    outputs:
+      kots_cursor: ${{ steps.cursor.outputs.kots_cursor }}
     steps:
       - name: Resolve release tag
         id: tag
@@ -137,3 +139,29 @@ jobs:
             -m "${RELEASE_URL}"
           git push origin "${TAG}"
           echo "Tagged ${GITHUB_SHA} as ${TAG}"
+
+      - name: Resolve the KOTS cursor for this release
+        id: cursor
+        env:
+          REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
+          REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
+          SEQUENCE: ${{ steps.release.outputs.sequence }}
+        run: |
+          # KOTS selects updates by channelSequence; the CLI prints the app-level
+          # releaseSequence. Join them to pin the deploy to this build.
+          CURSOR=$(replicated channel releases Beta --app "$REPLICATED_APP" --output json \
+            | jq -r --argjson rs "$SEQUENCE" \
+                'map(select(.releaseSequence == $rs)) | max_by(.channelSequence) | .channelSequence // empty')
+          [ -n "$CURSOR" ] || { echo "::error::no channelSequence on Beta for release $SEQUENCE"; exit 1; }
+          echo "kots_cursor=${CURSOR}" >> "$GITHUB_OUTPUT"
+          echo "release ${SEQUENCE} is channelSequence ${CURSOR} on Beta"
+
+  deploy:
+    needs: beta
+    if: needs.beta.outputs.kots_cursor != ''
+    uses: ./.github/workflows/deploy-replicated.yml
+    with:
+      instance: beta
+      kots_cursor: ${{ needs.beta.outputs.kots_cursor }}
+    secrets:
+      kots_password: ${{ secrets.KOTS_PASSWORD_BETA }}

--- a/.github/workflows/release-replicated-beta.yml
+++ b/.github/workflows/release-replicated-beta.yml
@@ -147,11 +147,12 @@ jobs:
           REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
           SEQUENCE: ${{ steps.release.outputs.sequence }}
         run: |
-          # KOTS selects updates by channelSequence; the CLI prints the app-level
-          # releaseSequence. Join them to pin the deploy to this build.
-          CURSOR=$(replicated channel releases Beta --app "$REPLICATED_APP" --output json \
+          # KOTS selects by channelSequence (404); the CLI's `sequence` is the
+          # app-level release sequence (1451). Join them to pin this build.
+          # Newest first, paginated; the release just created is on page 0.
+          CURSOR=$(replicated channel releases Beta --app "$REPLICATED_APP" --output json --page 0 --page-size 20 \
             | jq -r --argjson rs "$SEQUENCE" \
-                'map(select(.releaseSequence == $rs)) | max_by(.channelSequence) | .channelSequence // empty')
+                'map(select(.sequence == $rs)) | max_by(.channelSequence) | .channelSequence // empty')
           [ -n "$CURSOR" ] || { echo "::error::no channelSequence on Beta for release $SEQUENCE"; exit 1; }
           echo "kots_cursor=${CURSOR}" >> "$GITHUB_OUTPUT"
           echo "release ${SEQUENCE} is channelSequence ${CURSOR} on Beta"

--- a/.github/workflows/release-replicated.yml
+++ b/.github/workflows/release-replicated.yml
@@ -84,15 +84,19 @@ jobs:
         run: |
           # KOTS selects by channelSequence (404); the CLI's `sequence` is the
           # app-level release sequence (1451). Join them to pin the deploy to
-          # this build -- Unstable publishes on every push, so "newest" races.
+          # this build -- a channel can gain releases while one is deploying.
+          # Channel comes from the Makefile, which derives it from the branch:
+          # a dispatch on a feature branch publishes to that branch's channel,
+          # not Unstable.
           [ -n "$SEQUENCE" ] || { echo "::error::no release sequence to pin the deploy to"; exit 1; }
           # Newest first, paginated; the release just created is on page 0.
-          CURSOR=$(replicated channel releases Unstable --app "$REPLICATED_APP" --output json --page 0 --page-size 20 \
+          CHANNEL=$(make -s print-channel)
+          CURSOR=$(replicated channel releases "$CHANNEL" --app "$REPLICATED_APP" --output json --page 0 --page-size 20 \
             | jq -r --argjson rs "$SEQUENCE" \
                 'map(select(.sequence == $rs)) | max_by(.channelSequence) | .channelSequence // empty')
-          [ -n "$CURSOR" ] || { echo "::error::no channelSequence on Unstable for release $SEQUENCE"; exit 1; }
+          [ -n "$CURSOR" ] || { echo "::error::no channelSequence on $CHANNEL for release $SEQUENCE"; exit 1; }
           echo "kots_cursor=${CURSOR}" >> "$GITHUB_OUTPUT"
-          echo "release ${SEQUENCE} is channelSequence ${CURSOR} on Unstable"
+          echo "release ${SEQUENCE} is channelSequence ${CURSOR} on $CHANNEL"
 
   deploy:
     needs: release

--- a/.github/workflows/release-replicated.yml
+++ b/.github/workflows/release-replicated.yml
@@ -82,13 +82,14 @@ jobs:
           REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
           SEQUENCE: ${{ steps.release.outputs.sequence }}
         run: |
-          # KOTS selects updates by channelSequence; the CLI prints the app-level
-          # releaseSequence. Join them so the deploy is pinned to this build --
-          # Unstable publishes on every push to main, so "newest" races.
+          # KOTS selects by channelSequence (404); the CLI's `sequence` is the
+          # app-level release sequence (1451). Join them to pin the deploy to
+          # this build -- Unstable publishes on every push, so "newest" races.
           [ -n "$SEQUENCE" ] || { echo "::error::no release sequence to pin the deploy to"; exit 1; }
-          CURSOR=$(replicated channel releases Unstable --app "$REPLICATED_APP" --output json \
+          # Newest first, paginated; the release just created is on page 0.
+          CURSOR=$(replicated channel releases Unstable --app "$REPLICATED_APP" --output json --page 0 --page-size 20 \
             | jq -r --argjson rs "$SEQUENCE" \
-                'map(select(.releaseSequence == $rs)) | max_by(.channelSequence) | .channelSequence // empty')
+                'map(select(.sequence == $rs)) | max_by(.channelSequence) | .channelSequence // empty')
           [ -n "$CURSOR" ] || { echo "::error::no channelSequence on Unstable for release $SEQUENCE"; exit 1; }
           echo "kots_cursor=${CURSOR}" >> "$GITHUB_OUTPUT"
           echo "release ${SEQUENCE} is channelSequence ${CURSOR} on Unstable"

--- a/.github/workflows/release-replicated.yml
+++ b/.github/workflows/release-replicated.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      kots_cursor: ${{ steps.cursor.outputs.kots_cursor }}
 
     steps:
       - name: Checkout
@@ -72,3 +74,31 @@ jobs:
             echo "| Sequence | ${SEQUENCE} |"
             echo "| Vendor portal | [Release ${SEQUENCE} overview](${URL}) |"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Resolve the KOTS cursor for this release
+        id: cursor
+        env:
+          REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
+          REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
+          SEQUENCE: ${{ steps.release.outputs.sequence }}
+        run: |
+          # KOTS selects updates by channelSequence; the CLI prints the app-level
+          # releaseSequence. Join them so the deploy is pinned to this build --
+          # Unstable publishes on every push to main, so "newest" races.
+          [ -n "$SEQUENCE" ] || { echo "::error::no release sequence to pin the deploy to"; exit 1; }
+          CURSOR=$(replicated channel releases Unstable --app "$REPLICATED_APP" --output json \
+            | jq -r --argjson rs "$SEQUENCE" \
+                'map(select(.releaseSequence == $rs)) | max_by(.channelSequence) | .channelSequence // empty')
+          [ -n "$CURSOR" ] || { echo "::error::no channelSequence on Unstable for release $SEQUENCE"; exit 1; }
+          echo "kots_cursor=${CURSOR}" >> "$GITHUB_OUTPUT"
+          echo "release ${SEQUENCE} is channelSequence ${CURSOR} on Unstable"
+
+  deploy:
+    needs: release
+    if: needs.release.outputs.kots_cursor != ''
+    uses: ./.github/workflows/deploy-replicated.yml
+    with:
+      instance: unstable
+      kots_cursor: ${{ needs.release.outputs.kots_cursor }}
+    secrets:
+      kots_password: ${{ secrets.KOTS_PASSWORD_UNSTABLE }}

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,12 @@ check-release-guard:
 		exit 1; \
 	fi
 
+# Echo the channel `release` publishes to, so CI can pin a deploy to it without
+# re-deriving the branch mapping.
+.PHONY: print-channel
+print-channel:
+	@echo $(CHANNEL)
+
 # Build everything, lint, then publish a release to the Replicated channel
 .PHONY: release
 release: check-release-guard clean $(RELEASE_FILES) check-duplicate-chart-entries lint

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # OpenHands Cloud
+
+[![Unstable deploy](https://github.com/OpenHands/OpenHands-Cloud/actions/workflows/release-replicated.yml/badge.svg?branch=main)](https://github.com/OpenHands/OpenHands-Cloud/actions/workflows/release-replicated.yml)
+[![Beta deploy](https://github.com/OpenHands/OpenHands-Cloud/actions/workflows/release-replicated-beta.yml/badge.svg)](https://github.com/OpenHands/OpenHands-Cloud/actions/workflows/release-replicated-beta.yml)
+
 > [!WARNING]
 > This software is licensed under the [Polyform Free Trial License](./LICENSE). This is **NOT** an open source license. Usage is limited to 30 days per calendar year without a commercial license. If you would like to use it beyond 30 days, please [contact us](https://www.all-hands.dev/contact).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenHands Cloud
 
-[![Unstable deploy](https://github.com/OpenHands/OpenHands-Cloud/actions/workflows/release-replicated.yml/badge.svg?branch=main)](https://github.com/OpenHands/OpenHands-Cloud/actions/workflows/release-replicated.yml)
-[![Beta deploy](https://github.com/OpenHands/OpenHands-Cloud/actions/workflows/release-replicated-beta.yml/badge.svg)](https://github.com/OpenHands/OpenHands-Cloud/actions/workflows/release-replicated-beta.yml)
+[![Replicated Unstable deploy](https://github.com/OpenHands/OpenHands-Cloud/actions/workflows/release-replicated.yml/badge.svg?branch=main)](https://github.com/OpenHands/OpenHands-Cloud/actions/workflows/release-replicated.yml)
+[![Replicated Beta deploy](https://github.com/OpenHands/OpenHands-Cloud/actions/workflows/release-replicated-beta.yml/badge.svg)](https://github.com/OpenHands/OpenHands-Cloud/actions/workflows/release-replicated-beta.yml)
 
 > [!WARNING]
 > This software is licensed under the [Polyform Free Trial License](./LICENSE). This is **NOT** an open source license. Usage is limited to 30 days per calendar year without a commercial license. If you would like to use it beyond 30 days, please [contact us](https://www.all-hands.dev/contact).

--- a/scripts/replicated_deploy.sh
+++ b/scripts/replicated_deploy.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
-# Deploy one KOTS release to a Replicated Embedded Cluster instance via the
-# admin console's upgrade-service API.
+# Deploy one KOTS release to a Replicated Embedded Cluster instance.
 #
 #   KOTS_BASE=https://admin.unstable.staging.all-hands-testing.dev:30000 \
 #   KOTS_PASSWORD=... KOTS_CURSOR=418 scripts/replicated_deploy.sh
-#
-# Thin on purpose: EC v3 replaces this with `openhands upgrade --headless`.
-# No retries, no recovery — it works or it fails loudly.
 set -euo pipefail
 
 APP="${APP:-openhands}"
@@ -26,8 +22,7 @@ CODE="$(curl -sS -k -c "$JAR" -o /dev/null -w '%{http_code}' --max-time 30 \
 [ "$CODE" = 200 ] || fail "login to $KOTS_BASE returned HTTP $CODE"
 
 # --- select --------------------------------------------------------------
-# KOTS_CURSOR is the channel sequence. versionLabel is not unique: it comes
-# from Chart.yaml, which Unstable republishes on every push to main.
+# KOTS_CURSOR is the channel sequence; versionLabel is not unique.
 TMO=180 post -d '{}' "$KOTS_BASE/api/v1/app/$APP/updatecheck" >/dev/null
 TARGET="$(api "$KOTS_BASE/api/v1/app/$APP/updates" \
   | jq -c --arg c "$KOTS_CURSOR" '.updates[] | select(.updateCursor == $c)')"
@@ -78,14 +73,16 @@ TMO=120 post -d '{"isSkipPreflights":false,"continueWithFailedPreflights":false}
   || fail "deploy rejected"
 
 # The task stays empty for the whole deploy; downstream currentVersion is the
-# only progress signal. kotsadm restarts on an EC version bump, so an
-# unreachable console means keep waiting.
+# only progress signal. An unreachable console means kotsadm is restarting.
 for _ in $(seq 1 240); do
   [ "$(TMO=10 api "$KOTS_BASE/api/v1/app/$APP/task/upgrade-service" 2>/dev/null | jq -r '.status // ""')" = upgrade-failed ] \
     && fail "upgrade-failed"
   CUR="$(TMO=10 api "$KOTS_BASE/api/v1/apps" 2>/dev/null | jq -c '.apps[0].downstream.currentVersion | {updateCursor, sequence, status}' || true)"
   echo "  ${CUR:-<console unreachable, waiting>}"
-  [ "$(jq -r '"\(.updateCursor) \(.status)"' <<<"${CUR:-\{\}}" 2>/dev/null)" = "$KOTS_CURSOR deployed" ] && DONE=1 && break
+  case "$(jq -r '"\(.updateCursor) \(.status)"' <<<"${CUR:-\{\}}" 2>/dev/null)" in
+    "$KOTS_CURSOR deployed") DONE=1; break ;;
+    "$KOTS_CURSOR failed")   fail "instance reported the deploy failed — see the admin console version history" ;;
+  esac
   sleep 10
 done
 [ "${DONE:-}" ] || fail "timed out waiting for cursor $KOTS_CURSOR to deploy"

--- a/scripts/replicated_deploy.sh
+++ b/scripts/replicated_deploy.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Deploy one KOTS release to a Replicated Embedded Cluster instance via the
+# admin console's upgrade-service API.
+#
+#   KOTS_BASE=https://admin.unstable.staging.all-hands-testing.dev:30000 \
+#   KOTS_PASSWORD=... KOTS_CURSOR=418 scripts/replicated_deploy.sh
+#
+# Thin on purpose: EC v3 replaces this with `openhands upgrade --headless`.
+# No retries, no recovery — it works or it fails loudly.
+set -euo pipefail
+
+APP="${APP:-openhands}"
+: "${KOTS_BASE:?}" "${KOTS_PASSWORD:?}" "${KOTS_CURSOR:?}"
+UP="$KOTS_BASE/api/v1/upgrade-service/app/$APP"
+JAR="$(mktemp)"; trap 'rm -f "$JAR"' EXIT
+
+fail() { echo "::error::$*"; exit 1; }
+api()  { curl -sS -k --max-time "${TMO:-30}" -b "$JAR" -c "$JAR" "$@"; }
+post() { api -H 'Content-Type: application/json' -X POST "$@"; }
+ok()   { jq -e '.success == true' >/dev/null 2>&1; }
+
+# A 401 still sets a cookie, so a non-empty jar proves nothing.
+CODE="$(curl -sS -k -c "$JAR" -o /dev/null -w '%{http_code}' --max-time 30 \
+  -X POST "$KOTS_BASE/api/v1/login" -H 'Content-Type: application/json' \
+  --data "$(jq -nc --arg p "$KOTS_PASSWORD" '{password:$p}')")"
+[ "$CODE" = 200 ] || fail "login to $KOTS_BASE returned HTTP $CODE"
+
+# --- select --------------------------------------------------------------
+# KOTS_CURSOR is the channel sequence. versionLabel is not unique: it comes
+# from Chart.yaml, which Unstable republishes on every push to main.
+TMO=180 post -d '{}' "$KOTS_BASE/api/v1/app/$APP/updatecheck" >/dev/null
+TARGET="$(api "$KOTS_BASE/api/v1/app/$APP/updates" \
+  | jq -c --arg c "$KOTS_CURSOR" '.updates[] | select(.updateCursor == $c)')"
+[ -n "$TARGET" ] || fail "cursor $KOTS_CURSOR is not an available update for $APP"
+[ "$(jq -r .isDeployable <<<"$TARGET")" = true ] \
+  || fail "cursor $KOTS_CURSOR not deployable: $(jq -r '.nonDeployableCause // "unknown"' <<<"$TARGET")"
+
+FROM="$(api "$KOTS_BASE/api/v1/apps" | jq -r '.apps[0].downstream.currentVersion | "\(.versionLabel) @ \(.updateCursor)"')"
+echo "deploying: $FROM -> $(jq -r .versionLabel <<<"$TARGET") @ $KOTS_CURSOR"
+
+# --- boot the upgrade service -------------------------------------------
+post --data "$(jq -c '{versionLabel, updateCursor, channelId}' <<<"$TARGET")" \
+  "$KOTS_BASE/api/v1/app/$APP/start-upgrade-service" | ok \
+  || fail "start-upgrade-service rejected"
+
+# Task goes "starting" then EMPTY once up. Empty means ready, not pending.
+for _ in $(seq 1 60); do
+  [ "$(TMO=10 api "$KOTS_BASE/api/v1/app/$APP/task/upgrade-service" | jq -r '.status // ""')" = upgrade-failed ] \
+    && fail "upgrade service failed to start"
+  META="$(TMO=10 api "$UP" || true)"; ok <<<"$META" && break
+  META=""; sleep 5
+done
+[ -n "$META" ] || fail "upgrade service never came up"
+
+# --- config: read values, write them straight back -----------------------
+if [ "$(jq -r .isConfigurable <<<"$META")" = true ]; then
+  TMO=60 api "$UP/config" | jq -c '{configGroups}' >/tmp/cfg.json
+  TMO=60 api -H 'Content-Type: application/json' -X PUT --data-binary @/tmp/cfg.json "$UP/config" | ok \
+    || fail "config rejected — new release likely added a required item with no default"
+fi
+
+# --- preflights ----------------------------------------------------------
+if [ "$(jq -r .hasPreflight <<<"$META")" = true ]; then
+  TMO=60 post "$UP/preflight/run" >/dev/null
+  for _ in $(seq 1 60); do
+    R="$(api "$UP/preflight/result")"
+    # .preflightResult.result is a JSON string, null until the run finishes.
+    jq -e '.preflightResult.result' <<<"$R" >/dev/null 2>&1 && break
+    sleep 5
+  done
+  BAD="$(jq -r .preflightResult.result <<<"$R" | jq -c '[.results[] | select(.isPass != true)]')"
+  [ "$(jq -r .preflightResult.hasFailingStrictPreflights <<<"$R")" = true ] && fail "preflights failed: $BAD"
+  echo "preflights ok (non-passing: $BAD)"
+fi
+
+# --- deploy --------------------------------------------------------------
+TMO=120 post -d '{"isSkipPreflights":false,"continueWithFailedPreflights":false}' "$UP/deploy" | ok \
+  || fail "deploy rejected"
+
+# The task stays empty for the whole deploy; downstream currentVersion is the
+# only progress signal. kotsadm restarts on an EC version bump, so an
+# unreachable console means keep waiting.
+for _ in $(seq 1 240); do
+  [ "$(TMO=10 api "$KOTS_BASE/api/v1/app/$APP/task/upgrade-service" 2>/dev/null | jq -r '.status // ""')" = upgrade-failed ] \
+    && fail "upgrade-failed"
+  CUR="$(TMO=10 api "$KOTS_BASE/api/v1/apps" 2>/dev/null | jq -c '.apps[0].downstream.currentVersion | {updateCursor, sequence, status}' || true)"
+  echo "  ${CUR:-<console unreachable, waiting>}"
+  [ "$(jq -r '"\(.updateCursor) \(.status)"' <<<"${CUR:-\{\}}" 2>/dev/null)" = "$KOTS_CURSOR deployed" ] && DONE=1 && break
+  sleep 10
+done
+[ "${DONE:-}" ] || fail "timed out waiting for cursor $KOTS_CURSOR to deploy"
+
+# --- verify every statusInformer ----------------------------------------
+# Response key is "appstatus", all lowercase.
+for _ in $(seq 1 60); do
+  S="$(TMO=15 api "$KOTS_BASE/api/v1/app/$APP/status" 2>/dev/null || true)"
+  [ "$(jq -r '.appstatus.state // ""' <<<"${S:-\{\}}")" = ready ] && break
+  sleep 10
+done
+jq -c '.appstatus | {state, sequence, unhealthy: [.resourceStates[] | select(.state != "ready")]}' <<<"$S"
+[ "$(jq -r .appstatus.state <<<"$S")" = ready ] \
+  || fail "deployed but unhealthy: $(jq -c '[.appstatus.resourceStates[] | select(.state != "ready")]' <<<"$S")"
+echo "deployed cursor $KOTS_CURSOR, app ready"

--- a/scripts/replicated_deploy.sh
+++ b/scripts/replicated_deploy.sh
@@ -7,6 +7,11 @@ set -euo pipefail
 
 APP="${APP:-openhands}"
 : "${KOTS_BASE:?}" "${KOTS_PASSWORD:?}" "${KOTS_CURSOR:?}"
+# Whole-run budget in minutes; every wait loop below shares this one deadline.
+TIMEOUT_MINUTES="${TIMEOUT_MINUTES:-25}"
+DEADLINE=$(( $(date +%s) + TIMEOUT_MINUTES * 60 ))
+waiting() { [ "$(date +%s)" -lt "$DEADLINE" ]; }
+
 UP="$KOTS_BASE/api/v1/upgrade-service/app/$APP"
 JAR="$(mktemp)"; trap 'rm -f "$JAR"' EXIT
 
@@ -31,6 +36,7 @@ TARGET="$(api "$KOTS_BASE/api/v1/app/$APP/updates" \
   || fail "cursor $KOTS_CURSOR not deployable: $(jq -r '.nonDeployableCause // "unknown"' <<<"$TARGET")"
 
 FROM="$(api "$KOTS_BASE/api/v1/apps" | jq -r '.apps[0].downstream.currentVersion | "\(.versionLabel) @ \(.updateCursor)"')"
+echo "budget: ${TIMEOUT_MINUTES}m"
 echo "deploying: $FROM -> $(jq -r .versionLabel <<<"$TARGET") @ $KOTS_CURSOR"
 
 # --- boot the upgrade service -------------------------------------------
@@ -39,7 +45,8 @@ post --data "$(jq -c '{versionLabel, updateCursor, channelId}' <<<"$TARGET")" \
   || fail "start-upgrade-service rejected"
 
 # Task goes "starting" then EMPTY once up. Empty means ready, not pending.
-for _ in $(seq 1 60); do
+META=""
+while waiting; do
   [ "$(TMO=10 api "$KOTS_BASE/api/v1/app/$APP/task/upgrade-service" | jq -r '.status // ""')" = upgrade-failed ] \
     && fail "upgrade service failed to start"
   META="$(TMO=10 api "$UP" || true)"; ok <<<"$META" && break
@@ -57,12 +64,14 @@ fi
 # --- preflights ----------------------------------------------------------
 if [ "$(jq -r .hasPreflight <<<"$META")" = true ]; then
   TMO=60 post "$UP/preflight/run" >/dev/null
-  for _ in $(seq 1 60); do
+  R=""
+  while waiting; do
     R="$(api "$UP/preflight/result")"
     # .preflightResult.result is a JSON string, null until the run finishes.
     jq -e '.preflightResult.result' <<<"$R" >/dev/null 2>&1 && break
-    sleep 5
+    R=""; sleep 5
   done
+  [ -n "$R" ] || fail "timed out waiting for preflight results"
   BAD="$(jq -r .preflightResult.result <<<"$R" | jq -c '[.results[] | select(.isPass != true)]')"
   [ "$(jq -r .preflightResult.hasFailingStrictPreflights <<<"$R")" = true ] && fail "preflights failed: $BAD"
   echo "preflights ok (non-passing: $BAD)"
@@ -74,7 +83,7 @@ TMO=120 post -d '{"isSkipPreflights":false,"continueWithFailedPreflights":false}
 
 # The task stays empty for the whole deploy; downstream currentVersion is the
 # only progress signal. An unreachable console means kotsadm is restarting.
-for _ in $(seq 1 240); do
+while waiting; do
   [ "$(TMO=10 api "$KOTS_BASE/api/v1/app/$APP/task/upgrade-service" 2>/dev/null | jq -r '.status // ""')" = upgrade-failed ] \
     && fail "upgrade-failed"
   CUR="$(TMO=10 api "$KOTS_BASE/api/v1/apps" 2>/dev/null | jq -c '.apps[0].downstream.currentVersion | {updateCursor, sequence, status}' || true)"
@@ -89,11 +98,13 @@ done
 
 # --- verify every statusInformer ----------------------------------------
 # Response key is "appstatus", all lowercase.
-for _ in $(seq 1 60); do
+S=""
+while waiting; do
   S="$(TMO=15 api "$KOTS_BASE/api/v1/app/$APP/status" 2>/dev/null || true)"
   [ "$(jq -r '.appstatus.state // ""' <<<"${S:-\{\}}")" = ready ] && break
   sleep 10
 done
+[ -n "$S" ] || fail "timed out waiting for the app to report ready"
 jq -c '.appstatus | {state, sequence, unhealthy: [.resourceStates[] | select(.state != "ready")]}' <<<"$S"
 [ "$(jq -r .appstatus.state <<<"$S")" = ready ] \
   || fail "deployed but unhealthy: $(jq -c '[.appstatus.resourceStates[] | select(.state != "ready")]' <<<"$S")"


### PR DESCRIPTION
## Description

Embedded Cluster has no supported auto-update path on V2 so we have to handroll it with KOTS (the underlying k8s admin layer)

This wires the deploy into the release workflows and reports it. When a release publishes, the instance tracking that channel gets it, and a failure turns the release run red.

The deploy drives the same upgrade-service API the admin console's own wizard uses. It is undocumented (😢 ), so every call below was verified by hand against `replicated-unstable` (`0.45.0` → `0.48.0`, then `0.49.0`) before any of it was written down. 

### Why a `needs:` job and not `workflow_run`

The deploy has to be pinned to the release the caller just built, and `workflow_run` only ever executes the default-branch copy of a workflow — so the logic couldn't be iterated on a branch. Coupling it also means a deploy failure marks the release run red, which is the signal the PR check reads.

### Pinning, and why it needs a Makefile target

Three different numbers identify a release, and the one we actually use to update is totally hidden

| Number | Example | Scope |
|---|---|---|
| `versionLabel` | `0.49.0` | the build — **not unique**, `Unstable` republishes it on every push to main |
| release sequence | `1451` | app-global, what `replicated release create` prints |
| `channelSequence` / KOTS `updateCursor` | `404` | per channel — what KOTS actually selects on |

So the release job resolves its own release sequence to a `channelSequence` and hands that to the deploy. 

The channel comes from `make print-channel` rather than a hardcoded `Unstable`, because `Makefile` derives `CHANNEL` from the branch.

## Helm Chart Checklist

<!-- No Helm charts modified. -->

## Additional Notes

**Files**

- `scripts/replicated_deploy.sh` — 100 lines, no retries or recovery by design. Takes `KOTS_CURSOR`, deploys exactly that release, or fails loudly with `::error::`.
- `.github/workflows/deploy-replicated.yml` — reusable (`workflow_call` + `workflow_dispatch`), `concurrency: replicated-deploy-<instance>`, `cancel-in-progress: false`.
- `release-replicated.yml` / `release-replicated-beta.yml` — resolve the cursor, then call the deploy workflow as a `needs:` job.
- `deploy-gate.yml` — non-blocking PR check, both lanes.
- `Makefile` — adds `print-channel`. Purely additive; `release`, the guard, and local branch releases are untouched.
- `README.md` — native GitHub Actions badges for both lanes.

**The PR check is visibility only.** It is deliberately *not* in the `main` ruleset's `required_status_checks`, so a red X never blocks a merge. Promoting it later means adding the check context `last-deploy` under Settings → Rules → Rulesets — the context is the **job** name with no workflow prefix, which the four existing `publish-charts (…)` entries confirm.

It asserts coverage rather than age, because a stale badge reads as green: GitHub renders the last real conclusion forever, so a workflow that silently stopped firing stays passing. Each lane finds what *should* have triggered a deploy and checks a run exists for it.

- **unstable** — main's newest commit under `release-replicated.yml`'s own `on.push.paths`, read at runtime with `yq` so there's no second copy of that path list to drift. (`yq`, not PyYAML: YAML 1.1 parses a bare `on:` key as the boolean `True`.)
- **beta** — the newest `openhands/*` GitHub Release. Tag refs can't be used: `git/matching-refs` sorts alphabetically, so `openhands/0.9.0` outranks `openhands/0.49.0` and the check would pin to a months-old tag and pass forever.