### PR TITLE
feat(replicated): declare app and sandbox node roles

### DIFF
--- a/replicated/embedded-cluster.yaml
+++ b/replicated/embedded-cluster.yaml
@@ -7,6 +7,22 @@ spec:
   domains:
     proxyRegistryDomain: "images.r9.all-hands.dev"
     replicatedAppDomain: "updates.r9.all-hands.dev"
+  # Node roles offered in the Admin Console's add-node picker. Declaring any
+  # custom role turns that page into a role selector listing every role name,
+  # the controller role's included — hence "app" rather than the default
+  # "controller". A node that does not select "app" joins as a plain k0s worker
+  # with no control plane, carrying the sandbox label that sandbox pod
+  # scheduling keys on. Labels are stamped at join time only and are never
+  # applied retroactively to an already-joined node.
+  roles:
+    controller:
+      name: app
+      labels:
+        openhands.dev/app: "true"
+    custom:
+      - name: sandbox
+        labels:
+          openhands.dev/sandbox: "true"
   extensions:
     helm:
       repositories:


### PR DESCRIPTION
## Description

Declares the node roles the Admin Console's add-node picker offers. The controller role is renamed to `app`, and a custom `sandbox` role stamps `openhands.dev/sandbox=true` at join time.

Labels only - Embedded Cluster can't taint. Nothing keys on these yet.

## Helm Chart Checklist

No chart changes.

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values