### PR TITLE
ci: fix unparseable expression in deploy-replicated, lint workflows in CI

### DIFF
--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -71,7 +71,7 @@ jobs:
           case "$PATHS" in
             *'*'*) echo "::error::unsupported glob in on.push.paths: $PATHS"; exit 1 ;;
           esac
-          echo "trigger paths: $(echo $PATHS)"
+          echo "trigger paths: ${PATHS//$'\n'/ }"
 
           NEWEST=$(for P in $PATHS; do
             gh api "repos/${REPO}/commits?sha=main&path=${P}&per_page=1" \
@@ -81,7 +81,7 @@ jobs:
           if [ -n "$U_SHA" ]; then
             check unstable release-replicated-unstable.yml "branch=main&head_sha=${U_SHA}" "commit \`${U_SHA:0:8}\`"
           else
-            echo "| unstable | no commit under $(echo $PATHS) | skipped | — |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| unstable | no commit under ${PATHS//$'\n'/ } | skipped | — |" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           # Beta fires on the openhands/* tag release-please creates. Tag refs sort

--- a/.github/workflows/deploy-replicated.yml
+++ b/.github/workflows/deploy-replicated.yml
@@ -53,8 +53,9 @@ jobs:
   deploy:
     name: Deploy to ${{ inputs.instance }}
     runs-on: ubuntu-latest
-    # +5 so the script's own timeout error lands before the runner kills the job.
-    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) + 5 }}
+    # See timeout set in replicated release actions, this timeout should exceed
+    # by ~5 mins
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,22 @@
+name: Lint Workflows
+
+# Linter for github actions specifically. Surfaces rules YAML wouldn't notice
+# like attempting arithmetic in action files
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run actionlint
+        env:
+          ACTIONLINT_VERSION: '1.7.12'
+        run: |
+          bash <(curl -sSf "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash") "$ACTIONLINT_VERSION"
+          ./actionlint -color

--- a/.github/workflows/scan-docker-images.yml
+++ b/.github/workflows/scan-docker-images.yml
@@ -36,7 +36,7 @@ jobs:
             --arg agent_server "openhands/agent-server:${AGENT_SERVER_TAG}" \
             '[$runtime_api, $enterprise, $agent_server]')
 
-          echo "images=${IMAGES}" >> $GITHUB_OUTPUT
+          echo "images=${IMAGES}" >> "$GITHUB_OUTPUT"
           echo "Discovered images: ${IMAGES}"
 
   scan_docker_images:


### PR DESCRIPTION
## Human Description


A few of the replicated deploy actions had parsing errors that were valid YAML but invalid Github Action format. Did a pass of all action files in the repo to patch a few warnings and fix the mistakes i introduced.

Also added a linter step using `actionlint` for catching this in the future.

- `deploy-replicated.yml` — `timeout-minutes: 30`, a literal. `scripts/replicated_deploy.sh:11-12` enforces its own deadline from `TIMEOUT_MINUTES`, so the job cap is only a backstop; both callers use the default `"25"`, so this preserves current behavior. A caller passing `timeout_minutes: 60` would now be killed at 30 — there's no way to derive it without arithmetic, so the constraint is a comment.
- `lint-workflows.yml` — new. Runs actionlint on any PR touching `.github/workflows/**`, pinned to v1.7.12. This class of bug was statically detectable the whole time.
- `deploy-gate.yml` — `$(echo $PATHS)` relied on word-splitting to flatten newlines to spaces; now `${PATHS//$'\n'/ }`.
- `scan-docker-images.yml` — quote `$GITHUB_OUTPUT`.

The last two are pre-existing shellcheck findings, fixed so the new lint job starts from green.

Kept it a standalone workflow rather than a job in `pr-checks.yml`, which would have meant widening that workflow's path filter and running the chart/template suite on every workflow-only PR.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

N/A — no charts touched.

## Additional Notes

`actionlint` 1.7.12 is clean across the whole repo (exit 0), not just the changed files. Verified `${PATHS//$'\n'/ }` produces output identical to `$(echo $PATHS)` for a multi-line value.

The check won't block merges until its context is added to the `main` ruleset — same gap `deploy-gate.yml` has today.
