### PR TITLE
fix(deploy): tolerate a restarting kotsadm in replicated_deploy.sh

### DIFF
--- a/scripts/replicated_deploy.sh
+++ b/scripts/replicated_deploy.sh
@@ -41,16 +41,21 @@ done
 # cache, so re-issue the check rather than trusting the first read. `// []`
 # keeps an absent key from failing the pipe under pipefail, which would exit
 # before the message below.
+# Capped at 3m, not the whole budget: a cursor absent this long is a real
+# problem, not a restart settling. TMO=60 so the cap allows several tries.
 TARGET=""
-while waiting; do
-  TMO=180 post -d '{}' "$KOTS_BASE/api/v1/app/$APP/updatecheck" >/dev/null || true
+SELECT_DEADLINE=$(( $(date +%s) + 180 ))
+while :; do
+  TMO=60 post -d '{}' "$KOTS_BASE/api/v1/app/$APP/updatecheck" >/dev/null || true
   TARGET="$( (api "$KOTS_BASE/api/v1/app/$APP/updates" || true) \
     | jq -c --arg c "$KOTS_CURSOR" '(.updates // [])[] | select(.updateCursor == $c)' || true)"
   [ -n "$TARGET" ] && break
+  if [ "$(date +%s)" -ge "$SELECT_DEADLINE" ] || ! waiting; then
+    fail "cursor $KOTS_CURSOR never became an available update for $APP"
+  fi
   echo "  cursor $KOTS_CURSOR not in the update list yet, rechecking"
   sleep 15
 done
-[ -n "$TARGET" ] || fail "cursor $KOTS_CURSOR never became an available update for $APP"
 [ "$(jq -r .isDeployable <<<"$TARGET")" = true ] \
   || fail "cursor $KOTS_CURSOR not deployable: $(jq -r '.nonDeployableCause // "unknown"' <<<"$TARGET")"
 

--- a/scripts/replicated_deploy.sh
+++ b/scripts/replicated_deploy.sh
@@ -21,17 +21,36 @@ post() { api -H 'Content-Type: application/json' -X POST "$@"; }
 ok()   { jq -e '.success == true' >/dev/null 2>&1; }
 
 # A 401 still sets a cookie, so a non-empty jar proves nothing.
-CODE="$(curl -sS -k -c "$JAR" -o /dev/null -w '%{http_code}' --max-time 30 \
-  -X POST "$KOTS_BASE/api/v1/login" -H 'Content-Type: application/json' \
-  --data "$(jq -nc --arg p "$KOTS_PASSWORD" '{password:$p}')")"
-[ "$CODE" = 200 ] || fail "login to $KOTS_BASE returned HTTP $CODE"
+# Retried: kotsadm is often mid-restart when a release lands back-to-back with
+# the previous one, and a refused connect must not read as a bad password.
+BODY="$(jq -nc --arg p "$KOTS_PASSWORD" '{password:$p}')"
+LOGIN_DEADLINE=$(( $(date +%s) + 120 ))
+while :; do
+  CODE="$(curl -sS -k -c "$JAR" -o /dev/null -w '%{http_code}' --max-time 30 \
+    -X POST "$KOTS_BASE/api/v1/login" -H 'Content-Type: application/json' \
+    --data "$BODY" || echo 000)"
+  [ "$CODE" = 200 ] && break
+  [ "$(date +%s)" -lt "$LOGIN_DEADLINE" ] || fail "login to $KOTS_BASE returned HTTP $CODE"
+  echo "  login returned $CODE, retrying"
+  sleep 10
+done
 
 # --- select --------------------------------------------------------------
 # KOTS_CURSOR is the channel sequence; versionLabel is not unique.
-TMO=180 post -d '{}' "$KOTS_BASE/api/v1/app/$APP/updatecheck" >/dev/null
-TARGET="$(api "$KOTS_BASE/api/v1/app/$APP/updates" \
-  | jq -c --arg c "$KOTS_CURSOR" '.updates[] | select(.updateCursor == $c)')"
-[ -n "$TARGET" ] || fail "cursor $KOTS_CURSOR is not an available update for $APP"
+# A restarted kotsadm serves `updates: null` until a check repopulates its
+# cache, so re-issue the check rather than trusting the first read. `// []`
+# keeps an absent key from failing the pipe under pipefail, which would exit
+# before the message below.
+TARGET=""
+while waiting; do
+  TMO=180 post -d '{}' "$KOTS_BASE/api/v1/app/$APP/updatecheck" >/dev/null || true
+  TARGET="$( (api "$KOTS_BASE/api/v1/app/$APP/updates" || true) \
+    | jq -c --arg c "$KOTS_CURSOR" '(.updates // [])[] | select(.updateCursor == $c)' || true)"
+  [ -n "$TARGET" ] && break
+  echo "  cursor $KOTS_CURSOR not in the update list yet, rechecking"
+  sleep 15
+done
+[ -n "$TARGET" ] || fail "cursor $KOTS_CURSOR never became an available update for $APP"
 [ "$(jq -r .isDeployable <<<"$TARGET")" = true ] \
   || fail "cursor $KOTS_CURSOR not deployable: $(jq -r '.nonDeployableCause // "unknown"' <<<"$TARGET")"
 


### PR DESCRIPTION
## Description

0.50.0's unstable auto-deploy went red twice and neither failure was real. Both landed on the first two KOTS calls in `replicated_deploy.sh`, which had no tolerance for a kotsadm mid-restart — exactly its state right after the previous release deploys.

- **Attempt 1**: `curl: (7) ... after 82 ms` on login. That's a connect *refused* in one RTT (normal connect to that host measures 46–85ms), not a timeout — nothing was listening on `:30000`. Login had no retry at all, while every later loop already tolerates an unreachable console.
- **Attempt 2**: `jq: Cannot iterate over null` on the update list. `GET /updates` returned `updates: null` while cursor 426 was genuinely pending — seq 39 only flipped to "Version skipped" six minutes later, when seq 41 deployed.

Strict mode doubled both: the failing command substitution tripped `set -e`/`pipefail` before the `fail "..."` guard on the very next line could run, so the messages written for these exact cases never printed. You got a bare `exit 7` and `exit 5` instead.

`scripts/replicated_deploy.sh`:

- Login now retries for up to 2m. `|| echo 000` is what lets a refused connect reach the guard instead of killing the script. Bounded separately from `TIMEOUT_MINUTES` so a genuinely dead console still fails in two minutes.
- The cursor lookup polls for up to **3m**, re-issuing `updatecheck` each pass since a restarted kotsadm drops the queued check. `(.updates // [])[]` stops an absent key from failing the pipe under `pipefail`. The check's curl timeout drops 180s → 60s so the 3m cap still fits several attempts.

## Helm Chart Checklist

N/A — no chart changes.

## Additional Notes

`bash -n` and `shellcheck` clean. Exercised the new `jq` form against `{"updates":null}`, an `{"error":"missing authorization token"}` body, a non-JSON 502 page, and a real match: the first three now yield an empty `TARGET` and retry, where the old form exited 5. Both loop guards confirmed to reach `fail()` under `set -euo pipefail` rather than dying silently.
