### PR TITLE
ci: check the agent-server tag against the enterprise SDK pin

### DIFF
--- a/.github/workflows/check-agent-server-sync.yml
+++ b/.github/workflows/check-agent-server-sync.yml
@@ -1,0 +1,69 @@
+name: Check agent-server sync
+
+# Blocking check on release-please PRs: the agent-server image tag the charts
+# pin must match the software-agent-sdk version the pinned enterprise-server
+# release was built against.
+#
+# The enterprise server imports openhands-agent-server (published from
+# OpenHands/software-agent-sdk) as a client and talks to the agent-server image
+# over HTTP in every sandbox. Client and server are the same codebase, so a
+# version split is a protocol split. Nothing links the two pins, so a bump to
+# either one alone silently ships that split -- this catches it at the release
+# PR, the last point before the chart is published.
+#
+# See scripts/check_agent_server_sync.py for the pins it reads.
+
+on:
+  # Deliberately unfiltered by path. A release PR for a chart that does not
+  # touch charts/openhands (openhands-secrets, crd-check) still publishes the
+  # release line this invariant covers, and an always-triggered workflow can be
+  # a required check without leaving skipped PRs pending forever.
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-agent-server-sync:
+    name: Check agent-server sync
+    # release-please parks each chart's pending release PR on its own
+    # `release-please--branches--<base>--components--<chart>` branch, so the
+    # head ref identifies them across every release line (main and the
+    # release/X.Y maintenance branches alike). On any other PR the job skips,
+    # which reports as success.
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.head_ref, 'release-please--')
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      # OpenHands/enterprise is public, so the job's own read-only GITHUB_TOKEN
+      # can read its tags and pyproject.toml. It is passed only to raise the
+      # API rate limit above the unauthenticated one.
+      - name: Compare chart agent-server tag against the enterprise SDK pin
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          status=0
+          uv run scripts/check_agent_server_sync.py > report.txt 2>&1 || status=$?
+          cat report.txt
+          {
+            echo '### Agent-server / software-agent-sdk pin sync'
+            echo
+            echo '```'
+            cat report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"

--- a/scripts/check_agent_server_sync.py
+++ b/scripts/check_agent_server_sync.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["PyYAML"]
+# ///
+"""Fail when the charts' agent-server image tag drifts from the SDK the pinned
+enterprise-server release was built against.
+
+The enterprise server imports the agent-server as a Python package
+(``openhands-agent-server``, published from OpenHands/software-agent-sdk) and
+talks to it over HTTP in every sandbox. The client the app ships and the server
+image the sandbox runs are the same codebase, so they have to be the same
+version: a mismatch is a protocol mismatch.
+
+Two independent pins encode that pair, and nothing links them:
+
+  * ``charts/openhands/values.yaml`` -> ``image.tag`` -- the enterprise-server
+    release, which is a tag in the OpenHands/enterprise repo.
+  * ``global.agentServerImage.tag`` (plus the image-loader's ``image.tag``) --
+    the agent-server image the sandbox runs.
+
+So we resolve the first pin to its commit on the enterprise remote, read the
+``openhands-*`` versions that release pinned in its ``pyproject.toml``, and
+require the second pin to match. Bumping one without the other is the failure
+this catches.
+
+Run it from the chart repo root:
+
+    uv run scripts/check_agent_server_sync.py
+
+Exit status is 0 when the pins agree and 1 when they do not (or when a pin
+cannot be read, the enterprise tag does not exist, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tomllib
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+# Repo holding the enterprise-server source, in owner/name form. Its git tags
+# are the enterprise-server release versions the chart's `image.tag` names.
+DEFAULT_ENTERPRISE_REPO = "OpenHands/enterprise"
+
+# Packages published from OpenHands/software-agent-sdk that the enterprise
+# server pins. They move together on every SDK bump, and the agent-server image
+# is tagged with that same version, so all of them must agree with the chart.
+SDK_PACKAGES = ("openhands-agent-server", "openhands-sdk", "openhands-tools")
+
+API_ROOT = "https://api.github.com"
+
+# `1.43.1-python` -> the tag is the SDK version plus an image-variant suffix.
+_VARIANT_SUFFIX_RE = re.compile(r"^(?P<version>[^-]+)(?:-(?P<variant>.+))?$")
+
+# `sha-2809208` tags are built from a commit rather than a release, so there is
+# no tag to look up on the remote -- the commit itself is the ref.
+_SHA_TAG_RE = re.compile(r"^sha-(?P<sha>[0-9a-f]{7,40})$")
+
+# `openhands-agent-server[extra]==1.43.1 ; python_version >= "3.12"`
+_REQUIREMENT_RE = re.compile(
+    r"^(?P<name>[A-Za-z0-9._-]+)\s*(?:\[[^\]]*\])?\s*==\s*(?P<version>[^\s,;]+)"
+)
+
+
+class CheckError(Exception):
+    """A user-facing failure: unreadable pin, missing tag, network error, ..."""
+
+
+@dataclass(frozen=True)
+class Pin:
+    """A single scalar in a chart values file, addressed by its key path."""
+
+    path: Path
+    keys: tuple[str, ...]
+
+    def __str__(self) -> str:
+        return f"{self.path} -> .{'.'.join(self.keys)}"
+
+
+# The enterprise-server release the chart deploys.
+ENTERPRISE_SERVER_PIN = Pin(Path("charts/openhands/values.yaml"), ("image", "tag"))
+
+# Every place the agent-server image tag is written down. They are separate
+# files with no shared default, so they can drift from each other as well as
+# from the SDK, and all of them are checked.
+AGENT_SERVER_PINS = (
+    Pin(
+        Path("charts/openhands/values.yaml"),
+        ("global", "agentServerImage", "tag"),
+    ),
+    Pin(
+        Path("charts/openhands/charts/runtime-api/values.yaml"),
+        ("global", "agentServerImage", "tag"),
+    ),
+    Pin(Path("charts/image-loader/values.yaml"), ("image", "tag")),
+)
+
+
+def read_pin(repo_root: Path, pin: Pin) -> str:
+    """Return the scalar `pin` addresses, as a string."""
+    full_path = repo_root / pin.path
+    try:
+        document = yaml.safe_load(full_path.read_text())
+    except FileNotFoundError as error:
+        raise CheckError(f"{pin.path}: no such file") from error
+    except yaml.YAMLError as error:
+        raise CheckError(f"{pin.path}: not valid YAML: {error}") from error
+
+    node = document
+    for index, key in enumerate(pin.keys):
+        if not isinstance(node, dict) or key not in node:
+            missing = ".".join(pin.keys[: index + 1])
+            raise CheckError(f"{pin.path}: no value at .{missing}")
+        node = node[key]
+
+    # Only strings, so `tag: 1.10` (a YAML float that str()s back as "1.1")
+    # fails here instead of silently comparing the wrong version.
+    if not isinstance(node, str):
+        raise CheckError(
+            f"{pin} is a {type(node).__name__}, expected a quoted string"
+        )
+    return node
+
+
+def split_variant(tag: str) -> tuple[str, str | None]:
+    """Split an agent-server image tag into its version and variant suffix.
+
+    The image is published once per language runtime (`1.43.1-python`,
+    `1.43.1-golang`, ...) off a single SDK release, so only the leading segment
+    is comparable to a package version.
+    """
+    match = _VARIANT_SUFFIX_RE.match(tag)
+    if match is None:
+        raise CheckError(f"cannot read a version out of agent-server tag {tag!r}")
+    return match.group("version"), match.group("variant")
+
+
+def http_get(url: str, token: str | None, accept: str, missing: str | None = None) -> bytes:
+    """GET `url`, raising CheckError on any non-200 response.
+
+    `missing` replaces the message for a 404, which is the one status with a
+    cause worth naming: the ref we were told to look up is not on the remote.
+    """
+    request = urllib.request.Request(url, headers={"Accept": accept})
+    request.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.read()
+    except urllib.error.HTTPError as error:
+        if error.code == 404 and missing:
+            raise CheckError(missing) from error
+        raise CheckError(f"GET {url} failed: HTTP {error.code} {error.reason}") from error
+    except urllib.error.URLError as error:
+        raise CheckError(f"GET {url} failed: {error.reason}") from error
+
+
+def resolve_enterprise_ref(repo: str, tag: str, token: str | None) -> tuple[str, str]:
+    """Resolve the enterprise-server pin to a commit on the remote.
+
+    Returns the commit sha and a human-readable description of how we got there.
+    A `sha-<commit>` tag names its commit directly; anything else has to exist as
+    a git tag in `repo`.
+    """
+    sha_match = _SHA_TAG_RE.match(tag)
+    if sha_match:
+        sha = sha_match.group("sha")
+        # Round-trip through the remote so a tag naming a commit that was never
+        # pushed (or was force-pushed away) fails here rather than on the fetch.
+        payload = json.loads(
+            http_get(
+                f"{API_ROOT}/repos/{repo}/commits/{sha}",
+                token,
+                "application/vnd.github+json",
+                missing=(
+                    f"{ENTERPRISE_SERVER_PIN} is {tag}, but commit {sha} does not "
+                    f"exist in {repo}"
+                ),
+            )
+        )
+        return payload["sha"], f"commit {sha} in {repo}"
+
+    payload = json.loads(
+        http_get(
+            f"{API_ROOT}/repos/{repo}/git/ref/tags/{tag}",
+            token,
+            "application/vnd.github+json",
+            missing=(
+                f"{ENTERPRISE_SERVER_PIN} is {tag}, but {repo} has no tag {tag}. "
+                f"The enterprise-server pin must name a released version."
+            ),
+        )
+    )
+    obj = payload["object"]
+    if obj["type"] == "tag":
+        # Annotated tag: one more hop to reach the commit.
+        annotated = json.loads(
+            http_get(
+                f"{API_ROOT}/repos/{repo}/git/tags/{obj['sha']}",
+                token,
+                "application/vnd.github+json",
+            )
+        )
+        return annotated["object"]["sha"], f"tag {tag} in {repo}"
+    return obj["sha"], f"tag {tag} in {repo}"
+
+
+def read_sdk_pins(repo: str, ref: str, token: str | None) -> dict[str, str]:
+    """Return the `SDK_PACKAGES` versions `repo` pins at `ref`.
+
+    `[project].dependencies` is the pin uv installs from; the mirrored
+    `[tool.poetry.dependencies]` block is deliberately ignored so there is one
+    source of truth.
+    """
+    raw = http_get(
+        f"{API_ROOT}/repos/{repo}/contents/pyproject.toml?ref={ref}",
+        token,
+        "application/vnd.github.raw+json",
+        missing=f"{repo}@{ref} has no pyproject.toml",
+    )
+    try:
+        pyproject = tomllib.loads(raw.decode())
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+        raise CheckError(f"{repo}@{ref}: pyproject.toml is not valid TOML: {error}") from error
+
+    dependencies = pyproject.get("project", {}).get("dependencies")
+    if not isinstance(dependencies, list):
+        raise CheckError(f"{repo}@{ref}: pyproject.toml has no [project].dependencies list")
+
+    found: dict[str, str] = {}
+    for requirement in dependencies:
+        if not isinstance(requirement, str):
+            continue
+        match = _REQUIREMENT_RE.match(requirement.strip())
+        if match is None:
+            continue
+        name = match.group("name").lower().replace("_", "-")
+        if name in SDK_PACKAGES:
+            found[name] = match.group("version")
+
+    missing = [package for package in SDK_PACKAGES if package not in found]
+    if missing:
+        raise CheckError(
+            f"{repo}@{ref}: pyproject.toml [project].dependencies pins no exact "
+            f"version for {', '.join(missing)}"
+        )
+    return found
+
+
+def single_value(label: str, values: dict[str, str]) -> str:
+    """Return the one distinct value in `values`, or fail describing the split."""
+    distinct = sorted(set(values.values()))
+    if len(distinct) > 1:
+        detail = "\n".join(f"  {key}: {value}" for key, value in sorted(values.items()))
+        raise CheckError(f"{label} disagree with each other:\n{detail}")
+    return distinct[0]
+
+
+def check(repo_root: Path, enterprise_repo: str, token: str | None) -> list[str]:
+    """Run the check. Returns the report lines; raises CheckError on mismatch."""
+    enterprise_tag = read_pin(repo_root, ENTERPRISE_SERVER_PIN)
+
+    chart_tags = {str(pin): read_pin(repo_root, pin) for pin in AGENT_SERVER_PINS}
+    chart_tag = single_value("chart agent-server image tags", chart_tags)
+    chart_version, variant = split_variant(chart_tag)
+
+    ref, ref_description = resolve_enterprise_ref(enterprise_repo, enterprise_tag, token)
+    sdk_pins = read_sdk_pins(enterprise_repo, ref, token)
+    sdk_version = single_value(f"{enterprise_repo}@{ref[:7]} SDK pins", sdk_pins)
+
+    report = [
+        f"enterprise-server pin:  {enterprise_tag}  ({ref_description}, {ref[:7]})",
+        f"software-agent-sdk pin: {sdk_version}  (openhands-agent-server in pyproject.toml)",
+        f"chart agent-server tag: {chart_tag}",
+    ]
+
+    if chart_version != sdk_version:
+        expected = f"{sdk_version}-{variant}" if variant else sdk_version
+        pin_list = "\n".join(f"  {pin}: {tag}" for pin, tag in sorted(chart_tags.items()))
+        raise CheckError(
+            f"agent-server {chart_version} is pinned in the charts, but "
+            f"enterprise-server {enterprise_tag} was built against "
+            f"software-agent-sdk {sdk_version}.\n\n"
+            f"The enterprise server's agent-server client and the agent-server "
+            f"image the sandbox runs must be the same version.\n\n"
+            f"Fix: set every agent-server tag below to {expected}, or move "
+            f"{ENTERPRISE_SERVER_PIN} to an enterprise-server release that pins "
+            f"software-agent-sdk {chart_version}.\n{pin_list}"
+        )
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Chart repo root to read the pins from (default: cwd).",
+    )
+    parser.add_argument(
+        "--enterprise-repo",
+        default=DEFAULT_ENTERPRISE_REPO,
+        help=f"Enterprise-server repo in owner/name form (default: {DEFAULT_ENTERPRISE_REPO}).",
+    )
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+
+    try:
+        for line in check(args.repo_root, args.enterprise_repo, token):
+            print(line)
+    except CheckError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    print("\nagent-server and software-agent-sdk pins are in sync.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_agent_server_sync.py
+++ b/scripts/test_check_agent_server_sync.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["PyYAML", "pytest"]
+# ///
+"""Behavior tests for the agent-server / software-agent-sdk pin sync check."""
+
+import json
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import check_agent_server_sync as sync
+from check_agent_server_sync import AGENT_SERVER_PINS, ENTERPRISE_SERVER_PIN, CheckError
+
+REPO = "OpenHands/enterprise"
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github/workflows/check-agent-server-sync.yml"
+
+# Trimmed to the shape the check depends on: the PEP 621 pin list it reads, and
+# the mirrored poetry block it must ignore.
+PYPROJECT = """\
+[project]
+name = "openhands"
+dependencies = [
+  "litellm==1.94.0",
+  "openhands-agent-server=={agent_server}",
+  "openhands-sdk=={sdk}",
+  "openhands-tools=={tools}",
+  "pathspec>=0.12.1",
+]
+
+[tool.poetry.dependencies]
+openhands-sdk = "=={poetry}"
+openhands-agent-server = "=={poetry}"
+openhands-tools = "=={poetry}"
+"""
+
+
+def pyproject(agent_server="1.43.1", sdk=None, tools=None, poetry="9.9.9"):
+    return PYPROJECT.format(
+        agent_server=agent_server,
+        sdk=sdk or agent_server,
+        tools=tools or agent_server,
+        poetry=poetry,
+    )
+
+
+def write_charts(root: Path, enterprise_tag: str, agent_server_tag: str):
+    """Lay down the real pin paths, each in its own file, with real siblings.
+
+    The siblings matter: a check that walked to the wrong key would still find
+    a plausible tag, so every file carries a decoy `tag:` at another path.
+    """
+    documents: dict[Path, dict] = {}
+    for pin in (ENTERPRISE_SERVER_PIN, *AGENT_SERVER_PINS):
+        tag = enterprise_tag if pin == ENTERPRISE_SERVER_PIN else agent_server_tag
+        node = documents.setdefault(pin.path, {"decoy": {"image": {"tag": "0.0.1-decoy"}}})
+        for key in pin.keys[:-1]:
+            node = node.setdefault(key, {})
+        node[pin.keys[-1]] = tag
+
+    for path, document in documents.items():
+        (root / path).parent.mkdir(parents=True, exist_ok=True)
+        (root / path).write_text(yaml.safe_dump(document))
+    return root
+
+
+@pytest.fixture
+def fake_remote(monkeypatch):
+    """Stand in for the enterprise remote. Returns a mutable route table."""
+    routes = {
+        "git/ref/tags/1.56.0": {"object": {"type": "commit", "sha": "a" * 40}},
+        f"contents/pyproject.toml?ref={'a' * 40}": pyproject(),
+    }
+    calls = []
+
+    def http_get(url, token, accept, missing=None):
+        assert url.startswith(f"{sync.API_ROOT}/repos/{REPO}/")
+        route = url[len(f"{sync.API_ROOT}/repos/{REPO}/") :]
+        calls.append(route)
+        if route not in routes:
+            if missing:
+                raise CheckError(missing)
+            raise CheckError(f"GET {url} failed: HTTP 404 Not Found")
+        value = routes[route]
+        return json.dumps(value).encode() if isinstance(value, dict) else value.encode()
+
+    monkeypatch.setattr(sync, "http_get", http_get)
+    routes["calls"] = calls  # exposed for assertions on which endpoints were hit
+    return routes
+
+
+def run_check(root, repo=REPO):
+    return sync.check(root, repo, token=None)
+
+
+def test_matching_pins_pass(tmp_path, fake_remote):
+    write_charts(tmp_path, "1.56.0", "1.43.1-python")
+
+    report = "\n".join(run_check(tmp_path))
+
+    assert "1.56.0" in report
+    assert "1.43.1" in report
+
+
+def test_mismatched_pins_fail_and_name_both_versions(tmp_path, fake_remote):
+    write_charts(tmp_path, "1.56.0", "1.41.0-python")
+
+    with pytest.raises(CheckError) as error:
+        run_check(tmp_path)
+
+    message = str(error.value)
+    assert "1.41.0" in message
+    assert "1.43.1" in message
+    # The fix has to be actionable: name the tag to set and every file holding one.
+    assert "1.43.1-python" in message
+    for pin in AGENT_SERVER_PINS:
+        assert str(pin.path) in message
+
+
+def test_variant_suffix_is_not_compared(tmp_path, fake_remote):
+    """The image is published per language runtime off one SDK release."""
+    write_charts(tmp_path, "1.56.0", "1.43.1-golang")
+
+    assert run_check(tmp_path)  # does not raise
+
+
+def test_bare_agent_server_tag_without_a_variant_passes(tmp_path, fake_remote):
+    write_charts(tmp_path, "1.56.0", "1.43.1")
+
+    assert run_check(tmp_path)
+
+
+def test_agent_server_pins_must_agree_with_each_other(tmp_path, fake_remote):
+    write_charts(tmp_path, "1.56.0", "1.43.1-python")
+    drifted = AGENT_SERVER_PINS[-1]
+    document = yaml.safe_load((tmp_path / drifted.path).read_text())
+    document["image"]["tag"] = "1.42.0-python"
+    (tmp_path / drifted.path).write_text(yaml.safe_dump(document))
+
+    with pytest.raises(CheckError, match="disagree with each other"):
+        run_check(tmp_path)
+
+
+def test_enterprise_sdk_pins_must_agree_with_each_other(tmp_path, fake_remote):
+    fake_remote[f"contents/pyproject.toml?ref={'a' * 40}"] = pyproject(
+        agent_server="1.43.1", sdk="1.42.0"
+    )
+    write_charts(tmp_path, "1.56.0", "1.43.1-python")
+
+    with pytest.raises(CheckError, match="disagree with each other"):
+        run_check(tmp_path)
+
+
+def test_poetry_dependency_block_is_ignored(tmp_path, fake_remote):
+    """[project].dependencies is the pin uv installs from; poetry's is a mirror."""
+    fake_remote[f"contents/pyproject.toml?ref={'a' * 40}"] = pyproject(poetry="1.20.0")
+    write_charts(tmp_path, "1.56.0", "1.43.1-python")
+
+    assert run_check(tmp_path)
+
+
+def test_sha_prefixed_enterprise_pin_resolves_the_commit(tmp_path, fake_remote):
+    fake_remote["commits/2809208"] = {"sha": "b" * 40}
+    fake_remote[f"contents/pyproject.toml?ref={'b' * 40}"] = pyproject()
+    write_charts(tmp_path, "sha-2809208", "1.43.1-python")
+
+    report = "\n".join(run_check(tmp_path))
+
+    assert "commits/2809208" in fake_remote["calls"]
+    assert "commit 2809208" in report
+
+
+def test_annotated_enterprise_tag_is_dereferenced(tmp_path, fake_remote):
+    fake_remote["git/ref/tags/1.56.0"] = {"object": {"type": "tag", "sha": "c" * 40}}
+    fake_remote[f"git/tags/{'c' * 40}"] = {"object": {"sha": "d" * 40}}
+    fake_remote[f"contents/pyproject.toml?ref={'d' * 40}"] = pyproject()
+    write_charts(tmp_path, "1.56.0", "1.43.1-python")
+
+    assert run_check(tmp_path)
+
+
+def test_missing_enterprise_tag_names_the_pin_that_is_wrong(tmp_path, fake_remote):
+    write_charts(tmp_path, "9.9.9", "1.43.1-python")
+
+    with pytest.raises(CheckError) as error:
+        run_check(tmp_path)
+
+    message = str(error.value)
+    assert "no tag 9.9.9" in message
+    assert str(ENTERPRISE_SERVER_PIN.path) in message
+
+
+def test_enterprise_pin_without_an_exact_sdk_pin_fails(tmp_path, fake_remote):
+    fake_remote[f"contents/pyproject.toml?ref={'a' * 40}"] = (
+        '[project]\ndependencies = ["openhands-sdk>=1.43.1"]\n'
+    )
+    write_charts(tmp_path, "1.56.0", "1.43.1-python")
+
+    with pytest.raises(CheckError, match="no exact version"):
+        run_check(tmp_path)
+
+
+def test_a_missing_chart_pin_fails_loudly(tmp_path, fake_remote):
+    write_charts(tmp_path, "1.56.0", "1.43.1-python")
+    dropped = AGENT_SERVER_PINS[0]
+    document = yaml.safe_load((tmp_path / dropped.path).read_text())
+    del document[dropped.keys[0]]
+    (tmp_path / dropped.path).write_text(yaml.safe_dump(document))
+
+    with pytest.raises(CheckError, match="no value at"):
+        run_check(tmp_path)
+
+
+def test_an_unquoted_yaml_number_is_rejected(tmp_path, fake_remote):
+    """`tag: 1.10` parses as the float 1.1, which would compare as 1.1."""
+    write_charts(tmp_path, "1.56.0", "1.43.1-python")
+    # image-loader's pin is the one that owns its whole file.
+    (tmp_path / "charts/image-loader/values.yaml").write_text("image:\n  tag: 1.10\n")
+
+    with pytest.raises(CheckError, match="expected a quoted string"):
+        run_check(tmp_path)
+
+
+def test_http_errors_are_reported_not_swallowed(monkeypatch):
+    def urlopen(request, timeout=None):
+        raise urllib.error.HTTPError(request.full_url, 500, "Server Error", {}, None)
+
+    monkeypatch.setattr(sync.urllib.request, "urlopen", urlopen)
+
+    with pytest.raises(CheckError, match="HTTP 500"):
+        sync.http_get("https://example.invalid/x", None, "application/json")
+
+
+def test_pins_still_resolve_against_the_real_charts():
+    """Guards the pin table against a values.yaml restructure. No network."""
+    repo_root = Path(__file__).resolve().parents[1]
+
+    for pin in (ENTERPRISE_SERVER_PIN, *AGENT_SERVER_PINS):
+        assert sync.read_pin(repo_root, pin), f"{pin} resolved to an empty value"
+
+
+def test_workflow_runs_on_every_release_please_pr():
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    # PyYAML parses a bare `on:` key as the boolean True.
+    triggers = workflow[True]
+
+    # A path filter would skip release PRs for charts outside charts/openhands,
+    # and would leave the check pending forever if it were made required.
+    assert "paths" not in triggers["pull_request"]
+    assert "paths-ignore" not in triggers["pull_request"]
+
+    condition = workflow["jobs"]["check-agent-server-sync"]["if"]
+    assert "startsWith(github.head_ref, 'release-please--')" in condition
+
+
+def test_workflow_fails_the_job_on_a_mismatch():
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    job = workflow["jobs"]["check-agent-server-sync"]
+    step = job["steps"][-1]
+
+    assert job["runs-on"] == "ubuntu-24.04"
+    assert "scripts/check_agent_server_sync.py" in step["run"]
+    # The report is captured so it can reach the step summary; the script's exit
+    # status still has to decide the job.
+    assert 'exit "$status"' in step["run"]
+    assert "continue-on-error" not in step
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

The enterprise server imports `openhands-agent-server` (published from `software-agent-sdk`) as a client, and talks to the agent-server image over HTTP in every sandbox. Client and server are the same codebase, so a version split between them is a protocol split.

The charts pin both halves independently. `image.tag` names the enterprise-server release, `global.agentServerImage.tag` names the sandbox image, and nothing links the two. Bumping either one alone ships that split silently.

So this adds a blocking check on release-please PRs. It reads the enterprise-server pin, resolves it on the `OpenHands/enterprise` remote, reads the `openhands-agent-server` version that release pinned in its `pyproject.toml`, and fails when the chart's agent-server tag doesn't match.

One thing to know before merging: `main` is already out of sync. It pins enterprise-server `1.56.0`, which was built against SDK `1.43.1`, but the charts run `1.41.0-python`. This check fails on the next release PR until those tags move.

## Helm Chart Checklist

<!-- No helm charts are modified in this PR, so the checklist doesn't apply. -->

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

The `pull_request` trigger is deliberately unfiltered by path. An `openhands-secrets` or `crd-check` release PR touches nothing under `charts/openhands`, but it still publishes the release line this invariant covers. Keeping the workflow always-triggered also means it can be made a required check without leaving every other PR pending forever, since the job's `if` gate reports as skipped rather than never running at all.

The check covers all three agent-server pins, so it picks up `charts/image-loader/values.yaml` and the runtime-api subchart too. Those are separate files with no shared default, so they can drift from each other as well as from the SDK.

`OpenHands/enterprise` is public, so the job's own read-only `GITHUB_TOKEN` is enough to read its tags and `pyproject.toml`. It's passed only to lift the API rate limit, and there's no app token to provision.

Tests live in `scripts/test_check_agent_server_sync.py` and stub the remote, so they don't touch the network. One of them resolves the pin table against the real chart files, so a `values.yaml` restructure that moves a pin fails loudly instead of quietly turning the check into a no-op.