### PR TITLE
feat(replicated): gate dedicated sandbox nodes behind a config option

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1334,6 +1334,13 @@ spec:
             /dev/kvm. Verify with `ls -l /dev/kvm` on the node.
           type: bool
           default: "0"
+        - name: sandbox_dedicated_nodes
+          title: Run sandboxes on dedicated nodes
+          help_text: >-
+            Confine sandboxes to nodes joined with the sandbox role. Requires at least
+            1 sandbox node already joined.
+          type: bool
+          default: "0"
 
     - name: proxy_configuration
       title: Proxy Configuration

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -337,13 +337,17 @@ spec:
         STORAGE_CLASS: "openebs-hostpath"
         INGRESS_CLASS: "traefik"
         RUNTIME_CLASS: '{{repl if ConfigOptionEquals "sandbox_isolation" "sysbox"}}sysbox-runc{{repl else}}{{repl end}}'
-        # The embedded-cluster node carries no sysbox-install label or
-        # sysbox-runtime taint, so clear the scheduling defaults the runtime-api
-        # injects for the sysbox-runc class (node selector sysbox-install=yes +
-        # the sysbox-runtime toleration). Empty JSON collections mean "no node
-        # selector / no tolerations", keeping sandboxes schedulable on the single
-        # node. Scheduling is independent from the userns/hostUsers config
-        # (SET_HOST_USERS below). (runtime-api env vars from OpenHands/runtime-api#631.)
+        # Sandbox pod scheduling. Both are empty JSON collections ("no node
+        # selector", "no tolerations"), which overrides the defaults the
+        # runtime-api injects for the sysbox-runc class (node selector
+        # sysbox-install=yes + the sysbox-runtime toleration) — embedded-cluster
+        # nodes carry neither that label nor any taint, so those defaults would
+        # leave sandboxes unschedulable. Embedded Cluster cannot taint nodes at
+        # all, so RUNTIME_TOLERATIONS stays empty; the dedicated-nodes
+        # optionalValues block below points RUNTIME_NODE_SELECTOR at the sandbox
+        # role's label. Scheduling is independent from the userns/hostUsers
+        # config (SET_HOST_USERS below).
+        # (runtime-api env vars from OpenHands/runtime-api#631.)
         RUNTIME_TOLERATIONS: "[]"
         RUNTIME_NODE_SELECTOR: "{}"
         # Make the runtime-api set hostUsers: false on sysbox-runc sandboxes
@@ -1218,6 +1222,72 @@ spec:
             basePath: /canvas
             authRequired: false
             lockToCloud: 'https://{{repl ConfigOption "computed_app_hostname" }}'
+    # Dedicated sandbox nodes: sandboxes go to nodes joined with the `sandbox`
+    # role, everything else stays on the controller(s). Embedded Cluster v2
+    # cannot taint nodes — its custom roles only stamp labels — so "keep other
+    # workloads off the sandbox nodes" is a required nodeAffinity on our own
+    # pods rather than a taint the sandboxes tolerate.
+    #
+    # The affinity keys on the control-plane role label, which k0s stamps on
+    # every controller and never on a node joined as a plain worker. That label
+    # is already present on every existing install, whereas role labels are
+    # applied at join time only, so openhands.dev/app is absent from any node
+    # that joined before this feature existed. The two nodeSelectorTerms are
+    # OR'd: the second admits dedicated application-capacity workers, joined
+    # with the `app` role, if capacity ever needs to grow beyond the controllers.
+    #
+    # global.scheduling.affinity reaches every chart OpenHands owns; Helm does
+    # not propagate it into vendored third-party subcharts, so each of those
+    # that this install enables gets the same value under its own affinity key.
+    # Node-level DaemonSets (the KVM device plugin here, the sysbox installer in
+    # the infra-sysbox release) are deliberately exempt — they must keep running
+    # on the sandbox nodes too.
+    - when: '{{repl ConfigOptionEquals "sandbox_dedicated_nodes" "1" }}'
+      recursiveMerge: true
+      values:
+        global:
+          scheduling:
+            affinity: &dedicated_nodes_affinity
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node-role.kubernetes.io/control-plane
+                          operator: Exists
+                    - matchExpressions:
+                        - key: openhands.dev/app
+                          operator: Exists
+        keycloak:
+          affinity: *dedicated_nodes_affinity
+        litellm-helm:
+          affinity: *dedicated_nodes_affinity
+        minio:
+          affinity: *dedicated_nodes_affinity
+          # Bucket/service-account creation runs as a post-install hook Job with
+          # its own scheduling knobs.
+          postJob:
+            affinity: *dedicated_nodes_affinity
+        postgresql:
+          primary:
+            affinity: *dedicated_nodes_affinity
+        redis:
+          # architecture is standalone, so only the master pod is rendered.
+          master:
+            affinity: *dedicated_nodes_affinity
+        replicated:
+          affinity: *dedicated_nodes_affinity
+        laminar:
+          # Only rendered when analytics is enabled. Every component of the
+          # chart falls back to global.affinity, so one key covers all of them.
+          global:
+            affinity: *dedicated_nodes_affinity
+        runtime-api:
+          env:
+            # Sandboxes go the other way: onto the sandbox-role nodes only.
+            # Only newly created sandbox Deployments pick this up; an existing
+            # sandbox keeps the pod template it was created with, so its pod can
+            # still return to the node its openebs-hostpath PV is pinned to.
+            RUNTIME_NODE_SELECTOR: '{"openhands.dev/sandbox":"true"}'
 
   builder:
     keycloak:


### PR DESCRIPTION
## Description

Adds the `sandbox_dedicated_nodes` config option, off by default.

When on, app workloads get a required nodeAffinity and runtime-api gets `RUNTIME_NODE_SELECTOR={"openhands.dev/sandbox":"true"}`. The affinity matches `node-role.kubernetes.io/control-plane` or `openhands.dev/app`, so existing single-node installs keep scheduling normally without a node reset.

## Helm Chart Checklist

No chart changes.

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values