### PR TITLE
ci: block the openhands release PR on a red unstable E2E [ref PLTF-3540]

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,225 @@
+name: Release gate (unstable E2E)
+
+# Blocks the openhands release-please PR when the latest unstable E2E is not green.
+# Enforce by adding the `release-gate` context to the main ruleset.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  workflow_run:
+    workflows: ["Release Replicated to Unstable"]
+    types: [completed]
+  # Scheduled Argo runs fire no GitHub event, so nothing else would re-evaluate
+  # a blocked release PR when the signal recovers.
+  schedule:
+    - cron: "*/15 * * * *"
+
+permissions: {}
+
+env:
+  RELEASE_PR_BRANCH: "release-please--branches--main--components--openhands"
+  OVERRIDE_LABEL: "override-e2e-gate"
+  ARGO_NAMESPACE: "openhands-e2e"
+  ARGO_BASE: "https://workflows.dev.all-hands.dev"
+  E2E_INSTANCE: "unstable"
+  # Must stay under Argo's 24h ttlStrategy, or aged-out runs read as "no run".
+  E2E_MAX_AGE_HOURS: "20"
+
+jobs:
+  release-gate:
+    name: release-gate
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.ref == 'release-please--branches--main--components--openhands' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    # No `environment:` - e2e-replicated rejects refs/pull/N/merge, so the gate
+    # token is repo-level. Safe: it is read-only, no submit, no Secrets.
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Evaluate release gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ARGO_GATE_TOKEN: ${{ secrets.ARGO_WORKFLOWS_GATE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "### Release gate (unstable E2E)"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Scheduled and deploy-triggered runs share this name prefix, so one
+          # list covers both. Job names would miss the scheduled ones entirely.
+          listing=$(curl --fail-with-body --silent --show-error --max-time 30 \
+            --header "Authorization: Bearer ${ARGO_GATE_TOKEN}" \
+            "${ARGO_BASE}/api/v1/workflows/${ARGO_NAMESPACE}?listOptions.labelSelector=workflows.argoproj.io/phase!=Running") || {
+              echo "::error::could not reach Argo to read the ${E2E_INSTANCE} E2E result"
+              echo "| E2E result | **Argo unreachable** — blocked |" >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            }
+
+          signal=$(jq -r --arg prefix "openhands-e2e-${E2E_INSTANCE}-" '
+            [ (.items // [])[]
+              | select(.metadata.name | startswith($prefix))
+              | select(.status.finishedAt != null and .status.finishedAt != "")
+              | {name: .metadata.name, phase: .status.phase, finished: .status.finishedAt}
+            ]
+            | sort_by(.finished)
+            | last
+            | if . == null then empty else [.name, .phase, .finished] | @tsv end
+          ' <<<"$listing")
+
+          if [ -z "$signal" ]; then
+            echo "::error::no finished openhands-e2e-${E2E_INSTANCE}-* workflow found in Argo"
+            {
+              echo "| E2E result | **no run** — blocked |"
+              echo ""
+              echo "Argo keeps finished runs for 24h and has no archive database, so this also means no run has completed in the last day. Check the CronWorkflow: \`kubectl -n openhands-e2e get cronworkflow openhands-e2e-unstable-scheduled\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          IFS=$'\t' read -r wf_name E2E_CONCLUSION run_completed <<<"$signal"
+          run_url="${ARGO_BASE}/workflows/${ARGO_NAMESPACE}/${wf_name}"
+          # Normalise Argo's phase to the success word the rest of this uses.
+          [ "$E2E_CONCLUSION" = "Succeeded" ] && E2E_CONCLUSION=success
+
+          now=$(date -u +%s)
+          signal_epoch=$(date -u -d "$run_completed" +%s)
+          age_h=$(( (now - signal_epoch) / 3600 ))
+          {
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Latest E2E result | \`${E2E_CONCLUSION}\` |"
+            echo "| Workflow | [\`${wf_name}\`](${run_url}) |"
+            echo "| Completed | ${run_completed} |"
+            echo "| Age | ${age_h}h (max ${E2E_MAX_AGE_HOURS}h) |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          gate_reason=""
+          if [ "$E2E_CONCLUSION" != "success" ]; then
+            gate_reason="latest ${E2E_INSTANCE} E2E finished ${E2E_CONCLUSION}"
+          elif [ "$age_h" -gt "$E2E_MAX_AGE_HOURS" ]; then
+            gate_reason="latest ${E2E_INSTANCE} E2E is stale (${age_h}h old, max ${E2E_MAX_AGE_HOURS}h)"
+          else
+            echo "Latest ${E2E_INSTANCE} E2E is green and fresh (${age_h}h old)."
+            exit 0
+          fi
+
+          labels=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/labels" --jq '.[].name')
+          if ! grep -Fxq "$OVERRIDE_LABEL" <<<"$labels"; then
+            echo "::error::${gate_reason} — blocking the release PR. ${run_url}"
+            exit 1
+          fi
+
+          events=$(gh api --paginate --slurp \
+            "repos/${REPO}/issues/${PR_NUMBER}/events?per_page=100")
+          applier_when=$(jq -r --arg label "$OVERRIDE_LABEL" '
+            [.[][] | select(.event == "labeled" and .label.name == $label)]
+            | last
+            | if . == null then empty else [.actor.login, .created_at] | @tsv end
+          ' <<<"$events")
+          IFS=$'\t' read -r applier override_when <<<"$applier_when"
+
+          if [ -z "${applier:-}" ] || [ -z "${override_when:-}" ]; then
+            echo "::error::${OVERRIDE_LABEL} is present but no event records who applied it"
+            exit 1
+          fi
+
+          override_epoch=$(date -u -d "$override_when" +%s)
+          if [ "$override_epoch" -le "$signal_epoch" ]; then
+            echo "::error::override by ${applier} at ${override_when} predates the signal at ${run_completed}; remove and reapply ${OVERRIDE_LABEL} to authorize this result"
+            exit 1
+          fi
+
+          perm=$(gh api "repos/${REPO}/collaborators/${applier}/permission" \
+            --jq '.permission' 2>/dev/null || echo "none")
+          case "$perm" in
+            admin|write|maintain) ;;
+            *)
+              echo "::error::${OVERRIDE_LABEL} was applied by ${applier}, who lacks write permission (${perm})"
+              exit 1
+              ;;
+          esac
+
+          {
+            echo ""
+            echo "> [!WARNING]"
+            echo "> **E2E release gate overridden.**"
+            echo ">"
+            echo "> ${gate_reason}; override applied by \`${applier}\` (\`${perm}\`) at ${override_when}."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          marker="<!-- release-gate-override:${override_when} -->"
+          comments=$(gh api --paginate --slurp \
+            "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100")
+          already_recorded=$(jq -r --arg marker "$marker" \
+            'any(.[][]; .body | contains($marker))' <<<"$comments")
+          if [ "$already_recorded" != "true" ]; then
+            body=$(printf '%s\n\n%s\n\n%s' \
+              "🟡 **E2E release gate overridden** by \`${applier}\` (\`${perm}\`) at ${override_when}. ${gate_reason}; unstable → beta is allowed for this signal only." \
+              "$marker" \
+              "_Posted automatically by an AI-assisted workflow on behalf of the OpenHands-Cloud maintainers._")
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body"
+          fi
+
+          echo "Override honored for the signal completed at ${run_completed}."
+
+  refresh-release-gate:
+    name: Refresh release gate
+    if: github.event_name == 'workflow_run' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Rerun the open release PR gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          pr=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" | jq -c \
+            --arg repo "$REPO" --arg branch "$RELEASE_PR_BRANCH" '
+              first(.[] | select(
+                .base.ref == "main" and
+                .head.ref == $branch and
+                .head.repo.full_name == $repo
+              )) // empty
+            ')
+          if [ -z "$pr" ]; then
+            echo "No open openhands release PR; nothing to refresh."
+            exit 0
+          fi
+
+          sha=$(jq -r '.head.sha' <<<"$pr")
+          gate_run=$(gh api \
+            "repos/${REPO}/actions/workflows/release-gate.yml/runs?event=pull_request&per_page=100" \
+            | jq -c --arg sha "$sha" \
+              'first(.workflow_runs[] | select(.head_sha == $sha)) // empty')
+          if [ -z "$gate_run" ]; then
+            echo "::warning::No release-gate run found for release PR head ${sha}."
+            exit 0
+          fi
+
+          run_id=$(jq -r '.id' <<<"$gate_run")
+          status=$(jq -r '.status' <<<"$gate_run")
+          if [ "$status" != "completed" ]; then
+            echo "Release gate ${run_id} is ${status}; leaving it alone."
+            exit 0
+          fi
+          # A rerun request races the run finishing, so a 403 here is expected
+          # and must not redden a job that fires every 15 minutes.
+          if gh api --method POST "repos/${REPO}/actions/runs/${run_id}/rerun"; then
+            echo "Rerunning release gate ${run_id} for release PR head ${sha}."
+          else
+            echo "::notice::Release gate ${run_id} could not be rerun right now."
+          fi

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -16,6 +16,11 @@ on:
 
 permissions: {}
 
+defaults:
+  run:
+    # Some reasonable default args to any bash invocation usage
+    shell: bash --noprofile --norc -euo pipefail {0}
+
 env:
   RELEASE_PR_BRANCH: "release-please--branches--main--components--openhands"
   OVERRIDE_LABEL: "override-e2e-gate"
@@ -33,7 +38,7 @@ jobs:
       github.event.pull_request.base.ref == 'main' &&
       github.event.pull_request.head.ref == 'release-please--branches--main--components--openhands' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # No `environment:` - e2e-replicated rejects refs/pull/N/merge, so the gate
     # token is repo-level. Safe: it is read-only, no submit, no Secrets.
     permissions:
@@ -48,8 +53,6 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           ARGO_GATE_TOKEN: ${{ secrets.ARGO_WORKFLOWS_GATE_TOKEN }}
         run: |
-          set -euo pipefail
-
           {
             echo "### Release gate (unstable E2E)"
             echo ""
@@ -174,7 +177,7 @@ jobs:
   refresh-release-gate:
     name: Refresh release gate
     if: github.event_name == 'workflow_run' || github.event_name == 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
       contents: read
@@ -185,8 +188,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          set -euo pipefail
-
           pr=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" | jq -c \
             --arg repo "$REPO" --arg branch "$RELEASE_PR_BRANCH" '
               first(.[] | select(

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -11,6 +11,7 @@ on:
       - 'replicated/**'
       - '.github/workflows/deploy-replicated.yml'
       - '.github/workflows/e2e-replicated.yml'
+      - '.github/workflows/release-gate.yml'
       - '.github/workflows/publish-release-charts.yml'
       - '.github/workflows/test-scripts.yml'
 

--- a/scripts/test_deploy_replicated_e2e_trigger.py
+++ b/scripts/test_deploy_replicated_e2e_trigger.py
@@ -7,6 +7,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 DEPLOY_WORKFLOW = ROOT / ".github/workflows/deploy-replicated.yml"
 E2E_WORKFLOW = ROOT / ".github/workflows/e2e-replicated.yml"
+RELEASE_GATE_WORKFLOW = ROOT / ".github/workflows/release-gate.yml"
 TEST_WORKFLOW = ROOT / ".github/workflows/test-scripts.yml"
 RELEASE_WORKFLOWS = {
     "unstable": ROOT / ".github/workflows/release-replicated-unstable.yml",
@@ -170,7 +171,101 @@ def test_deploy_replicated_does_not_call_e2e():
     assert "e2e" not in load_workflow(DEPLOY_WORKFLOW)["jobs"]
 
 
-def test_workflow_contract_runs_when_either_workflow_changes():
+def test_workflow_contract_runs_when_related_workflows_change():
     text = TEST_WORKFLOW.read_text(encoding="utf-8")
     assert "- '.github/workflows/deploy-replicated.yml'" in text
     assert "- '.github/workflows/e2e-replicated.yml'" in text
+    assert "- '.github/workflows/release-gate.yml'" in text
+
+
+def release_gate_command():
+    workflow = load_workflow(RELEASE_GATE_WORKFLOW)
+    return workflow["jobs"]["release-gate"]["steps"][0]["run"]
+
+
+def test_incident_io_is_not_wired_into_ci():
+    # Paging belongs to the Argo exit handler in saas-deploy: it sees scheduled
+    # runs, which CI cannot, and it cannot redden the E2E verdict.
+    for path in [E2E_WORKFLOW, RELEASE_GATE_WORKFLOW]:
+        assert "incident.io" not in path.read_text(), path
+
+
+def test_release_gate_reads_the_result_from_argo():
+    # Most unstable runs are scheduled and have no GitHub run at all, so job
+    # names cannot be the signal - the gate would be blind to them.
+    command = release_gate_command()
+    assert "/api/v1/workflows/${ARGO_NAMESPACE}" in command
+    assert "openhands-e2e-${E2E_INSTANCE}-" in command
+    assert ".status.finishedAt" in command
+    assert "sort_by(.finished)" in command
+    # No trace of the old GitHub-job-name matching.
+    assert "actions/workflows/" not in command
+    assert 'startswith($name + " /")' not in command
+
+
+def test_release_gate_uses_a_read_only_argo_token():
+    # The submit token is environment-scoped and can create runs; the gate must
+    # not use it. The read-only token is repo-level because the e2e-replicated
+    # environment admits only main and openhands/*, which a pull_request job
+    # can never satisfy.
+    workflow = load_workflow(RELEASE_GATE_WORKFLOW)
+    job = workflow["jobs"]["release-gate"]
+    assert "environment" not in job
+    step = job["steps"][0]
+    assert step["env"]["ARGO_GATE_TOKEN"] == (
+        "${{ secrets.ARGO_WORKFLOWS_GATE_TOKEN }}"
+    )
+    assert "ARGO_WORKFLOWS_E2E_TOKEN" not in yaml.safe_dump(workflow)
+
+
+def test_release_gate_staleness_window_fits_inside_argo_retention():
+    # Argo has no archive database here; a finished run is deleted after its
+    # 24h TTL. A window at or past that blocks on runs that merely aged out.
+    workflow = load_workflow(RELEASE_GATE_WORKFLOW)
+    assert int(workflow["env"]["E2E_MAX_AGE_HOURS"]) < 24
+
+
+def test_release_gate_scopes_the_release_please_branch():
+    workflow = load_workflow(RELEASE_GATE_WORKFLOW)
+    job = workflow["jobs"]["release-gate"]
+
+    assert "github.event.pull_request.head.ref" in str(job)
+    assert "github.event.pull_request.base.ref" in str(job)
+    assert "github.event.pull_request.head.repo.full_name" in str(job)
+    assert "autorelease: openhands pending" not in release_gate_command()
+
+
+def test_release_gate_refreshes_on_a_schedule():
+    # A scheduled Argo run fires no GitHub event, so workflow_run alone would
+    # leave a blocked release PR red until someone pushed to it.
+    workflow = load_workflow(RELEASE_GATE_WORKFLOW)
+    triggers = workflow[True]
+    assert "schedule" in triggers
+    assert triggers["schedule"][0]["cron"]
+    refresh = workflow["jobs"]["refresh-release-gate"]
+    assert "schedule" in refresh["if"]
+
+
+def test_release_gate_refreshes_after_unstable_e2e_completes():
+    workflow = load_workflow(RELEASE_GATE_WORKFLOW)
+    triggers = workflow[True]
+
+    assert triggers["workflow_run"] == {
+        "workflows": ["Release Replicated to Unstable"],
+        "types": ["completed"],
+    }
+    refresh = workflow["jobs"]["refresh-release-gate"]
+    assert refresh["permissions"] == {
+        "actions": "write",
+        "contents": "read",
+        "pull-requests": "read",
+    }
+    assert "/rerun" in refresh["steps"][0]["run"]
+
+
+def test_release_gate_override_must_postdate_the_e2e_signal():
+    command = release_gate_command()
+
+    assert "override_epoch" in command
+    assert "signal_epoch" in command
+    assert 'override_epoch" -le "$signal_epoch' in command


### PR DESCRIPTION
Promotion from unstable to beta happens by merging the openhands release-please PR, and nothing checks whether unstable is actually green first.

Adds `release-gate.yml`, a check scoped to that one PR.

### Reading the result from Argo, not from GitHub

Most unstable runs will be scheduled by a CronWorkflow in saas-deploy ([#995](https://github.com/OpenHands/saas-deploy/pull/995)), and **a scheduled run has no GitHub run at all** — so a gate inspecting job names would be blind to the majority of runs and would gate on the rarer deploy-triggered subset. One `list` call over `openhands-e2e-unstable-*` covers both trigger paths, because scheduled (`-scheduled-<epoch>`) and deploy-bound (`-gh-<run id>-<attempt>`) submits share the prefix. It also survives a job being renamed, which name-matching does not.

### Blocks on "no run", not just on red

Argo has no archive database here, so a finished Workflow lives only as long as its 24h TTL. The staleness window is **20h**, deliberately inside that: a wider window would block on runs that merely aged out. A missing signal is treated as a failure — a badge renders its last conclusion forever, so "the suite stopped running" has to be a blocking state or it's invisible.

### Override is attributable and single-use

`override-e2e-gate` is honoured only when its newest `labeled` event **postdates the failing signal** and its applier has write access. Re-labelling is required for each new red signal, and the gate posts a comment recording who overrode what.

### Scoping

The release PR is identified by its same-repository head branch (`release-please--branches--main--components--openhands`), not by a label anyone can remove. Non-matching PRs skip the job, which satisfies a required check without a `paths:` filter.

A 15-minute `schedule` and a `workflow_run` trigger re-run the gate for an open release PR, so a scheduled recovery clears it without anyone pushing. The refresh job exits immediately when no release PR is open.

### Depends on

- saas-deploy [#996](https://github.com/OpenHands/saas-deploy/pull/996) for `ARGO_WORKFLOWS_GATE_TOKEN`. Set it **repo-level, not scoped to `e2e-replicated`** — the gate job runs on `refs/pull/N/merge`, which that environment does not admit, so an environment-scoped secret reads as empty and blocks every release PR on "Argo unreachable". Safe at repo level: the token is read-only (`list`, `get` on workflows in one namespace).
- saas-deploy [#995](https://github.com/OpenHands/saas-deploy/pull/995) for the schedule, so a quiet week still produces a signal.

**Not enforcing on merge.** Add the `release-gate` context to the main ruleset only after watching it against real release PRs.

Rebased onto main post-#1228 and squashed: the earlier six commits included a wait-and-page implementation that a later commit removed, and `e2e-replicated.yml` now takes main's version unchanged. `scripts/test_deploy_replicated_e2e_trigger.py` 22 pass. `actionlint` clean.

