### PR TITLE
feat(agent-server): bump image tag to 1.43.1-python

### DIFF
--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -1,7 +1,7 @@
 # Agent-server image the loader pre-pulls onto nodes; keep tag in sync with the sandbox runtime.
 image:
   repository: ghcr.io/openhands/agent-server
-  tag: 1.41.0-python
+  tag: 1.43.1-python
   pullPolicy: Always
 
 resources:

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -321,7 +321,7 @@ global:
   # global wins; this default only applies when rendering the subchart alone.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.41.0-python
+    tag: 1.43.1-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1312,7 +1312,7 @@ global:
   # either of those for per-use exceptions; set it here to move them together.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.41.0-python
+    tag: 1.43.1-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1298,9 +1298,9 @@ spec:
           required: true
         - name: custom_sandbox_image_tag
           title: Sandbox Image Tag
-          help_text: Image tag, e.g. 1.41.0-python
+          help_text: Image tag, e.g. 1.43.1-python
           type: text
-          default: "1.41.0-python"
+          default: "1.43.1-python"
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: true
         - name: custom_sandbox_image_registry_server


### PR DESCRIPTION
## Description

Bumps the sandbox `agent-server` image from `1.41.0-python` to `1.43.1-python` so it matches the SDK that Enterprise Server already ships.

`enterprise-server` 1.56.0 (the tag pinned in chart 0.54.0) pins `openhands-sdk`, `openhands-agent-server`, and `openhands-tools` at `==1.43.1`, but `global.agentServerImage.tag` has been on `1.41.0-python` since #1045 (Aug 11). That left the control plane on SDK 1.43.1 while sandboxes ran 1.41.0, so agent-server-side changes in 1.42.0 through 1.43.1 were not reaching sandboxes, including `base_state.json` as the single source of truth (software-agent-sdk#4440), conversation-summary caching (#4483), and `POST /file/create_directory` (#4482).

Same four files as #1045:

- `charts/image-loader/values.yaml`
- `charts/openhands/values.yaml`
- `charts/openhands/charts/runtime-api/values.yaml`
- `replicated/config.yaml` (`custom_sandbox_image_tag` default and help text)

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

Verified locally:

- `ghcr.io/openhands/agent-server:1.43.1-python` exists in GHCR (registry manifest request returns 200)
- `helm unittest` passes: `charts/openhands` (108 tests), `charts/openhands/charts/runtime-api` (12), `charts/image-loader` (1)
- `helm lint` clean on both charts, and `helm template` renders `ghcr.io/openhands/agent-server:1.43.1-python` in the openhands chart and in the image-loader DaemonSet
- `pytest scripts/test_keycloak_realm_template.py scripts/test_openhands_secrets_template.py scripts/test_replicated_resolver_label.py` — 18 passed

Not tested: a live cluster upgrade. This only moves the default tag, so existing `global.agentServerImage.tag` overrides still take precedence. No new or renamed values, so no chart README change is needed.

## Additional Notes

This is a `feat:` commit, so release-please will cut openhands `0.55.0` and image-loader `0.2.0`. Relevant to the pending Stable promotion: 0.54.0 still carries the version skew, so promoting 0.55.0 instead would ship the matched server/sandbox pair.
