### PR TITLE
feat(preflight): warn when dedicated sandbox nodes are enabled with no sandbox node

### DIFF
--- a/charts/openhands/templates/troubleshoot/_sandbox-nodes.tpl
+++ b/charts/openhands/templates/troubleshoot/_sandbox-nodes.tpl
@@ -1,0 +1,35 @@
+{{/*
+Dedicated sandbox nodes preflight: when sandboxes are confined to nodes carrying
+the `sandbox` role label, verify at least one such node is actually in the
+cluster. With none, every sandbox pod has an unsatisfiable node selector and sits
+Pending, so conversations never start.
+
+Warn rather than fail: the operator may be enabling this in the same config pass
+that precedes joining the node, and a hard gate would block that ordering.
+
+Read from the default clusterResources collector's cluster-resources/nodes.json
+via textAnalyze (no pod, no hostPath -> Pod Security Standards safe). textAnalyze
+matches if ANY node carries the label, which is exactly the question here.
+
+Gated in preflights.yaml on the runtime-api's RUNTIME_NODE_SELECTOR targeting the
+sandbox label, which replicated/openhands.yaml sets from the config option.
+*/}}
+
+{{- define "troubleshoot.sandboxNodes.vars" -}}
+{{- $rtApiEnv := (index .Values "runtime-api" | default dict).env | default dict -}}
+selected: {{ contains "openhands.dev/sandbox" ($rtApiEnv.RUNTIME_NODE_SELECTOR | default "" | toString) }}
+{{- end -}}
+
+{{- define "troubleshoot.analyzers.sandboxNodes" -}}
+- textAnalyze:
+    checkName: "Sandbox nodes: at least one node carries the sandbox role"
+    fileName: cluster-resources/nodes.json
+    regex: '"openhands\.dev/sandbox":\s*"true"'
+    outcomes:
+      - pass:
+          when: "true"
+          message: "At least one node is joined with the sandbox role."
+      - warn:
+          when: "false"
+          message: "No node carries the sandbox role, so sandboxes have nowhere to schedule. Add a node from Cluster Management and select the sandbox role, or turn off \"Run sandboxes on dedicated nodes\"."
+{{- end -}}

--- a/charts/openhands/templates/troubleshoot/preflights.yaml
+++ b/charts/openhands/templates/troubleshoot/preflights.yaml
@@ -1,6 +1,7 @@
 {{- define "troubleshoot.preflights" -}}
 {{- $tls := include "troubleshoot.tlsHostname.vars" . | fromYaml -}}
 {{- $sysbox := include "troubleshoot.sysbox.vars" . | fromYaml -}}
+{{- $sandboxNodes := include "troubleshoot.sandboxNodes.vars" . | fromYaml -}}
 apiVersion: troubleshoot.sh/v1beta2
 kind: Preflight
 metadata:
@@ -15,6 +16,9 @@ spec:
     {{- include "troubleshoot.analyzers.shared" . | nindent 4 }}
     {{- if $sysbox.selected }}
     {{- include "troubleshoot.analyzers.sysbox" . | nindent 4 }}
+    {{- end }}
+    {{- if $sandboxNodes.selected }}
+    {{- include "troubleshoot.analyzers.sandboxNodes" . | nindent 4 }}
     {{- end }}
     {{- if $tls.cert }}
     {{- include "troubleshoot.analyzers.tlsHostname" . | nindent 4 }}

--- a/charts/openhands/tests/sandbox_nodes_preflight_test.yaml
+++ b/charts/openhands/tests/sandbox_nodes_preflight_test.yaml
@@ -1,0 +1,55 @@
+suite: dedicated sandbox nodes preflight
+# secrets.yaml includes the troubleshoot.preflights and troubleshoot.supportBundle
+# defines, which live in these two templates. Neither is an underscore partial,
+# so both have to be listed here or the includes fail to resolve; each test
+# scopes its asserts to secrets.yaml.
+templates:
+  - troubleshoot/secrets.yaml
+  - troubleshoot/preflights.yaml
+  - troubleshoot/support-bundle.yaml
+tests:
+  - it: adds the sandbox-node analyzer when sandboxes are confined to sandbox-role nodes
+    template: troubleshoot/secrets.yaml
+    set:
+      runtime-api:
+        env:
+          RUNTIME_NODE_SELECTOR: '{"openhands.dev/sandbox":"true"}'
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-preflight
+    asserts:
+      - matchRegex:
+          path: stringData["preflight.yaml"]
+          pattern: "Sandbox nodes: at least one node carries the sandbox role"
+      - matchRegex:
+          path: stringData["preflight.yaml"]
+          pattern: 'fileName: cluster-resources/nodes\.json'
+      # Absence of the label is a warning, not a hard gate: the operator may
+      # enable this in the same config pass that precedes joining the node.
+      - matchRegex:
+          path: stringData["preflight.yaml"]
+          pattern: 'warn:\n\s+when: "false"\n\s+message: "No node carries the sandbox role'
+
+  - it: omits the sandbox-node analyzer by default
+    template: troubleshoot/secrets.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-preflight
+    asserts:
+      - notMatchRegex:
+          path: stringData["preflight.yaml"]
+          pattern: "Sandbox nodes"
+
+  - it: omits the sandbox-node analyzer when the selector targets some other label
+    template: troubleshoot/secrets.yaml
+    set:
+      runtime-api:
+        env:
+          RUNTIME_NODE_SELECTOR: '{"pool":"my-pool"}'
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-preflight
+    asserts:
+      - notMatchRegex:
+          path: stringData["preflight.yaml"]
+          pattern: "Sandbox nodes"


### PR DESCRIPTION
## Description

Warns when `sandbox_dedicated_nodes` is on but no node carries the sandbox role, since sandboxes would have nowhere to schedule.

Warns rather than fails - the option can be turned on in the config pass before the node is joined.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values