### PR TITLE
feat(local-kind): PLTF-3527 enable Agent Canvas at /canvas

### DIFF
--- a/local-kind/values.yaml.tmpl
+++ b/local-kind/values.yaml.tmpl
@@ -59,3 +59,19 @@ litellm-helm:
         litellm_params:
           model: anthropic/${LLM_MODEL}
           api_key: os.environ/ANTHROPIC_API_KEY
+
+# lockToCloud points the UI at this instance's backend so users skip the "Manage
+# Backends" prompt; tls off because traefik serves the default cert (create-cluster.sh).
+agent-canvas:
+  enabled: true
+  ingress:
+    enabled: true
+    host: app.${BASE_DOMAIN}
+    className: traefik
+    path: /canvas
+    tls:
+      enabled: false
+  staticServer:
+    basePath: /canvas
+    authRequired: false
+    lockToCloud: https://app.${BASE_DOMAIN}


### PR DESCRIPTION
## Why
Enable Agent Canvas in the local-kind install so the Canvas flow can be exercised locally. It mounts the frontend-only UI at `/canvas` on the app host, with `lockToCloud` pointing the UI at this instance's backend and `authRequired: false`, so users skip the in-app "Manage Backends" / API-key step. `tls.enabled: false` because local-kind terminates TLS at Traefik's default certificate rather than a per-ingress secret.

## Validation
- **Clean install (chart 0.45.0)** — from a fresh `helm install` into an empty namespace, `/canvas` and the app root both return 200 on a trusted cert.
- **Locked backend** — Canvas launches with `--lock-to-cloud https://app.<domain>` and no `--auth-required`; logging in and opening `/canvas` reached a working conversation with no backend or API-key prompt.

This PR was drafted by an AI agent on behalf of the user.
