### PR TITLE
feat(replicated): PLTF-3461 configure duplicate email checks

### DIFF
--- a/charts/openhands/templates/_env.yaml
+++ b/charts/openhands/templates/_env.yaml
@@ -34,6 +34,8 @@
 - name: OH_DAILY_CONVERSATION_LIMIT
   value: {{ .Values.dailyConversationLimit | quote }}
 {{- end }}
+- name: DUPLICATE_EMAIL_CHECK
+  value: {{ .Values.duplicateEmailCheck | quote }}
 - name: OH_RESOLVER_LABEL
   value: {{ get $integrations "resolverLabel" | default "openhands" | quote }}
 - name: LOG_JSON # Configure structured logging for Google Cloud

--- a/charts/openhands/tests/duplicate_email_check_test.yaml
+++ b/charts/openhands/tests/duplicate_email_check_test.yaml
@@ -1,0 +1,44 @@
+suite: duplicate email check env wiring
+templates:
+  - deployment.yaml
+  # deployment.yaml unconditionally checksums this ConfigMap into its pod
+  # annotations, so it must be compiled alongside it for the render to succeed.
+  - litellm-config-script.yaml
+tests:
+  - it: prevents duplicate base emails by default
+    set:
+      enabled: true
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DUPLICATE_EMAIL_CHECK
+            value: "true"
+
+  - it: allows operators to disable duplicate base email checks
+    set:
+      enabled: true
+      duplicateEmailCheck: false
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DUPLICATE_EMAIL_CHECK
+            value: "false"
+
+  - it: preserves the generic env override without duplicate entries
+    set:
+      enabled: true
+      duplicateEmailCheck: true
+      env:
+        DUPLICATE_EMAIL_CHECK: "false"
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DUPLICATE_EMAIL_CHECK
+            value: "false"
+          count: 1

--- a/charts/openhands/tests/values_schema_test.yaml
+++ b/charts/openhands/tests/values_schema_test.yaml
@@ -26,6 +26,12 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "dailyConversationLimit"
+  - it: rejects a non-boolean duplicate email check
+    set:
+      duplicateEmailCheck: "yes"
+    asserts:
+      - failedTemplate:
+          errorPattern: "duplicateEmailCheck.*want boolean"
   - it: rejects a storage backend the app does not support
     set:
       filestore.type: local

--- a/charts/openhands/values.schema.json
+++ b/charts/openhands/values.schema.json
@@ -7,6 +7,7 @@
   "properties": {
     "enabled": { "type": "boolean" },
     "dailyConversationLimit": { "type": ["integer", "null"] },
+    "duplicateEmailCheck": { "type": "boolean" },
     "image": {
       "type": "object",
       "required": ["repository", "tag"],

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -37,6 +37,10 @@ appConfig:
 # enterprise application default unlimited; set an integer to enforce a limit.
 dailyConversationLimit: null
 
+# Reject sign-ins when another identity has the same base email after removing
+# a plus-address suffix (for example, name+test@example.com and name@example.com).
+duplicateEmailCheck: true
+
 datadog:
   enabled: false
   env: "dev" # Default environment, can be overridden

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -740,6 +740,16 @@ spec:
           default: "1"
           when: 'repl{{ and (ConfigOptionEquals "default_openhands_org_enabled" "1") (ConfigOptionEquals "default_openhands_org_auto_add_users" "1") }}'
 
+    - name: authentication_security
+      title: Authentication Security
+      description: Configure safeguards applied when users sign in.
+      items:
+        - name: duplicate_email_check
+          title: Prevent Duplicate Base Emails
+          help_text: Reject sign-ins when another user has the same base email after removing a plus-address suffix (for example, name+test@example.com matches name@example.com).
+          type: bool
+          default: "1"
+
     - name: bitbucket_data_center_authentication
       title: Bitbucket Data Center Authentication
       description: Configure Bitbucket Data Center OAuth for user authentication

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -39,6 +39,8 @@ spec:
     imagePullSecrets:
       - name: '{{repl ImagePullSecretName }}'
 
+    duplicateEmailCheck: repl{{ ConfigOptionEquals "duplicate_email_check" "1" }}
+
     env:
       # Default model for new users/orgs: the first non-empty line of the
       # "Anthropic Models" KOTS textarea (anthropic is the base provider; the

--- a/scripts/test_replicated_duplicate_email_check.py
+++ b/scripts/test_replicated_duplicate_email_check.py
@@ -1,0 +1,39 @@
+"""Tests for the Replicated duplicate-email configuration contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPLICATED_CONFIG = REPO_ROOT / "replicated" / "config.yaml"
+REPLICATED_OPENHANDS = REPO_ROOT / "replicated" / "openhands.yaml"
+
+
+def replicated_config_item(name: str) -> dict[str, object]:
+    config = yaml.safe_load(REPLICATED_CONFIG.read_text(encoding="utf-8"))
+    for group in config["spec"]["groups"]:
+        for item in group["items"]:
+            if item["name"] == name:
+                return item
+    raise AssertionError(f"Replicated config item {name!r} was not found")
+
+
+def test_replicated_exposes_duplicate_email_check_with_secure_default() -> None:
+    item = replicated_config_item("duplicate_email_check")
+
+    assert item["type"] == "bool"
+    assert item["default"] == "1"
+    assert "plus" in str(item["help_text"]).lower()
+
+
+def test_replicated_passes_duplicate_email_check_to_the_chart_value() -> None:
+    values = REPLICATED_OPENHANDS.read_text(encoding="utf-8")
+
+    assert (
+        '    duplicateEmailCheck: repl{{ ConfigOptionEquals "duplicate_email_check" "1" }}'
+        in values
+    )
+    assert "DUPLICATE_EMAIL_CHECK:" not in values


### PR DESCRIPTION
## Why

Replicated installations need an explicit way to disable duplicate base-email protection when plus-address identities are intentional. This adds a typed `duplicateEmailCheck` chart value and a Replicated **Prevent Duplicate Base Emails** checkbox; it defaults to `true` to preserve existing behavior, while an explicit `env.DUPLICATE_EMAIL_CHECK` override still takes precedence without rendering duplicate entries. Disabling the option permits identities whose plus-address variants normalize to the same base email and should only be used where that behavior is intentional.

## Validation

- **Chart rendering** — Verified the default and disabled values render `DUPLICATE_EMAIL_CHECK` as `true` and `false`, respectively.
- **Override precedence** — Verified an explicit environment override wins and renders exactly one `DUPLICATE_EMAIL_CHECK` entry.
- **Replicated contract** — Verified the checkbox defaults enabled and maps to the chart value rather than directly to the application environment.

This PR was drafted by an AI agent on behalf of the user.