### PR TITLE
fix(e2e): PLTF-3461 move the credit-gated API key check into the billing suite

### DIFF
--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -129,6 +129,8 @@ chromium:new-user  ──▶ setup:new-user
 
 Every `*.spec.ts` file is picked up by both the `:returning` and `:new-user` variants of each browser, so the same suite runs once per user role. Specs read the active role via `runUser(testInfo)` (see `utils/config.ts`), which resolves Playwright project metadata (`project.metadata.user`) and falls back to the `AUTH_RUN_USER` env var for ad-hoc single-spec runs.
 
+Spec filenames are numbered (`001-`, `002-`, …) because Playwright runs the files within a project in filename order. The New User starts with a zero balance, so the credit top-up in `002-billing.spec.ts` has to run before anything that needs credits. Keep the prefixes when adding a spec.
+
 ### Auth behavior: `AUTH_METHOD`
 
 - Default — each setup project logs in fresh and overwrites its storage-state file.

--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -129,7 +129,7 @@ chromium:new-user  ──▶ setup:new-user
 
 Every `*.spec.ts` file is picked up by both the `:returning` and `:new-user` variants of each browser, so the same suite runs once per user role. Specs read the active role via `runUser(testInfo)` (see `utils/config.ts`), which resolves Playwright project metadata (`project.metadata.user`) and falls back to the `AUTH_RUN_USER` env var for ad-hoc single-spec runs.
 
-Spec filenames are numbered (`001-`, `002-`, …) because Playwright runs the files within a project in filename order. The New User starts with a zero balance, so the credit top-up in `002-billing.spec.ts` has to run before anything that needs credits. Keep the prefixes when adding a spec.
+Spec filenames are numbered (`001-`, `002-`, …) because Playwright runs the files within a project in filename order. Keep the prefixes when adding a spec; a spec that must run at a particular point says why in its own header.
 
 ### Auth behavior: `AUTH_METHOD`
 

--- a/e2e_tests/tests/002-billing.spec.ts
+++ b/e2e_tests/tests/002-billing.spec.ts
@@ -14,8 +14,6 @@ import { runUser } from "../utils/config";
  * As with the rest of the harness, each spec runs once per user role
  * (returning / new-user); the active role is read from project metadata via
  * `runUser(testInfo)`.
- *
- * Spec files are numbered because Playwright runs them in filename order.
  */
 
 const STRIPE_TEST_CARD = {

--- a/e2e_tests/tests/002-billing.spec.ts
+++ b/e2e_tests/tests/002-billing.spec.ts
@@ -15,13 +15,11 @@ import { runUser } from "../utils/config";
  * (returning / new-user); the active role is read from project metadata via
  * `runUser(testInfo)`.
  *
- * This file is prefixed `002-` so Playwright runs it before
- * `004-api-keys.spec.ts` within a project (files run in filename order). The
- * API keys spec requires the user to have credits — the "Refresh API Key"
- * button only renders once the balance is non-zero — so for the new-user role
- * the $10 top-up here must happen first. If billing is disabled the top-up is
- * skipped and the API keys spec will fail for new-users regardless of order,
- * since there is no other way to obtain credits.
+ * Spec files are numbered because Playwright runs them in filename order.
+ *
+ * The BYOR "Refresh API Key" check belongs here, not with the other API key
+ * specs: the top-up below is the only way the harness obtains the credits that
+ * make the button render.
  */
 
 const STRIPE_TEST_CARD = {
@@ -126,5 +124,27 @@ test.describe("Billing @billing", () => {
     await page.screenshot({
       path: "test-results/screenshots/billing-after-payment.png",
     });
+  });
+
+  test("should show the LLM API key refresh button once credits exist", async ({
+    page,
+  }, testInfo) => {
+    test.info().annotations.push({
+      type: "user",
+      description: runUser(testInfo),
+    });
+
+    await homePage.goto();
+    await homePage.openUserMenu();
+
+    const apiKeysLink = page.getByRole("link", { name: /api keys/i });
+    await apiKeysLink.click();
+
+    await page.waitForURL(/\/settings\/api-keys/, { timeout: 30_000 });
+
+    // The button appears only once `GET /api/keys/llm/byor` stops answering
+    // 402, which needs a non-zero balance.
+    const refreshApiKeyButton = page.getByRole("button", { name: /refresh/i });
+    await expect(refreshApiKeyButton).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/e2e_tests/tests/002-billing.spec.ts
+++ b/e2e_tests/tests/002-billing.spec.ts
@@ -14,6 +14,9 @@ import { runUser } from "../utils/config";
  * As with the rest of the harness, each spec runs once per user role
  * (returning / new-user); the active role is read from project metadata via
  * `runUser(testInfo)`.
+ *
+ * The New User starts with a zero balance, so the top-up below has to run
+ * before anything that needs credits — hence the low `002-` prefix.
  */
 
 const STRIPE_TEST_CARD = {

--- a/e2e_tests/tests/002-billing.spec.ts
+++ b/e2e_tests/tests/002-billing.spec.ts
@@ -16,10 +16,6 @@ import { runUser } from "../utils/config";
  * `runUser(testInfo)`.
  *
  * Spec files are numbered because Playwright runs them in filename order.
- *
- * The BYOR "Refresh API Key" check belongs here, not with the other API key
- * specs: the top-up below is the only way the harness obtains the credits that
- * make the button render.
  */
 
 const STRIPE_TEST_CARD = {

--- a/e2e_tests/tests/004-api-keys.spec.ts
+++ b/e2e_tests/tests/004-api-keys.spec.ts
@@ -9,10 +9,6 @@ import { runUser } from "../utils/config";
  * creation + API access flow). As with the rest of the harness, each spec runs
  * once per user role (returning / new-user); the active role is read from
  * project metadata via `runUser(testInfo)`.
- *
- * Nothing here needs credits, so this runs on billing-disabled deployments
- * too; the credit-gated BYOR "Refresh API Key" check lives in
- * `002-billing.spec.ts`.
  */
 
 const API_KEY_NAME = "Integration Test Key";

--- a/e2e_tests/tests/004-api-keys.spec.ts
+++ b/e2e_tests/tests/004-api-keys.spec.ts
@@ -10,11 +10,9 @@ import { runUser } from "../utils/config";
  * once per user role (returning / new-user); the active role is read from
  * project metadata via `runUser(testInfo)`.
  *
- * This file is prefixed `004-` so Playwright runs it after
- * `002-billing.spec.ts` within a project (files run in filename order). The
- * "Refresh API Key" button only renders once the user has a non-zero balance,
- * so for the new-user role the billing top-up must happen first. Returning
- * users already have credits, so ordering does not matter for them.
+ * Nothing here needs credits, so this runs on billing-disabled deployments
+ * too; the credit-gated BYOR "Refresh API Key" check lives in
+ * `002-billing.spec.ts`.
  */
 
 const API_KEY_NAME = "Integration Test Key";
@@ -40,13 +38,6 @@ test.describe("api keys", () => {
 
     await page.waitForURL(/\/settings\/api-keys/, { timeout: 30_000 });
     console.log("Navigated to API Keys page");
-
-    // The "Refresh API Key" button only renders once the user has a non-zero
-    // balance; for the new-user role this depends on 002-billing.spec.ts having
-    // purchased credits first (see the file-level doc).
-    const refreshApiKeyButton = page.getByRole("button", { name: /refresh/i });
-    await expect(refreshApiKeyButton).toBeVisible({ timeout: 10_000 });
-    console.log("Refresh API Key button is visible - user has credits");
 
     // Delete any existing key with the same name so creation is deterministic.
     const existingKeyRow = page.locator("tr", { hasText: API_KEY_NAME });


### PR DESCRIPTION
## Why

`004-api-keys.spec.ts` waited for the "Refresh API Key" button before creating a key, but that button belongs to the BYOR LLM key section rather than the OpenHands API keys section the spec covers. The frontend only renders it when `GET /api/keys/llm/byor` does not answer 402, and the server answers 402 until the organization has credits. The single way this harness obtains credits is the Stripe top-up in `002-billing.spec.ts`, which skips itself whenever the deployment reports `feature_flags.enable_billing` false. On a billing-disabled deployment the button therefore never appears, and the spec failed on that pre-check before reaching anything it was written to exercise.

The assertion now lives in `002-billing.spec.ts` directly after the top-up that gives it its precondition, so the existing billing fixture skips it along with the rest of that file. `004-api-keys.spec.ts` keeps creating a key and calling `/api/v1/sandboxes/search` with it; neither step is credit-gated, so that coverage runs on billing-disabled deployments too instead of failing on a paywalled button.

## Validation

- **Static checks** — `npm run lint` in `e2e_tests` (typecheck, eslint, prettier) passes.
- **Test discovery** — `npx playwright test --project=chromium:returning --list` lists the moved assertion as a second test under `Billing @billing`, so it inherits both the tag and the fixture's skip, and lists `004-api-keys.spec.ts` with only its create-and-use test.
- **Flag difference** — `/api/v1/web-client/config` reports `enable_billing: false` on the deployment where the spec failed and `true` on SaaS staging, which is why the same spec passed there.

_This PR was drafted by an AI agent on behalf of the user._