### PR TITLE
fix(ci): PLTF-3461 call the E2E trigger from each release workflow

### DIFF
--- a/.github/workflows/deploy-replicated.yml
+++ b/.github/workflows/deploy-replicated.yml
@@ -87,10 +87,3 @@ jobs:
             echo "| Admin console | https://admin.${INSTANCE}.staging.all-hands-testing.dev:30000 |"
             echo "| App | https://app.${INSTANCE}.staging.all-hands-testing.dev |"
           } >> "$GITHUB_STEP_SUMMARY"
-
-  e2e:
-    name: E2E Replicated
-    needs: deploy
-    uses: ./.github/workflows/e2e-replicated.yml
-    with:
-      instance: ${{ inputs.instance }}

--- a/.github/workflows/release-replicated-beta.yml
+++ b/.github/workflows/release-replicated-beta.yml
@@ -171,3 +171,14 @@ jobs:
       kots_cursor: ${{ needs.beta.outputs.kots_cursor }}
     secrets:
       kots_password: ${{ secrets.KOTS_PASSWORD_BETA }}
+
+  e2e:
+    name: E2E Replicated
+    needs: deploy
+    uses: ./.github/workflows/e2e-replicated.yml
+    with:
+      instance: beta
+    # A called workflow gets no secrets unless the call site passes them, and
+    # they reach only the workflow called directly. Nesting this under the
+    # deploy workflow left the environment's Argo token empty at dispatch.
+    secrets: inherit

--- a/.github/workflows/release-replicated-unstable.yml
+++ b/.github/workflows/release-replicated-unstable.yml
@@ -107,3 +107,14 @@ jobs:
       kots_cursor: ${{ needs.release.outputs.kots_cursor }}
     secrets:
       kots_password: ${{ secrets.KOTS_PASSWORD_UNSTABLE }}
+
+  e2e:
+    name: E2E Replicated
+    needs: deploy
+    uses: ./.github/workflows/e2e-replicated.yml
+    with:
+      instance: unstable
+    # A called workflow gets no secrets unless the call site passes them, and
+    # they reach only the workflow called directly. Nesting this under the
+    # deploy workflow left the environment's Argo token empty at dispatch.
+    secrets: inherit

--- a/scripts/test_deploy_replicated_e2e_trigger.py
+++ b/scripts/test_deploy_replicated_e2e_trigger.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 import yaml
 
 
@@ -7,6 +8,10 @@ ROOT = Path(__file__).resolve().parents[1]
 DEPLOY_WORKFLOW = ROOT / ".github/workflows/deploy-replicated.yml"
 E2E_WORKFLOW = ROOT / ".github/workflows/e2e-replicated.yml"
 TEST_WORKFLOW = ROOT / ".github/workflows/test-scripts.yml"
+RELEASE_WORKFLOWS = {
+    "unstable": ROOT / ".github/workflows/release-replicated-unstable.yml",
+    "beta": ROOT / ".github/workflows/release-replicated-beta.yml",
+}
 
 
 def load_workflow(path: Path):
@@ -71,16 +76,26 @@ def test_e2e_workflow_never_retries_the_dispatch():
     assert "--retry" not in trigger_step()["run"]
 
 
-def test_deploy_replicated_calls_e2e_only_after_a_successful_deploy():
-    workflow = load_workflow(DEPLOY_WORKFLOW)
-    e2e = workflow["jobs"]["e2e"]
+@pytest.mark.parametrize("instance", sorted(RELEASE_WORKFLOWS))
+def test_each_release_calls_e2e_only_after_a_successful_deploy(instance):
+    """Called directly by the release workflow, not nested under the deploy.
 
-    assert e2e == {
+    Secrets reach only the workflow a call site names, so a job nested one
+    level further down saw an empty token however the environment was set up.
+    """
+    workflow = load_workflow(RELEASE_WORKFLOWS[instance])
+
+    assert workflow["jobs"]["e2e"] == {
         "name": "E2E Replicated",
         "needs": "deploy",
         "uses": "./.github/workflows/e2e-replicated.yml",
-        "with": {"instance": "${{ inputs.instance }}"},
+        "with": {"instance": instance},
+        "secrets": "inherit",
     }
+
+
+def test_deploy_replicated_does_not_call_e2e():
+    assert "e2e" not in load_workflow(DEPLOY_WORKFLOW)["jobs"]
 
 
 def test_workflow_contract_runs_when_either_workflow_changes():


### PR DESCRIPTION
## Why

The E2E trigger dispatched with an empty token and Argo rejected it:

```
env:
  ARGO_TOKEN: 
curl: (22) The requested URL returned error: 401
{"code":16,"message":"token not valid..."}
```

A called workflow receives no secrets unless its call site passes them, and they reach only the workflow named directly by that call site. The trigger sat two levels down, release -> deploy-replicated -> e2e-replicated, so `secrets.ARGO_WORKFLOWS_E2E_TOKEN` was empty no matter how the environment was configured. Declaring `environment:` on the job is not enough on its own.

The outer hop cannot use `secrets: inherit`, because it maps `KOTS_PASSWORD_<INSTANCE>` to `kots_password` explicitly and a call site cannot do both. So each release workflow now calls the trigger itself, one level down, with `secrets: inherit`. The deploy workflow goes back to deploying.

Behaviour is unchanged otherwise: E2E still runs only after a successful deploy, against the same instance.

## Validation

Measured on a scratch branch against this repo's real `e2e-replicated` environment, printing secret lengths rather than values, with a second known 10-character secret as a control:

| Shape | token | control |
| --- | --- | --- |
| job declared in the caller | 965 | 10 |
| called workflow, `secrets: inherit` | 965 | 10 |
| called workflow, no inherit | 0 | 0 |
| two levels, inherit on the inner call only | 0 | 0 |

The second row is the shape this PR adopts. The last row is why inherit could not simply be added where the call already was. The scratch branch, its temporary environment branch policy, and the control secret have all been deleted.

`uv run --with pyyaml --with pytest pytest scripts/test_deploy_replicated_e2e_trigger.py` passes, 8 tests, with the call-site contract now asserted per release workflow including `secrets: inherit`, plus a test that the deploy workflow no longer calls E2E.

_This PR was drafted by an AI agent on behalf of the user._
