### PR TITLE
fix(e2e): PLTF-3461 honor AUTH_BASE_URL for Keycloak admin URL

### DIFF
--- a/e2e_tests/package.json
+++ b/e2e_tests/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "test": "playwright test",
+    "test:unit": "playwright test --config unit-tests/playwright.config.ts",
     "test:chromium": "playwright test --project=chromium:returning --project=chromium:new-user",
     "test:returning": "playwright test --project=chromium:returning --project=firefox:returning --project=webkit:returning",
     "test:new-user": "playwright test --project=chromium:new-user --project=firefox:new-user --project=webkit:new-user",

--- a/e2e_tests/unit-tests/keycloak-config.spec.ts
+++ b/e2e_tests/unit-tests/keycloak-config.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "@playwright/test";
+
+import { keycloakAdminConfig } from "../utils/config";
+
+const configEnvKeys = [
+  "AUTH_BASE_URL",
+  "BASE_URL",
+  "KEYCLOAK_ADMIN_USERNAME",
+  "KEYCLOAK_ADMIN_PASSWORD",
+  "KEYCLOAK_NEW_USER_EMAIL",
+] as const;
+
+function withConfigEnv(
+  overrides: Partial<Record<(typeof configEnvKeys)[number], string>>,
+  run: () => void,
+): void {
+  const original = Object.fromEntries(
+    configEnvKeys.map((key) => [key, process.env[key]]),
+  );
+
+  try {
+    configEnvKeys.forEach((key) => delete process.env[key]);
+    Object.assign(process.env, {
+      KEYCLOAK_ADMIN_USERNAME: "admin",
+      KEYCLOAK_ADMIN_PASSWORD: "password",
+      KEYCLOAK_NEW_USER_EMAIL: "new-user@example.com",
+      ...overrides,
+    });
+    run();
+  } finally {
+    configEnvKeys.forEach((key) => {
+      const value = original[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    });
+  }
+}
+
+test("uses the derived Keycloak URL when AUTH_BASE_URL is empty", () => {
+  withConfigEnv(
+    {
+      AUTH_BASE_URL: "   ",
+      BASE_URL: "https://staging.all-hands.dev",
+    },
+    () => {
+      expect(keycloakAdminConfig().keycloakUrl).toBe(
+        "https://auth.staging.all-hands.dev",
+      );
+    },
+  );
+});
+
+test("uses the derived Keycloak URL when AUTH_BASE_URL is unset", () => {
+  withConfigEnv({ BASE_URL: "https://staging.all-hands.dev" }, () => {
+    expect(keycloakAdminConfig().keycloakUrl).toBe(
+      "https://auth.staging.all-hands.dev",
+    );
+  });
+});
+
+test("normalizes an explicit AUTH_BASE_URL", () => {
+  withConfigEnv({ AUTH_BASE_URL: "  https://auth.example.com/  " }, () => {
+    expect(keycloakAdminConfig().keycloakUrl).toBe("https://auth.example.com");
+  });
+});
+
+test("accepts an explicit HTTP AUTH_BASE_URL", () => {
+  withConfigEnv({ AUTH_BASE_URL: "http://localhost:8080/" }, () => {
+    expect(keycloakAdminConfig().keycloakUrl).toBe("http://localhost:8080");
+  });
+});
+
+test("rejects a malformed AUTH_BASE_URL", () => {
+  withConfigEnv({ AUTH_BASE_URL: "not a URL" }, () => {
+    expect(() => keycloakAdminConfig()).toThrow(
+      "AUTH_BASE_URL must be a valid HTTP(S) URL.",
+    );
+  });
+});
+
+test("rejects a non-HTTP AUTH_BASE_URL", () => {
+  withConfigEnv({ AUTH_BASE_URL: "ftp://auth.example.com" }, () => {
+    expect(() => keycloakAdminConfig()).toThrow(
+      "AUTH_BASE_URL must be a valid HTTP(S) URL.",
+    );
+  });
+});

--- a/e2e_tests/unit-tests/playwright.config.ts
+++ b/e2e_tests/unit-tests/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: /.*\.spec\.ts$/,
+  fullyParallel: false,
+  workers: 1,
+  reporter: "list",
+});

--- a/e2e_tests/utils/config.ts
+++ b/e2e_tests/utils/config.ts
@@ -29,13 +29,14 @@ import path from "path";
  *  - KEYCLOAK_ADMIN_PASSWORD       admin password.
  *  - KEYCLOAK_NEW_USER_EMAIL       email of the New User to delete.
  *
- *  - AUTH_BASE_URL                 (optional) explicit Keycloak server URL. When
- *                                  set it is used as-is; otherwise the URL is
- *                                  derived from BASE_URL by prefixing the host
- *                                  with "auth." (e.g. https://staging.all-hands.dev
- *                                  → https://auth.staging.all-hands.dev). Set it
- *                                  for targets served under a subdomain (e.g.
- *                                  "app."), where the derivation is wrong.
+ *  - AUTH_BASE_URL                 (optional) explicit HTTP(S) Keycloak server
+ *                                  URL. When non-empty it is validated and used;
+ *                                  otherwise the URL is derived from BASE_URL by
+ *                                  prefixing the host with "auth." (e.g.
+ *                                  https://staging.all-hands.dev →
+ *                                  https://auth.staging.all-hands.dev). Set it for
+ *                                  targets served under a subdomain (e.g. "app."),
+ *                                  where the derivation is wrong.
  *
  * Returning User (GitHub):
  *  - RETURNING_GITHUB_USERNAME
@@ -157,9 +158,19 @@ export function keycloakAdminConfig(): KeycloakAdminConfig {
  * targets set AUTH_BASE_URL to the correct host.
  */
 function keycloakUrlFromBaseUrl(): string {
-  const explicit = process.env.AUTH_BASE_URL;
+  const explicit = process.env.AUTH_BASE_URL?.trim();
   if (explicit) {
-    return explicit.replace(/\/$/, "");
+    try {
+      const url = new URL(explicit);
+      if (url.protocol !== "http:" && url.protocol !== "https:") {
+        throw new Error(`Unsupported protocol: ${url.protocol}`);
+      }
+      return url.toString().replace(/\/$/, "");
+    } catch (error) {
+      throw new Error("AUTH_BASE_URL must be a valid HTTP(S) URL.", {
+        cause: error,
+      });
+    }
   }
   const baseUrl = process.env.BASE_URL;
   if (!baseUrl) {

--- a/e2e_tests/utils/config.ts
+++ b/e2e_tests/utils/config.ts
@@ -29,9 +29,13 @@ import path from "path";
  *  - KEYCLOAK_ADMIN_PASSWORD       admin password.
  *  - KEYCLOAK_NEW_USER_EMAIL       email of the New User to delete.
  *
- *  The Keycloak server URL is derived from BASE_URL by prefixing the subdomain
- *  with "auth." (e.g. https://staging.all-hands.dev →
- *  https://auth.staging.all-hands.dev).
+ *  - AUTH_BASE_URL                 (optional) explicit Keycloak server URL. When
+ *                                  set it is used as-is; otherwise the URL is
+ *                                  derived from BASE_URL by prefixing the host
+ *                                  with "auth." (e.g. https://staging.all-hands.dev
+ *                                  → https://auth.staging.all-hands.dev). Set it
+ *                                  for targets served under a subdomain (e.g.
+ *                                  "app."), where the derivation is wrong.
  *
  * Returning User (GitHub):
  *  - RETURNING_GITHUB_USERNAME
@@ -140,10 +144,23 @@ export function keycloakAdminConfig(): KeycloakAdminConfig {
 }
 
 /**
- * Derive the Keycloak URL from BASE_URL by prefixing the subdomain with "auth.".
- * e.g. https://staging.all-hands.dev → https://auth.staging.all-hands.dev
+ * Resolve the Keycloak server URL.
+ *
+ * Prefers an explicit AUTH_BASE_URL (the target's real auth host, e.g. resolved
+ * from its published web-client config), falling back to deriving it from
+ * BASE_URL by prefixing the host with "auth.".
+ *
+ * The derivation only holds when the app is served at the environment apex
+ * (e.g. https://staging.all-hands.dev → https://auth.staging.all-hands.dev). It
+ * is wrong when the app is served under a subdomain such as "app.", where the
+ * auth host drops that label rather than gaining an "auth." prefix; for those
+ * targets set AUTH_BASE_URL to the correct host.
  */
 function keycloakUrlFromBaseUrl(): string {
+  const explicit = process.env.AUTH_BASE_URL;
+  if (explicit) {
+    return explicit.replace(/\/$/, "");
+  }
   const baseUrl = process.env.BASE_URL;
   if (!baseUrl) {
     throw new Error("BASE_URL is required to derive the Keycloak URL.");


### PR DESCRIPTION
## Why

`keycloak-cleanup` prepends `auth.` to the full `BASE_URL` host, so targets served at `app.<env-domain>` resolve to `auth.app.<env-domain>`, which is outside the environment certificate and blocks the New-User path. The harness now prefers a trimmed, validated HTTP(S) `AUTH_BASE_URL`; leaving it unset or blank preserves the existing derivation for apex-style targets.

Fixes #1125

## Validation

- **Unit tests** — `npm run test:unit` passed all six cases covering unset and blank fallback, URL normalization, supported protocols, malformed input, and unsupported protocols.

_This PR was drafted by an AI agent on behalf of the user._
