### PR TITLE
feat(chart): add affinity plumbing to all pod specs

### DIFF
--- a/charts/openhands/charts/agent-canvas/templates/_helpers.tpl
+++ b/charts/openhands/charts/agent-canvas/templates/_helpers.tpl
@@ -50,3 +50,16 @@ Selector labels
 app.kubernetes.io/name: {{ include "agent-canvas.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Pod affinity. Renders the affinity map as YAML, or nothing when no affinity is
+configured, so callers can wrap the include in a `with` and omit the key
+entirely. A chart-level `affinity` value wins over the umbrella-wide
+`global.scheduling.affinity`.
+*/}}
+{{- define "agent-canvas.affinity" -}}
+{{- $affinity := .Values.affinity | default (dig "scheduling" "affinity" (dict) (.Values.global | default (dict))) -}}
+{{- with $affinity -}}
+{{- toYaml . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openhands/charts/agent-canvas/templates/deployment.yaml
+++ b/charts/openhands/charts/agent-canvas/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (include "agent-canvas.affinity" .) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       containers:
         - name: agent-canvas
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/openhands/charts/agent-canvas/values.yaml
+++ b/charts/openhands/charts/agent-canvas/values.yaml
@@ -66,6 +66,10 @@ staticServer:
     - /redoc
     - /openapi.json
 
+# Affinity for this chart's pods. Overrides global.scheduling.affinity, which
+# the openhands umbrella sets for every chart at once; leave empty to inherit it.
+affinity: {}
+
 # Pod-level security context
 securityContext:
   runAsUser: 42420
@@ -94,3 +98,10 @@ probes:
 
 # Extra environment variables to pass to the container.
 env: {}
+
+global:
+  scheduling:
+    # Affinity applied to this chart's pods when `affinity` above is empty. The
+    # openhands umbrella sets this once for every chart it owns; this default
+    # only applies when rendering the subchart alone.
+    affinity: {}

--- a/charts/openhands/charts/automation/templates/_helpers.tpl
+++ b/charts/openhands/charts/automation/templates/_helpers.tpl
@@ -50,3 +50,16 @@ Selector labels
 app.kubernetes.io/name: {{ include "automation.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Pod affinity. Renders the affinity map as YAML, or nothing when no affinity is
+configured, so callers can wrap the include in a `with` and omit the key
+entirely. A chart-level `affinity` value wins over the umbrella-wide
+`global.scheduling.affinity`.
+*/}}
+{{- define "automation.affinity" -}}
+{{- $affinity := .Values.affinity | default (dig "scheduling" "affinity" (dict) (.Values.global | default (dict))) -}}
+{{- with $affinity -}}
+{{- toYaml . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openhands/charts/automation/templates/deployment.yaml
+++ b/charts/openhands/charts/automation/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (include "automation.affinity" .) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- if .Values.caBundle.enabled }}
       volumes:
         - name: openhands-ca-bundle

--- a/charts/openhands/charts/automation/templates/events-deployment.yaml
+++ b/charts/openhands/charts/automation/templates/events-deployment.yaml
@@ -32,6 +32,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (include "automation.affinity" .) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- if .Values.caBundle.enabled }}
       volumes:
         - name: openhands-ca-bundle

--- a/charts/openhands/charts/automation/values.yaml
+++ b/charts/openhands/charts/automation/values.yaml
@@ -65,6 +65,10 @@ events:
         matchLabels:
           app: automation-events
 
+# Affinity for this chart's pods. Overrides global.scheduling.affinity, which
+# the openhands umbrella sets for every chart at once; leave empty to inherit it.
+affinity: {}
+
 securityContext:
   runAsUser: 42420
   runAsGroup: 42420
@@ -190,3 +194,8 @@ global:
   security:
     # This allows using the bitnamilegacy image repo
     allowInsecureImages: true
+  scheduling:
+    # Affinity applied to this chart's pods when `affinity` above is empty. The
+    # openhands umbrella sets this once for every chart it owns; this default
+    # only applies when rendering the subchart alone.
+    affinity: {}

--- a/charts/openhands/charts/integrations-hub/templates/_helpers.tpl
+++ b/charts/openhands/charts/integrations-hub/templates/_helpers.tpl
@@ -50,3 +50,16 @@ Selector labels
 app.kubernetes.io/name: {{ include "integrations-hub.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Pod affinity. Renders the affinity map as YAML, or nothing when no affinity is
+configured, so callers can wrap the include in a `with` and omit the key
+entirely. A chart-level `affinity` value wins over the umbrella-wide
+`global.scheduling.affinity`.
+*/}}
+{{- define "integrations-hub.affinity" -}}
+{{- $affinity := .Values.affinity | default (dig "scheduling" "affinity" (dict) (.Values.global | default (dict))) -}}
+{{- with $affinity -}}
+{{- toYaml . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openhands/charts/integrations-hub/templates/deployment.yaml
+++ b/charts/openhands/charts/integrations-hub/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (include "integrations-hub.affinity" .) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       initContainers:
       {{- with .Values.extraInitContainers }}
       {{- tpl (toYaml .) $ | nindent 6 }}

--- a/charts/openhands/charts/integrations-hub/values.yaml
+++ b/charts/openhands/charts/integrations-hub/values.yaml
@@ -14,6 +14,10 @@ deployment:
       memory: 512Mi
       cpu: 500m
 
+# Affinity for this chart's pods. Overrides global.scheduling.affinity, which
+# the openhands umbrella sets for every chart at once; leave empty to inherit it.
+affinity: {}
+
 securityContext:
   runAsUser: 42420
   runAsGroup: 42420
@@ -170,3 +174,8 @@ global:
   security:
     # This allows using the bitnamilegacy image repo
     allowInsecureImages: true
+  scheduling:
+    # Affinity applied to this chart's pods when `affinity` above is empty. The
+    # openhands umbrella sets this once for every chart it owns; this default
+    # only applies when rendering the subchart alone.
+    affinity: {}

--- a/charts/openhands/charts/plugin-directory/templates/_helpers.tpl
+++ b/charts/openhands/charts/plugin-directory/templates/_helpers.tpl
@@ -50,3 +50,16 @@ Selector labels
 app.kubernetes.io/name: {{ include "plugin-directory.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Pod affinity. Renders the affinity map as YAML, or nothing when no affinity is
+configured, so callers can wrap the include in a `with` and omit the key
+entirely. A chart-level `affinity` value wins over the umbrella-wide
+`global.scheduling.affinity`.
+*/}}
+{{- define "plugin-directory.affinity" -}}
+{{- $affinity := .Values.affinity | default (dig "scheduling" "affinity" (dict) (.Values.global | default (dict))) -}}
+{{- with $affinity -}}
+{{- toYaml . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openhands/charts/plugin-directory/templates/deployment.yaml
+++ b/charts/openhands/charts/plugin-directory/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (include "plugin-directory.affinity" .) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- if .Values.caBundle.enabled }}
       volumes:
         - name: openhands-ca-bundle

--- a/charts/openhands/charts/plugin-directory/values.yaml
+++ b/charts/openhands/charts/plugin-directory/values.yaml
@@ -56,6 +56,10 @@ caBundle:
 deployment:
   replicas: 1
 
+# Affinity for this chart's pods. Overrides global.scheduling.affinity, which
+# the openhands umbrella sets for every chart at once; leave empty to inherit it.
+affinity: {}
+
 # Security context for the pod
 securityContext:
   runAsUser: 1001
@@ -154,3 +158,10 @@ datadog:
 
 # Env vars passed directly to the containers (overrides defaults)
 env: {}
+
+global:
+  scheduling:
+    # Affinity applied to this chart's pods when `affinity` above is empty. The
+    # openhands umbrella sets this once for every chart it owns; this default
+    # only applies when rendering the subchart alone.
+    affinity: {}

--- a/charts/openhands/charts/runtime-api/templates/_helpers.tpl
+++ b/charts/openhands/charts/runtime-api/templates/_helpers.tpl
@@ -105,3 +105,16 @@ PostgreSQL secret key
 {{- printf "db-password" -}}
 {{- end }}
 {{- end -}}
+
+{{/*
+Pod affinity. Renders the affinity map as YAML, or nothing when no affinity is
+configured, so callers can wrap the include in a `with` and omit the key
+entirely. A chart-level `affinity` value wins over the umbrella-wide
+`global.scheduling.affinity`.
+*/}}
+{{- define "runtime-api.affinity" -}}
+{{- $affinity := .Values.affinity | default (dig "scheduling" "affinity" (dict) (.Values.global | default (dict))) -}}
+{{- with $affinity -}}
+{{- toYaml . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openhands/charts/runtime-api/templates/cleanup-cronjob.yaml
+++ b/charts/openhands/charts/runtime-api/templates/cleanup-cronjob.yaml
@@ -25,6 +25,10 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with (include "runtime-api.affinity" .) }}
+          affinity:
+            {{- . | nindent 12 }}
+          {{- end }}
           {{- if .Values.ingressBase.enabled }}
           volumes:
             - name: ingress-base-config

--- a/charts/openhands/charts/runtime-api/templates/create-db-user-job.yaml
+++ b/charts/openhands/charts/runtime-api/templates/create-db-user-job.yaml
@@ -16,6 +16,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (include "runtime-api.affinity" .) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       containers:
       - name: create-user
         image: postgres:14

--- a/charts/openhands/charts/runtime-api/templates/db-cleanup-cronjob.yaml
+++ b/charts/openhands/charts/runtime-api/templates/db-cleanup-cronjob.yaml
@@ -24,6 +24,10 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with (include "runtime-api.affinity" .) }}
+          affinity:
+            {{- . | nindent 12 }}
+          {{- end }}
           {{- if .Values.ingressBase.enabled }}
           volumes:
             - name: ingress-base-config

--- a/charts/openhands/charts/runtime-api/templates/deployment.yaml
+++ b/charts/openhands/charts/runtime-api/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (include "runtime-api.affinity" .) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.warmRuntimes.enabled .Values.ingressBase.enabled .Values.caBundle.enabled }}
       volumes:
         {{- if .Values.warmRuntimes.enabled }}

--- a/charts/openhands/charts/runtime-api/templates/pod-status-logger-cronjob.yaml
+++ b/charts/openhands/charts/runtime-api/templates/pod-status-logger-cronjob.yaml
@@ -24,6 +24,10 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with (include "runtime-api.affinity" .) }}
+          affinity:
+            {{- . | nindent 12 }}
+          {{- end }}
           {{- if .Values.ingressBase.enabled }}
           volumes:
             - name: ingress-base-config

--- a/charts/openhands/charts/runtime-api/templates/test-keys-cleanup-cronjob.yaml
+++ b/charts/openhands/charts/runtime-api/templates/test-keys-cleanup-cronjob.yaml
@@ -20,6 +20,10 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with (include "runtime-api.affinity" .) }}
+          affinity:
+            {{- . | nindent 12 }}
+          {{- end }}
           containers:
           - name: test-keys-cleanup
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/openhands/charts/runtime-api/templates/warm-runtimes-cronjob.yaml
+++ b/charts/openhands/charts/runtime-api/templates/warm-runtimes-cronjob.yaml
@@ -28,6 +28,10 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12}}
           {{- end }}
+          {{- with (include "runtime-api.affinity" .) }}
+          affinity:
+            {{- . | nindent 12 }}
+          {{- end }}
           containers:
             - name: warm-runtimes
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/openhands/charts/runtime-api/tests/scheduling_test.yaml
+++ b/charts/openhands/charts/runtime-api/tests/scheduling_test.yaml
@@ -1,0 +1,80 @@
+suite: pod scheduling affinity
+templates:
+  - templates/cleanup-cronjob.yaml
+  - templates/deployment.yaml
+tests:
+  - it: the runtime-api Deployment renders global.scheduling.affinity
+    template: templates/deployment.yaml
+    set:
+      global.scheduling.affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+              - matchExpressions:
+                  - key: openhands.dev/app
+                    operator: Exists
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms
+          value:
+            - matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: Exists
+            - matchExpressions:
+                - key: openhands.dev/app
+                  operator: Exists
+
+  - it: the chart-level affinity value wins over global.scheduling.affinity
+    template: templates/deployment.yaml
+    set:
+      global.scheduling.affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: openhands.dev/app
+                    operator: Exists
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: chart.example.com/override
+                    operator: Exists
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: chart.example.com/override
+
+  - it: the runtime-api Deployment renders no affinity key by default
+    template: templates/deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.affinity
+
+  - it: the cleanup CronJob renders global.scheduling.affinity
+    template: templates/cleanup-cronjob.yaml
+    set:
+      cleanup.enabled: true
+      global.scheduling.affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: node-role.kubernetes.io/control-plane
+
+  - it: the cleanup CronJob renders no affinity key by default
+    template: templates/cleanup-cronjob.yaml
+    set:
+      cleanup.enabled: true
+    asserts:
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.affinity

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -112,6 +112,10 @@ jobSettings:
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2
 
+# Affinity for this chart's pods. Overrides global.scheduling.affinity, which
+# the openhands umbrella sets for every chart at once; leave empty to inherit it.
+affinity: {}
+
 securityContext: {}
 
 # The KVM device plugin that used to live here (smarter-device-manager,
@@ -326,3 +330,8 @@ global:
   # proxy vars, CA paths). Mirrored into each warm-runtime entry's env so
   # runtime-api's exact-env matching can claim warm pods.
   agentServerEnv: {}
+  scheduling:
+    # Affinity applied to this chart's pods when `affinity` above is empty. The
+    # openhands umbrella sets this once for every chart it owns; this default
+    # only applies when rendering the subchart alone.
+    affinity: {}

--- a/charts/openhands/templates/_helpers.tpl
+++ b/charts/openhands/templates/_helpers.tpl
@@ -50,3 +50,16 @@ Selector labels
 app.kubernetes.io/name: {{ include "openhands.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Pod affinity. Renders the affinity map as YAML, or nothing when no affinity is
+configured, so callers can wrap the include in a `with` and omit the key
+entirely. A chart-level `affinity` value wins over the umbrella-wide
+`global.scheduling.affinity`.
+*/}}
+{{- define "openhands.affinity" -}}
+{{- $affinity := .Values.affinity | default (dig "scheduling" "affinity" (dict) (.Values.global | default (dict))) -}}
+{{- with $affinity -}}
+{{- toYaml . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openhands/templates/budget-maintenance-cronjob.yaml
+++ b/charts/openhands/templates/budget-maintenance-cronjob.yaml
@@ -34,6 +34,10 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with (include "openhands.affinity" .) }}
+          affinity:
+            {{- . | nindent 12 }}
+          {{- end }}
           {{- if .Values.caBundle.enabled }}
           volumes:
             {{- include "openhands.caBundle.volume" . | nindent 12 }}

--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -42,6 +42,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (include "openhands.affinity" .) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       volumes:
         {{- include "openhands.caBundle.volume" . | nindent 8 }}
         {{- if .Values.allowedUsers }}

--- a/charts/openhands/templates/enrich-user-interaction-cronjob.yaml
+++ b/charts/openhands/templates/enrich-user-interaction-cronjob.yaml
@@ -33,6 +33,10 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with (include "openhands.affinity" .) }}
+          affinity:
+            {{- . | nindent 12 }}
+          {{- end }}
           {{- if .Values.caBundle.enabled }}
           volumes:
             {{- include "openhands.caBundle.volume" . | nindent 12 }}

--- a/charts/openhands/templates/gitlab-webhook-install-cronjob.yaml
+++ b/charts/openhands/templates/gitlab-webhook-install-cronjob.yaml
@@ -32,6 +32,10 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with (include "openhands.affinity" .) }}
+          affinity:
+            {{- . | nindent 12 }}
+          {{- end }}
           {{- if .Values.caBundle.enabled }}
           volumes:
             {{- include "openhands.caBundle.volume" . | nindent 12 }}

--- a/charts/openhands/templates/integration-events-deployment.yaml
+++ b/charts/openhands/templates/integration-events-deployment.yaml
@@ -37,6 +37,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (include "openhands.affinity" .) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       volumes:
         {{- include "openhands.caBundle.volume" . | nindent 8 }}
         {{- if .Values.allowedUsers }}

--- a/charts/openhands/templates/maintenance-tasks-cronjob.yaml
+++ b/charts/openhands/templates/maintenance-tasks-cronjob.yaml
@@ -34,6 +34,10 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with (include "openhands.affinity" .) }}
+          affinity:
+            {{- . | nindent 12 }}
+          {{- end }}
           {{- if .Values.caBundle.enabled }}
           volumes:
             {{- include "openhands.caBundle.volume" . | nindent 12 }}

--- a/charts/openhands/templates/mcp-events-deployment.yaml
+++ b/charts/openhands/templates/mcp-events-deployment.yaml
@@ -37,6 +37,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (include "openhands.affinity" .) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       volumes:
         {{- include "openhands.caBundle.volume" . | nindent 8 }}
         {{- if .Values.allowedUsers }}

--- a/charts/openhands/templates/proactive-convo-clean-cronjob.yaml
+++ b/charts/openhands/templates/proactive-convo-clean-cronjob.yaml
@@ -32,6 +32,10 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with (include "openhands.affinity" .) }}
+          affinity:
+            {{- . | nindent 12 }}
+          {{- end }}
           containers:
             - name: {{ .Release.Name }}-proactive-convo-clean
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/openhands/templates/resend-sync-cronjob.yaml
+++ b/charts/openhands/templates/resend-sync-cronjob.yaml
@@ -32,6 +32,10 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with (include "openhands.affinity" .) }}
+          affinity:
+            {{- . | nindent 12 }}
+          {{- end }}
           {{- if .Values.caBundle.enabled }}
           volumes:
             {{- include "openhands.caBundle.volume" . | nindent 12 }}

--- a/charts/openhands/tests/scheduling_test.yaml
+++ b/charts/openhands/tests/scheduling_test.yaml
@@ -1,0 +1,94 @@
+suite: pod scheduling affinity
+# deployment.yaml checksums litellm-config-script.yaml into a pod annotation, so
+# that template has to be listed here for the include to resolve. Each test sets
+# `template:` to scope its assertions to one template.
+templates:
+  - budget-maintenance-cronjob.yaml
+  - deployment.yaml
+  - litellm-config-script.yaml
+tests:
+  - it: the openhands Deployment renders global.scheduling.affinity
+    template: deployment.yaml
+    set:
+      enabled: true
+      keycloak.enabled: false
+      keycloak.provisionRealm: false
+      global.scheduling.affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+              - matchExpressions:
+                  - key: openhands.dev/app
+                    operator: Exists
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms
+          value:
+            - matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: Exists
+            - matchExpressions:
+                - key: openhands.dev/app
+                  operator: Exists
+
+  - it: the chart-level affinity value wins over global.scheduling.affinity
+    template: deployment.yaml
+    set:
+      enabled: true
+      keycloak.enabled: false
+      keycloak.provisionRealm: false
+      global.scheduling.affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: openhands.dev/app
+                    operator: Exists
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: chart.example.com/override
+                    operator: Exists
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: chart.example.com/override
+
+  - it: the openhands Deployment renders no affinity key by default
+    template: deployment.yaml
+    set:
+      enabled: true
+      keycloak.enabled: false
+      keycloak.provisionRealm: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.affinity
+
+  - it: the budget-maintenance CronJob renders global.scheduling.affinity
+    template: budget-maintenance-cronjob.yaml
+    set:
+      enabled: true
+      global.scheduling.affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: node-role.kubernetes.io/control-plane
+
+  - it: the budget-maintenance CronJob renders no affinity key by default
+    template: budget-maintenance-cronjob.yaml
+    set:
+      enabled: true
+    asserts:
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.affinity

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -76,6 +76,11 @@ deployment:
     limits:
       memory: 3Gi
 
+# Affinity for the pods this chart owns directly (the app, integrations and MCP
+# Deployments, and the maintenance CronJobs). Overrides
+# global.scheduling.affinity for those pods; leave empty to inherit it.
+affinity: {}
+
 # Security context settings for all pods
 securityContext:
   runAsUser: 42420
@@ -1306,6 +1311,14 @@ global:
   # runtime-api claims warm pods by exact env match, so a key present here but
   # absent from the warm env would make the pool unclaimable.
   agentServerEnv: {}
+  scheduling:
+    # Affinity applied to every pod this chart and its OpenHands subcharts own
+    # (Deployments, Jobs and CronJobs alike). Node-level DaemonSets are exempt
+    # so they keep covering every node — the KVM device plugin and the sysbox
+    # installer in charts/infra must run on sandbox nodes too. Vendored
+    # third-party subcharts cannot read this; set each one's own `affinity`
+    # value alongside it. A chart-level `affinity` value wins over this.
+    affinity: {}
 
 # Trust-manager Bundle that fans a CA bundle (public CAs + an optional
 # operator-supplied CA certificate) out as a ConfigMap into the release


### PR DESCRIPTION
## Description

Adds an `openhands.affinity` helper and renders it in every pod spec this chart and its OpenHands subcharts own - deployments, jobs and cronjobs.

Defaults to `{}`, so it's a no-op until something sets it. Node-level DaemonSets are exempt so they keep covering every node.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values