### PR TITLE
feat(e2e): PLTF-3514 dispatch e2e test revision bumps to saas-deploy

### DIFF
--- a/.github/workflows/dispatch-e2e-test-revision-bump.yml
+++ b/.github/workflows/dispatch-e2e-test-revision-bump.yml
@@ -1,0 +1,62 @@
+# Tells OpenHands/saas-deploy to bump the e2e test revision its openhands-e2e
+# development chart is pinned to, whenever a change under e2e_tests/ lands here.
+#
+# This repo is public and saas-deploy is private, so we cannot call a reusable
+# workflow over there. We send a repository_dispatch instead. The payload is
+# provenance and requested state, not authorisation: saas-deploy authorises on
+# this dispatcher App's identity and opens a pull request a human still merges.
+#
+# See docs/automated-e2e-test-revision-bumps.md.
+
+name: Dispatch e2e test revision bump
+
+run-name: "Dispatch e2e test revision bump (${{ github.sha }})"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'e2e_tests/**'
+  workflow_dispatch:
+
+concurrency:
+  group: dispatch-e2e-test-revision-bump
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch e2e test revision bump
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    # Holds the dispatcher App credentials, and is restricted to main so a run
+    # from any other ref cannot reach them.
+    environment: e2e-test-revision-bump-dispatcher
+    steps:
+      - name: Mint saas-deploy dispatcher token
+        id: dispatcher-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.E2E_TEST_REVISION_BUMP_DISPATCHER_APP_ID }}
+          private-key: ${{ secrets.E2E_TEST_REVISION_BUMP_DISPATCHER_APP_PRIVATE_KEY }}
+          owner: OpenHands
+          repositories: saas-deploy
+          permission-contents: write
+
+      - name: Dispatch bump-e2e-test-revision
+        env:
+          GH_TOKEN: ${{ steps.dispatcher-token.outputs.token }}
+          REVISION: ${{ github.sha }}
+          SOURCE_REPO: ${{ github.repository }}
+        run: |
+          gh api \
+            --method POST \
+            /repos/OpenHands/saas-deploy/dispatches \
+            -f event_type=bump-e2e-test-revision \
+            -f "client_payload[revision]=${REVISION}" \
+            -f "client_payload[environment]=development" \
+            -f "client_payload[source-repo]=${SOURCE_REPO}"
+
+          echo "Requested a development e2e test revision bump to ${REVISION}." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/automated-e2e-test-revision-bumps.md
+++ b/docs/automated-e2e-test-revision-bumps.md
@@ -1,0 +1,57 @@
+# Automated e2e test revision bumps
+
+`OpenHands/saas-deploy` runs the Playwright suite in `e2e_tests/` from a pinned
+commit of this repository. When a change under `e2e_tests/` lands on `main`, this
+repo notifies `saas-deploy` so that pin can move without anyone editing it by
+hand.
+
+The sender lives in
+[`.github/workflows/dispatch-e2e-test-revision-bump.yml`](../.github/workflows/dispatch-e2e-test-revision-bump.yml):
+
+1. A push to `main` touching `e2e_tests/**` starts the workflow.
+2. The job mints a token for the dedicated e2e test revision dispatcher GitHub
+   App.
+3. The job sends `repository_dispatch` to `OpenHands/saas-deploy` with
+   `event_type: bump-e2e-test-revision`.
+
+`saas-deploy` owns the edit. Its receiver opens or updates one rolling pull
+request that moves the pin to the newest revision. Merging that pull request is
+what decides the revision the e2e runners use, so a revision is skipped by
+leaving the pull request unmerged rather than by gating this dispatch.
+
+## Dispatch payload
+
+| Field | Value |
+| ----- | ----- |
+| `revision` | The commit pushed to `main`, as a full 40-character SHA. |
+| `environment` | `development` |
+| `source-repo` | `OpenHands/OpenHands-Cloud` |
+
+The receiver treats the payload as requested state and provenance, not as its
+authorization boundary. Authorization comes from the dispatcher's GitHub App
+identity on the `saas-deploy` side.
+
+## Trust boundary and prerequisites
+
+Create the dispatcher with the generic App helper:
+
+```bash
+uv run scripts/create_chart_bump_dispatcher/create_chart_bump_dispatcher.py \
+  --org OpenHands \
+  --app-name e2e-test-revision-bump-dispatcher
+```
+
+Install the App only on `OpenHands/saas-deploy`. It needs only `contents: write`
+and `metadata: read`, and it must not be a `saas-deploy` ruleset bypass actor.
+The receiver validates both the bot login and its numeric user ID before minting
+any write token, so record the ID when the App is created.
+
+Store these environment-scoped secrets in the
+`e2e-test-revision-bump-dispatcher` GitHub Environment:
+
+- `E2E_TEST_REVISION_BUMP_DISPATCHER_APP_ID`
+- `E2E_TEST_REVISION_BUMP_DISPATCHER_APP_PRIVATE_KEY`
+
+Restrict that Environment to `main`. This sender is branch-triggered, so a branch
+policy keeps the credentials out of reach of runs from any other ref. The chart
+bump dispatchers cannot do this because they run from tags.


### PR DESCRIPTION
## Why

`OpenHands/saas-deploy` runs the Playwright suite in `e2e_tests/` from a pinned commit of this repository, and today someone edits that pin by hand every time the suite changes, so it drifts. This adds the sending half of an automated path: a push to `main` touching `e2e_tests/**` sends a `repository_dispatch` to `saas-deploy`, which opens a rolling pull request moving the pin. Merging that pull request is what decides the revision the e2e runners use.

Dispatching is the same shape the staging and development chart bumps already use. The payload carries requested state and provenance, and `saas-deploy` authorises on the dispatcher App's identity.

Also adds `docs/automated-e2e-test-revision-bumps.md`, alongside the two existing chart bump documents, covering the payload, the trust boundary, and the App setup.

## Validation

- **Workflow syntax** — `actionlint` passes on the new workflow with no findings.
- **Credentials in place** — the `e2e-test-revision-bump-dispatcher` Environment exists

This PR was drafted by an AI agent on behalf of the user.
