### PR TITLE
feat(infra): pull from ECR using node IAM on embedded cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,12 @@ $(foreach element,$(MANIFESTS),$(eval $(call make-manifest-target,$(element))))
 # ── Chart targets ───────────────────────────────────────────────────
 # For each Helm chart, package it into a versioned .tgz in build/.
 # Dependencies include all yaml/tpl/schema files so changes trigger a rebuild.
+# *.sh is in the list because the infra chart's node installers live under
+# files/ and reach the host through .Files.Get; without it, editing an installer
+# leaves the packaged chart on the previous copy.
 define make-chart-target
 $(eval VER := $(shell yq .version $(CHARTDIR)/$1/Chart.yaml))
-$(BUILDDIR)/$1-$(VER).tgz : $(CHARTDIR)/$1 $(shell find $(CHARTDIR)/$1 -name '*.yaml' -o -name '*.yml' -o -name "*.tpl" -o -name "NOTES.txt" -o -name "values.schema.json") | $$(BUILDDIR)
+$(BUILDDIR)/$1-$(VER).tgz : $(CHARTDIR)/$1 $(shell find $(CHARTDIR)/$1 -name '*.yaml' -o -name '*.yml' -o -name "*.tpl" -o -name "*.sh" -o -name "NOTES.txt" -o -name "values.schema.json") | $$(BUILDDIR)
 	@# Rewrite any dependency that points to a remote registry but exists as a
 	@# sibling chart to use a local file:// reference instead. This lets
 	@# `helm package -u` resolve unpublished chart versions during local builds.

--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra
 description: Cluster-wide infrastructure (cert-manager, trust-manager) that the OpenHands application chart depends on
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "1.0.0"
 maintainers:
   - name: all-hands-ai

--- a/charts/infra/README.md
+++ b/charts/infra/README.md
@@ -36,19 +36,70 @@ application chart runs.
   containerd drop-in. It targets Embedded Cluster (k0s) and discovers the
   containerd config path at runtime, so it works regardless of the EC
   `--data-dir`. Requires a Debian/Ubuntu host with internet access.
+- `templates/ecr-credential-provider-installer.yaml` renders, only when
+  `ecrCredentialProvider.enabled: true`, a privileged DaemonSet that runs
+  `files/install-ecr-credential-provider.sh` on each host (via
+  `nsenter --target 1`). The installer puts the kubelet ECR credential provider
+  plugin on the node and points the kubelet at it, so pulls from Amazon ECR
+  authenticate with the node's EC2 instance profile instead of a pull secret
+  holding a token that expires every 12 hours. Requires EC2 nodes and host
+  egress to the plugin's release host; see below for what it does to the node.
+
+## The ECR credential provider changes the node
+
+Everything else in this chart installs Kubernetes objects. This one edits the
+host, because the two settings it needs — `--image-credential-provider-config`
+and `--image-credential-provider-bin-dir` — are kubelet **command-line flags**.
+They are not fields of `KubeletConfiguration`, so k0s `workerProfiles` cannot
+express them, and Embedded Cluster's `unsupportedOverrides.k0s` only patches the
+k0s `ClusterConfig`. Embedded Cluster hardcodes `--kubelet-extra-args` when it
+runs `k0s install`, and the k0s systemd unit bakes its arguments straight into
+`ExecStart=` with no `EnvironmentFile`, so there is no drop-in to hook either.
+
+That leaves editing the unit. The installer rewrites the `--kubelet-extra-args`
+value in `k0scontroller.service` (or `k0sworker.service`), keeps the original at
+`<installDir>/<unit>.service.orig`, and restarts k0s. The restart is required:
+k0s builds kubelet's argument list once at startup and its supervisor re-execs
+kubelet from that stored list, so killing kubelet alone changes nothing.
+
+Consequences worth knowing before enabling it:
+
+- The node's k0s components bounce once, which on a controller briefly takes the
+  API server with them. Running containers survive, because containerd's shims
+  outlive containerd.
+- Only the first enable pays that cost. The installer compares desired against
+  actual and restarts nothing when the flags are already in place.
+- A node joining later gets a fresh unit from `k0s install`, so its own
+  DaemonSet pod repeats the edit and the restart on that node alone.
+- Embedded Cluster upgrades are safe: they roll k0s through autopilot binary
+  swaps rather than re-running `k0s install`, so the edited unit survives.
+- The plugin is downloaded on the host, checksum-pinned, from
+  `ecrCredentialProvider.releaseBaseUrl`. Air-gapped installs need that URL
+  repointed at an internal mirror serving the same layout.
+- Turning the option back off removes the DaemonSet but leaves the node as it
+  is, which keeps ECR pulls working. To undo the host change, restore
+  `<installDir>/<unit>.service.orig` over the unit, `systemctl daemon-reload`,
+  restart k0s, and delete `<installDir>`.
 
 ## Releases
 
-Three Replicated HelmChart manifests reference this chart with different
+Four Replicated HelmChart manifests reference this chart with different
 toggles:
 
-| Manifest                              | `cert-manager.enabled` | `trust-manager.enabled` | `crdCheck.enabled` | `sysbox.enabled`              | KOTS weight |
-|---------------------------------------|------------------------|-------------------------|--------------------|-------------------------------|-------------|
-| `replicated/infra-cert-manager.yaml`  | `true`                 | `false`                 | `false`            | `false`                       | 5           |
-| `replicated/infra-trust-manager.yaml` | `false`                | `true`                  | `true`             | `false`                       | 6           |
-| `replicated/infra-sysbox.yaml`        | `false`                | `false`                 | `false`            | `true` when Sandbox Isolation = Sysbox | 7           |
+| Manifest                                        | `cert-manager.enabled` | `trust-manager.enabled` | `crdCheck.enabled` | Other                                            | KOTS weight |
+|-------------------------------------------------|------------------------|-------------------------|--------------------|--------------------------------------------------|-------------|
+| `replicated/infra-cert-manager.yaml`            | `true`                 | `false`                 | `false`            | `sandboxUpgradeCoordinator.enabled: true`        | 5           |
+| `replicated/infra-trust-manager.yaml`           | `false`                | `true`                  | `true`             | —                                                | 6           |
+| `replicated/infra-sysbox.yaml`                  | `false`                | `false`                 | `false`            | `sysbox` on when Sandbox Isolation = Sysbox      | 7           |
+| `replicated/infra-ecr-credential-provider.yaml` | `false`                | `false`                 | `false`            | `ecrCredentialProvider` on when ECR node IAM is enabled | 20          |
 
 The trust-manager release runs the CRD check before applying its own
 resources, because `helm install --wait` only waits for pods to become
 ready — not for CRD apiserver registration — so a fast follow-on apply
 after cert-manager finishes can race.
+
+The ECR release is weighted last and deliberately does not pass `--wait`. Its
+first deploy restarts k0s, so the restart has to land after KOTS has applied
+every other release rather than while Helm is waiting on one. Nothing depends on
+it being early: the credential provider is only consulted when a pod pulls from
+ECR, and a pull that races the restart backs off and retries.

--- a/charts/infra/files/install-ecr-credential-provider.sh
+++ b/charts/infra/files/install-ecr-credential-provider.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+# install-ecr-credential-provider.sh — runs on each node, installed by the infra
+# chart's ECR credential provider DaemonSet. The DaemonSet execs this script on
+# the HOST via `nsenter --target 1`, so the download, the systemd unit edit and
+# systemctl all act on the node itself.
+#
+# It installs the kubelet ECR credential provider plugin and points the kubelet
+# at it, so image pulls from Amazon ECR authenticate with the node's own EC2
+# instance profile. The plugin resolves credentials through the AWS SDK chain as
+# the kubelet's user (root), which on an Embedded Cluster node means IMDS: there
+# is no static credential on the node and nothing to rotate when ECR's 12-hour
+# authorization token expires.
+#
+# Embedded Cluster bakes kubelet's arguments into the k0s systemd unit's
+# ExecStart line and exposes no supported override, so this rewrites the
+# --kubelet-extra-args value in that unit. Restarting k0s is the only way
+# kubelet picks the new flags up: k0s builds kubelet's argument list once at
+# startup and its supervisor re-execs kubelet from that stored list, so killing
+# kubelet alone changes nothing.
+#
+# Idempotent: the unit is rewritten (and k0s restarted) only when the plugin
+# files or the kubelet flags are not already what this script wants, so a pod
+# restart on a configured node does nothing. The restart bounces the node's k0s
+# components for a few seconds; running containers survive it because
+# containerd's shims outlive containerd.
+
+set -euo pipefail
+
+# Release to install. The binaries are the upstream cloud-provider-aws plugin
+# rebuilt and published by dntosas/ecr-credential-provider, because
+# kubernetes/cloud-provider-aws itself ships no release binary and no tagged
+# image. The download is checksum-pinned, so the release host only has to be
+# reachable, not trusted.
+ECR_CP_VERSION="${ECR_CP_VERSION:?ECR_CP_VERSION is required}"
+ECR_CP_RELEASE_BASE_URL="${ECR_CP_RELEASE_BASE_URL:?ECR_CP_RELEASE_BASE_URL is required}"
+ECR_CP_SHA256_AMD64="${ECR_CP_SHA256_AMD64:?ECR_CP_SHA256_AMD64 is required}"
+ECR_CP_SHA256_ARM64="${ECR_CP_SHA256_ARM64:?ECR_CP_SHA256_ARM64 is required}"
+# Host directory that holds both the plugin binary and the kubelet's
+# CredentialProviderConfig. kubelet execs everything in the bin dir, so it stays
+# ours alone rather than a shared location like /usr/local/bin.
+ECR_CP_INSTALL_DIR="${ECR_CP_INSTALL_DIR:-/opt/openhands/image-credential-provider}"
+# Newline-separated kubelet matchImages globs.
+ECR_CP_MATCH_IMAGES="${ECR_CP_MATCH_IMAGES:?ECR_CP_MATCH_IMAGES is required}"
+# Newline-separated NAME=VALUE pairs added to the plugin's environment in the
+# CredentialProviderConfig. kubelet appends these after the host environment and
+# exec keeps the last duplicate, so they override what kubelet itself inherited.
+ECR_CP_PROVIDER_ENV="${ECR_CP_PROVIDER_ENV:-}"
+# Optional image reference used to prove, on this node, that the plugin can
+# actually mint an ECR token with the instance profile. Empty disables the check.
+ECR_CP_SELF_TEST_IMAGE="${ECR_CP_SELF_TEST_IMAGE:-}"
+# Shortest interval between two k0s restarts driven by this script.
+ECR_CP_RESTART_COOLDOWN="${ECR_CP_RESTART_COOLDOWN:-900}"
+
+BIN_DIR="$ECR_CP_INSTALL_DIR/bin"
+BIN_PATH="$BIN_DIR/ecr-credential-provider"
+CONFIG_PATH="$ECR_CP_INSTALL_DIR/config.yaml"
+RESTART_STAMP="$ECR_CP_INSTALL_DIR/.last-k0s-restart"
+READY_FILE=/run/ecr-credential-provider-installer.ready
+
+err() { echo "ERROR: $*" >&2; exit 1; }
+log() { echo "==> $*"; }
+
+# Re-gate readiness until this run finishes configuring the node.
+rm -f "$READY_FILE"
+
+# Proxy settings reach us as provider env so that kubelet's exec of the plugin
+# uses them too; export them here as well so this script's own download and
+# self-test take the same path the plugin will.
+if [ -n "$ECR_CP_PROVIDER_ENV" ]; then
+  while IFS= read -r pair; do
+    [ -n "$pair" ] || continue
+    export "${pair?}"
+  done <<EOF
+$ECR_CP_PROVIDER_ENV
+EOF
+fi
+
+# --- Resolve the release artifact for this node's architecture ---------------
+case "$(uname -m)" in
+  x86_64 | amd64) ARCH=amd64; WANT_SHA256="$ECR_CP_SHA256_AMD64" ;;
+  aarch64 | arm64) ARCH=arm64; WANT_SHA256="$ECR_CP_SHA256_ARM64" ;;
+  *) err "unsupported architecture $(uname -m); the ECR credential provider ships linux/amd64 and linux/arm64 only" ;;
+esac
+URL="$ECR_CP_RELEASE_BASE_URL/$ECR_CP_VERSION/ecr-credential-provider-linux-$ARCH"
+NODE_NAME="$(uname -n)"
+
+log "node $NODE_NAME ($ARCH), plugin $ECR_CP_VERSION"
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$1" | awk '{print $NF}'
+  else
+    err "no sha256sum or openssl on the host; cannot verify the download"
+  fi
+}
+
+# Content comparison via sha256_of rather than cmp/diff: diffutils is not part
+# of a minimal RHEL or Amazon Linux install, and the hashing tools are already
+# a hard requirement for verifying the download.
+same_content() {
+  [ -f "$2" ] && [ "$(sha256_of "$1")" = "$(sha256_of "$2")" ]
+}
+
+fetch() {
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL --connect-timeout 15 --retry 5 --retry-delay 3 -o "$2" "$1"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q -T 15 -t 5 -O "$2" "$1"
+  else
+    err "no curl or wget on the host; cannot download $1"
+  fi
+}
+
+# --- 1. Plugin binary --------------------------------------------------------
+if [ -x "$BIN_PATH" ] && [ "$(sha256_of "$BIN_PATH")" = "$WANT_SHA256" ]; then
+  log "plugin already installed at $BIN_PATH"
+else
+  log "downloading $URL"
+  TMP_BIN="$(mktemp)"
+  fetch "$URL" "$TMP_BIN" || err "failed to download the ECR credential provider from $URL"
+  GOT_SHA256="$(sha256_of "$TMP_BIN")"
+  if [ "$GOT_SHA256" != "$WANT_SHA256" ]; then
+    rm -f "$TMP_BIN"
+    err "checksum mismatch for $URL (want $WANT_SHA256, got $GOT_SHA256)"
+  fi
+  install -D -m 0755 "$TMP_BIN" "$BIN_PATH"
+  rm -f "$TMP_BIN"
+  log "installed plugin to $BIN_PATH"
+fi
+
+# --- 2. CredentialProviderConfig --------------------------------------------
+# defaultCacheDuration is 0s on purpose: it applies only when the plugin returns
+# no duration of its own, and an ECR token that outlives its own expiry in
+# kubelet's cache is worse than an extra exec per pull. The plugin does return a
+# duration (half the token's remaining life), so this is a floor, not the norm.
+NEW_CONFIG="$(mktemp)"
+{
+  echo "apiVersion: kubelet.config.k8s.io/v1"
+  echo "kind: CredentialProviderConfig"
+  echo "providers:"
+  echo "  - name: ecr-credential-provider"
+  echo "    apiVersion: credentialprovider.kubelet.k8s.io/v1"
+  echo "    defaultCacheDuration: 0s"
+  echo "    matchImages:"
+  while IFS= read -r glob; do
+    glob="$(echo "$glob" | tr -d '[:space:]')"
+    [ -n "$glob" ] && echo "      - \"$glob\""
+  done <<EOF
+$ECR_CP_MATCH_IMAGES
+EOF
+  if [ -n "$ECR_CP_PROVIDER_ENV" ]; then
+    echo "    env:"
+    while IFS= read -r pair; do
+      [ -n "$pair" ] || continue
+      echo "      - name: \"${pair%%=*}\""
+      echo "        value: \"${pair#*=}\""
+    done <<EOF
+$ECR_CP_PROVIDER_ENV
+EOF
+  fi
+} > "$NEW_CONFIG"
+
+config_changed=false
+if same_content "$NEW_CONFIG" "$CONFIG_PATH"; then
+  log "credential provider config already current at $CONFIG_PATH"
+  rm -f "$NEW_CONFIG"
+else
+  install -D -m 0644 "$NEW_CONFIG" "$CONFIG_PATH"
+  rm -f "$NEW_CONFIG"
+  config_changed=true
+  log "wrote credential provider config to $CONFIG_PATH"
+fi
+
+# --- 3. Point the kubelet at the plugin via the k0s unit ---------------------
+# Controller nodes (including the single-node install, which k0s runs with
+# --enable-worker) use k0scontroller.service; nodes joined with the sandbox role
+# are plain workers and use k0sworker.service.
+# A running unit is the authoritative answer; a node reset from one role to the
+# other can leave the unit file for the role it no longer runs.
+UNIT_NAME=""
+for candidate in k0scontroller k0sworker; do
+  if systemctl is-active --quiet "$candidate.service" 2>/dev/null; then
+    UNIT_NAME="$candidate"
+    break
+  fi
+done
+if [ -z "$UNIT_NAME" ]; then
+  for candidate in k0scontroller k0sworker; do
+    if [ -f "/etc/systemd/system/$candidate.service" ]; then
+      UNIT_NAME="$candidate"
+      break
+    fi
+  done
+fi
+[ -n "$UNIT_NAME" ] || err "no k0scontroller.service or k0sworker.service on this host; is this an Embedded Cluster node?"
+UNIT_PATH="/etc/systemd/system/$UNIT_NAME.service"
+grep -qE '^ExecStart=.*/k0s ' "$UNIT_PATH" \
+  || err "$UNIT_PATH does not look like a k0s unit; refusing to modify it"
+
+log "k0s unit: $UNIT_PATH"
+
+# k0s takes kubelet's flags as one --kubelet-extra-args=<flags> argument, and
+# kardianos/service (which writes the unit) escapes the spaces inside that value
+# as \x20. So the edit happens inside a single ExecStart field: split it on
+# \x20, drop any credential provider flags a previous run left, and append the
+# current ones. Passing the flags through ENVIRON rather than -v keeps awk from
+# interpreting \x20 as an escape and collapsing it to a real space.
+render_unit() {
+  CFG_FLAG="--image-credential-provider-config=$CONFIG_PATH" \
+  BIN_FLAG="--image-credential-provider-bin-dir=$BIN_DIR" \
+  awk '
+    function rebuild(tok,   n, parts, j, out) {
+      n = split(tok, parts, /\\x20/)
+      out = ""
+      for (j = 1; j <= n; j++) {
+        if (parts[j] ~ /^--image-credential-provider-(config|bin-dir)=/) continue
+        out = (out == "") ? parts[j] : out "\\x20" parts[j]
+      }
+      return out "\\x20" ENVIRON["CFG_FLAG"] "\\x20" ENVIRON["BIN_FLAG"]
+    }
+    /^ExecStart=/ && !patched {
+      found = 0
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^--kubelet-extra-args=/) { $i = rebuild($i); found = 1 }
+      }
+      if (!found) {
+        $0 = $0 " --kubelet-extra-args=" ENVIRON["CFG_FLAG"] "\\x20" ENVIRON["BIN_FLAG"]
+      }
+      patched = 1
+    }
+    { print }
+  ' "$1"
+}
+
+NEW_UNIT="$(mktemp)"
+render_unit "$UNIT_PATH" > "$NEW_UNIT"
+grep -qF -- "--image-credential-provider-bin-dir=$BIN_DIR" "$NEW_UNIT" \
+  || { rm -f "$NEW_UNIT"; err "failed to add the credential provider flags to $UNIT_PATH"; }
+
+unit_changed=false
+if same_content "$NEW_UNIT" "$UNIT_PATH"; then
+  log "kubelet flags already present in $UNIT_PATH"
+  rm -f "$NEW_UNIT"
+else
+  # Keep the unit as Embedded Cluster first wrote it, so the node can be put
+  # back by hand without reinstalling. Written once; later runs edit the live
+  # unit, which already carries our flags, and must not overwrite this copy.
+  [ -f "$ECR_CP_INSTALL_DIR/$UNIT_NAME.service.orig" ] \
+    || install -D -m 0644 "$UNIT_PATH" "$ECR_CP_INSTALL_DIR/$UNIT_NAME.service.orig"
+  install -m 0644 "$NEW_UNIT" "$UNIT_PATH"
+  rm -f "$NEW_UNIT"
+  unit_changed=true
+  log "added the credential provider flags to $UNIT_PATH"
+fi
+
+# Walks /proc rather than using pgrep, which is not part of a minimal RHEL or
+# Amazon Linux install. Matching argv[0] first keeps this from being satisfied by
+# some other process that merely mentions the flag, such as this script's own
+# grep should it land on a recycled PID.
+kubelet_configured() {
+  local proc argv0
+  for proc in /proc/[0-9]*; do
+    [ -r "$proc/cmdline" ] || continue
+    argv0="$(tr '\0' '\n' < "$proc/cmdline" 2>/dev/null | head -1)"
+    case "$argv0" in */kubelet | kubelet) ;; *) continue ;; esac
+    if tr '\0' '\n' < "$proc/cmdline" 2>/dev/null \
+      | grep -qxF -- "--image-credential-provider-config=$CONFIG_PATH"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+wait_for_kubelet() {
+  local deadline=$((SECONDS + $1))
+  until kubelet_configured; do
+    [ "$SECONDS" -lt "$deadline" ] || return 1
+    sleep 5
+  done
+}
+
+need_restart=false
+if [ "$unit_changed" = true ] || [ "$config_changed" = true ]; then
+  # A real change to what the kubelet should be running with. Restart on its
+  # own merit, uncooled: the desired state is derived from the chart values, so
+  # once it is written it stops changing and this cannot repeat.
+  need_restart=true
+elif ! wait_for_kubelet 60; then
+  # Files were already right but the running kubelet is not using them, so an
+  # earlier run patched the unit and never got as far as restarting k0s. The
+  # grace period keeps a kubelet that is merely slow to come up from being read
+  # as unconfigured.
+  log "kubelet is not using the credential provider yet"
+  # This branch is the repeat: nothing changed since last time and the restart
+  # did not take. Rate-limit it so a node that never comes back configured
+  # cannot turn this pod's restart loop into a k0s restart loop. Failing here
+  # leaves the pod un-ready and the node on the kubelet it already had.
+  now="$(date +%s)"
+  last=0
+  [ -f "$RESTART_STAMP" ] && last="$(cat "$RESTART_STAMP" 2>/dev/null || echo 0)"
+  [ $((now - last)) -ge "$ECR_CP_RESTART_COOLDOWN" ] \
+    || err "$UNIT_NAME was already restarted $((now - last))s ago and the kubelet still is not using the credential provider; not restarting again within ${ECR_CP_RESTART_COOLDOWN}s. Check journalctl -u $UNIT_NAME"
+  need_restart=true
+fi
+
+if [ "$need_restart" = true ]; then
+  date +%s > "$RESTART_STAMP"
+  systemctl daemon-reload
+  # Detach the restart from this shell. Stopping k0s takes kubelet down with it,
+  # and a kubelet that is mid-restart can leave this pod's exec plumbing in a
+  # bad state; handing the job to systemd means the restart finishes either way.
+  systemctl reset-failed openhands-ecr-cp-k0s-restart.service 2>/dev/null || true
+  log "restarting $UNIT_NAME to load the new kubelet flags (one time; the node's k0s components bounce, running containers do not)"
+  systemd-run --no-block --collect \
+    --unit=openhands-ecr-cp-k0s-restart \
+    --description="Restart k0s to load the OpenHands ECR credential provider" \
+    /bin/systemctl restart "$UNIT_NAME.service"
+
+  log "waiting for the kubelet to come back with the credential provider configured"
+  wait_for_kubelet 300 \
+    || err "kubelet did not come back with the credential provider flags within 300s; check journalctl -u $UNIT_NAME"
+fi
+
+log "kubelet is running with the ECR credential provider"
+
+# --- 4. Prove the node's IAM identity can actually mint an ECR token ---------
+# Same binary, same credential chain, same user kubelet will use, so a pass here
+# means the next ECR pull authenticates. Non-fatal: the node is configured
+# either way and the fix is an IAM change, not a redeploy.
+if [ -n "$ECR_CP_SELF_TEST_IMAGE" ]; then
+  log "self-test: requesting an ECR token for $ECR_CP_SELF_TEST_IMAGE"
+  SELF_TEST_ERR="$(mktemp)"
+  REQUEST="{\"kind\":\"CredentialProviderRequest\",\"apiVersion\":\"credentialprovider.kubelet.k8s.io/v1\",\"image\":\"$ECR_CP_SELF_TEST_IMAGE\"}"
+  # The response carries a live registry password, so it is matched and dropped
+  # rather than logged.
+  if printf '%s' "$REQUEST" | "$BIN_PATH" 2>"$SELF_TEST_ERR" | grep -q '"auth"'; then
+    log "self-test passed: this node's IAM identity can pull from ECR"
+  else
+    echo "ERROR: self-test failed: the plugin could not get an ECR token on this node." >&2
+    echo "ERROR: the node's instance profile needs ecr:GetAuthorizationToken plus" >&2
+    echo "ERROR: ecr:BatchGetImage and ecr:GetDownloadUrlForLayer on the repository," >&2
+    echo "ERROR: and IMDS must be reachable from the host. Plugin output follows." >&2
+    sed 's/^/ERROR: /' "$SELF_TEST_ERR" >&2
+  fi
+  rm -f "$SELF_TEST_ERR"
+fi
+
+log "ECR credential provider ready on $NODE_NAME"
+: > "$READY_FILE"
+
+# Hold the pod open; a re-run on restart keeps the node configured.
+exec sleep infinity

--- a/charts/infra/templates/ecr-credential-provider-installer.yaml
+++ b/charts/infra/templates/ecr-credential-provider-installer.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.ecrCredentialProvider.enabled }}
+{{- $ecr := .Values.ecrCredentialProvider }}
+# Privileged DaemonSet that installs the kubelet ECR credential provider plugin
+# on every node, so image pulls from Amazon ECR authenticate with the node's own
+# EC2 instance profile instead of a pull secret holding a 12-hour authorization
+# token.
+#
+# One container, unlike the Sysbox installer: there is no artifact to stage out
+# of an image, because the plugin ships as neither a first-party binary release
+# nor a tagged image. The installer downloads it on the HOST (checksum-pinned),
+# which also means the node's own trust store and proxy settings apply. All this
+# image contributes is a modern nsenter to get there.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ecr-credential-provider-installer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "infra.labels" . | nindent 4 }}
+    app.kubernetes.io/name: ecr-credential-provider-installer
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ecr-credential-provider-installer
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ecr-credential-provider-installer
+      annotations:
+        # The script is passed to the host through the pod spec, so a change to
+        # it has to roll the DaemonSet or nodes keep running the old installer.
+        checksum/install-script: {{ .Files.Get "files/install-ecr-credential-provider.sh" | sha256sum }}
+    spec:
+      # hostPID lets `nsenter --target 1` reach the host's init namespaces, and
+      # lets the installer see the kubelet process to confirm it came back with
+      # the credential provider flags.
+      hostPID: true
+      {{- with $ecr.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $ecr.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $ecr.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: installer
+          image: "{{ $ecr.image.repository }}:{{ $ecr.image.tag }}"
+          imagePullPolicy: {{ $ecr.image.pullPolicy }}
+          securityContext:
+            privileged: true
+          env:
+            - name: ECR_CP_VERSION
+              value: {{ $ecr.version | quote }}
+            - name: ECR_CP_RELEASE_BASE_URL
+              value: {{ $ecr.releaseBaseUrl | quote }}
+            - name: ECR_CP_SHA256_AMD64
+              value: {{ $ecr.checksums.amd64 | quote }}
+            - name: ECR_CP_SHA256_ARM64
+              value: {{ $ecr.checksums.arm64 | quote }}
+            - name: ECR_CP_INSTALL_DIR
+              value: {{ $ecr.installDir | quote }}
+            - name: ECR_CP_RESTART_COOLDOWN
+              value: {{ $ecr.restartCooldownSeconds | quote }}
+            # Newline-separated so the installer can build the config's
+            # matchImages list without a YAML parser on the host.
+            - name: ECR_CP_MATCH_IMAGES
+              value: |-
+                {{- range $ecr.matchImages }}
+                {{ . }}
+                {{- end }}
+            - name: ECR_CP_PROVIDER_ENV
+              value: |-
+                {{- range $name, $value := $ecr.providerEnv }}
+                {{ $name }}={{ $value }}
+                {{- end }}
+            - name: ECR_CP_SELF_TEST_IMAGE
+              value: {{ $ecr.selfTestImage | quote }}
+            - name: INSTALL_SCRIPT
+              value: |
+{{ .Files.Get "files/install-ecr-credential-provider.sh" | indent 16 }}
+          # `nsenter` enters the host namespaces and the host's bash runs the
+          # installer. The container bash expands $INSTALL_SCRIPT and hands the
+          # text to the host's bash.
+          command:
+            - /bin/bash
+            - -c
+            - exec nsenter --target 1 --mount --uts --ipc --net --pid -- /bin/bash -c "$INSTALL_SCRIPT"
+          # Ready only once the kubelet on this node is confirmed to be running
+          # with the credential provider (sentinel on host). failureThreshold
+          # covers the k0s restart, which takes the kubelet down with it.
+          readinessProbe:
+            exec:
+              command: ["nsenter", "--target", "1", "--mount", "--", "test", "-f", "/run/ecr-credential-provider-installer.ready"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 60
+          resources:
+            {{- toYaml $ecr.resources | nindent 12 }}
+{{- end }}

--- a/charts/infra/tests/ecr-credential-provider_test.yaml
+++ b/charts/infra/tests/ecr-credential-provider_test.yaml
@@ -1,0 +1,127 @@
+suite: ECR credential provider installer
+templates:
+  - templates/ecr-credential-provider-installer.yaml
+tests:
+  - it: renders nothing unless it is enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: installs a privileged host-PID DaemonSet on every Linux node
+    set:
+      ecrCredentialProvider.enabled: true
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: metadata.name
+          value: ecr-credential-provider-installer
+      - equal:
+          path: spec.template.spec.hostPID
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.privileged
+          value: true
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/os"]
+          value: linux
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - operator: Exists
+
+  # The plugin is only ever reached through the kubelet's exec of it, so a
+  # mismatch between the checksums the chart pins and the version it asks for
+  # would surface as a failed pull on the node instead of a failed render.
+  - it: passes the pinned release and both architecture checksums to the installer
+    set:
+      ecrCredentialProvider.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ECR_CP_VERSION
+            value: v1.2.0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ECR_CP_RELEASE_BASE_URL
+            value: https://github.com/dntosas/ecr-credential-provider/releases/download
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ECR_CP_SHA256_AMD64
+            value: 6b9c0b8ba9c4b2ab1b3eb093044c9b4500eb2916b6b9f792a8923d91789cd1a4
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ECR_CP_SHA256_ARM64
+            value: 9652fd710dccab8f62f0ab29b374d3845c746e7490e6004a01edf84a42d36726
+
+  - it: hands the match globs to the installer one per line
+    set:
+      ecrCredentialProvider.enabled: true
+      ecrCredentialProvider.matchImages:
+        - "*.dkr.ecr.*.amazonaws.com"
+        - "public.ecr.aws"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ECR_CP_MATCH_IMAGES
+            value: |-
+              *.dkr.ecr.*.amazonaws.com
+              public.ecr.aws
+
+  - it: hands the provider environment to the installer as NAME=VALUE lines
+    set:
+      ecrCredentialProvider.enabled: true
+      ecrCredentialProvider.providerEnv:
+        NO_PROXY: 169.254.169.254
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ECR_CP_PROVIDER_ENV
+            value: |-
+              NO_PROXY=169.254.169.254
+
+  - it: leaves the provider environment empty when no proxy is configured
+    set:
+      ecrCredentialProvider.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ECR_CP_PROVIDER_ENV
+            value: ""
+
+  # .Files.Get inlines the installer into the pod spec, so without this
+  # annotation an edited installer would sit in the packaged chart while the
+  # nodes kept running the old copy.
+  - it: rolls the DaemonSet when the installer script changes
+    set:
+      ecrCredentialProvider.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/install-script"]
+          pattern: ^[0-9a-f]{64}$
+
+  - it: runs the installer on the host through nsenter and gates readiness on it
+    set:
+      ecrCredentialProvider.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: nsenter --target 1 --mount --uts --ipc --net --pid
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command
+          value:
+            - nsenter
+            - --target
+            - "1"
+            - --mount
+            - --
+            - test
+            - -f
+            - /run/ecr-credential-provider-installer.ready

--- a/charts/infra/tests/labels_test.yaml
+++ b/charts/infra/tests/labels_test.yaml
@@ -2,6 +2,7 @@ suite: recommended labels
 templates:
   - templates/sysbox-installer.yaml
   - templates/sandbox-upgrade-coordinator.yaml
+  - templates/ecr-credential-provider-installer.yaml
 tests:
   - it: the sysbox DaemonSet carries the recommended labels and keeps its selector
     template: templates/sysbox-installer.yaml
@@ -100,3 +101,38 @@ tests:
           value:
             app.kubernetes.io/name: sandbox-upgrade-coordinator
             app.kubernetes.io/instance: RELEASE-NAME
+
+  - it: the ECR credential provider DaemonSet carries the recommended labels and keeps its selector
+    template: templates/ecr-credential-provider-installer.yaml
+    set:
+      ecrCredentialProvider.enabled: true
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: ecr-credential-provider-installer
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.labels["app.kubernetes.io/part-of"]
+          value: openhands
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^infra-
+      - isNotEmpty:
+          path: metadata.labels["app.kubernetes.io/version"]
+      # spec.selector is immutable, so it stays on the workload's own name and
+      # the pod template keeps matching it unchanged.
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: ecr-credential-provider-installer
+      - equal:
+          path: spec.template.metadata.labels
+          value:
+            app.kubernetes.io/name: ecr-credential-provider-installer

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -176,3 +176,87 @@ sysbox:
       memory: 100Mi
     limits:
       memory: 512Mi
+
+# Kubelet ECR credential provider installer. When enabled, a privileged
+# DaemonSet installs the kubelet credential provider plugin for Amazon ECR on
+# every node and points the kubelet at it, so pulls from ECR authenticate with
+# the node's own IAM identity. Nothing on the cluster holds an ECR authorization
+# token, so nothing has to be re-entered when one expires after 12 hours.
+#
+# EC2 only. The plugin resolves credentials through the AWS SDK chain running as
+# the kubelet's user, which on an Embedded Cluster node means the instance
+# profile via IMDS. A node outside EC2 has no credential source and every ECR
+# pull on it will fail.
+#
+# Enabling this reconfigures the kubelet. Embedded Cluster bakes kubelet's
+# arguments into the k0s systemd unit and offers no supported override, so the
+# installer edits that unit and restarts k0s once per node. See
+# files/install-ecr-credential-provider.sh for what that costs and why nothing
+# lighter works.
+ecrCredentialProvider:
+  enabled: false
+  # Plugin release to install. These are the upstream cloud-provider-aws
+  # binaries rebuilt and published by dntosas/ecr-credential-provider:
+  # kubernetes/cloud-provider-aws itself publishes no release binary and its
+  # registry.k8s.io repository carries no tags, so there is nothing first-party
+  # to pull. The download is checksum-pinned, so the release host only has to be
+  # reachable, not trusted. Point releaseBaseUrl at an internal mirror that
+  # serves the same layout to install without reaching GitHub.
+  version: v1.2.0
+  releaseBaseUrl: https://github.com/dntosas/ecr-credential-provider/releases/download
+  # sha256 of ecr-credential-provider-linux-<arch> for .version. Update both
+  # whenever .version moves; the installer refuses a binary that does not match.
+  checksums:
+    amd64: 6b9c0b8ba9c4b2ab1b3eb093044c9b4500eb2916b6b9f792a8923d91789cd1a4
+    arm64: 9652fd710dccab8f62f0ab29b374d3845c746e7490e6004a01edf84a42d36726
+  # Host directory holding the plugin binary and the kubelet's
+  # CredentialProviderConfig. kubelet execs every file in the bin directory, so
+  # this stays a directory of ours rather than a shared one like /usr/local/bin.
+  installDir: /opt/openhands/image-credential-provider
+  # Registries the plugin is consulted for. Each glob matches a single subdomain
+  # segment, so the two wildcards below stand for the account ID and the region.
+  # Covers the commercial, FIPS, China and US government partitions plus ECR
+  # Public; images outside this list are pulled the normal way.
+  matchImages:
+    - "*.dkr.ecr.*.amazonaws.com"
+    - "*.dkr.ecr-fips.*.amazonaws.com"
+    - "*.dkr.ecr.*.amazonaws.com.cn"
+    - "*.dkr.ecr.*.on.aws"
+    - "*.dkr.ecr.*.c2s.ic.gov"
+    - "*.dkr.ecr.*.sc2s.sgov.gov"
+    - "public.ecr.aws"
+  # Environment for the plugin process, written into the CredentialProviderConfig
+  # as NAME: VALUE. kubelet appends these after its own environment and exec
+  # keeps the last duplicate, so they win over whatever kubelet inherited. This
+  # is how proxy settings reach the plugin; see the Replicated manifest, which
+  # fills it in and keeps IMDS off the proxy.
+  providerEnv: {}
+  # Image reference the installer uses to prove, on each node, that the plugin
+  # can really mint an ECR token there. Same binary, same credential chain, same
+  # user kubelet will use, so a pass means the next pull authenticates. Empty
+  # skips the check; the Replicated manifest points it at the sandbox image.
+  selfTestImage: ""
+  # Shortest interval, in seconds, between two k0s restarts driven by the
+  # installer. Stops a node that never comes back configured from turning a pod
+  # restart loop into a k0s restart loop.
+  restartCooldownSeconds: 900
+  image:
+    # Only needed for a modern nsenter (util-linux >= 2.38) to enter the host
+    # namespaces and run files/install-ecr-credential-provider.sh. Nothing from
+    # this image is installed on the node, and the download happens on the host,
+    # so the node's own curl and trust store are what talk to the release host.
+    repository: docker.io/library/debian
+    tag: bookworm-slim
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  # Run on every Linux node, tolerating all taints (incl. control-plane).
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - operator: Exists
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      memory: 128Mi

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -472,6 +472,18 @@ spec:
         namespace: ingress-nginx
         limits:
           maxAge: 336h
+    # ECR credential provider installer logs. This is where an ECR pull failure
+    # gets explained: the installer logs the plugin install, the kubelet flags it
+    # set, and the result of the per-node check that the instance profile can
+    # actually mint an ECR token. Collected unconditionally — the selector simply
+    # matches nothing when the feature is off.
+    - logs:
+        name: kube-system/ecr-credential-provider-installer/logs
+        selector:
+          - app.kubernetes.io/name=ecr-credential-provider-installer
+        namespace: kube-system
+        limits:
+          maxAge: 336h
     {{- if and .Values.postgresql.enabled .Values.replicated.enabled .Values.replicated.postgresPassword }}
     - postgresql:
         collectorName: postgresql

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1307,8 +1307,9 @@ spec:
           title: Registry Server
           help_text: |
             Host (and optional port) of the registry, e.g. my-registry.example.com.
-            Leave blank if the registry is public, or if your cluster authenticates
-            via a credential provider (EKS IRSA, GKE Workload Identity, AKS managed
+            Leave blank if the registry is public, if you enabled "Authenticate to
+            Amazon ECR with Node IAM" below, or if your cluster authenticates via a
+            credential provider (EKS IRSA, GKE Workload Identity, AKS managed
             identity).
           type: text
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
@@ -1332,6 +1333,28 @@ spec:
           type: password
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: false
+        - name: ecr_credential_provider_enabled
+          title: Authenticate to Amazon ECR with Node IAM
+          help_text: |
+            Pull images from Amazon ECR using each node's own IAM role. Nothing in
+            the cluster holds an ECR authorization token, so there is nothing to
+            re-enter when one expires after 12 hours. Leave Registry Username and
+            Registry Password blank when this is on.
+
+            Your nodes must be EC2 instances whose instance profile grants
+            ecr:GetAuthorizationToken, plus ecr:BatchGetImage and
+            ecr:GetDownloadUrlForLayer on the repository. A node outside EC2 has no
+            credentials to fall back on and every ECR pull on it fails.
+
+            Turning this on reconfigures the kubelet, so k0s restarts once on each
+            node. The cluster API is briefly unavailable the first time you deploy
+            with it enabled, and again on each node that joins afterwards. Running
+            workloads are not restarted, and later deploys leave the nodes alone.
+
+            Each node downloads the credential provider from GitHub, so this does
+            not work on an air-gapped install.
+          type: bool
+          default: "0"
         - name: sandbox_additional_host_paths
           title: Additional Host Path Mounts
           help_text: >-

--- a/replicated/infra-ecr-credential-provider.yaml
+++ b/replicated/infra-ecr-credential-provider.yaml
@@ -1,0 +1,85 @@
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: infra-ecr-credential-provider
+spec:
+  chart:
+    name: infra
+  releaseName: infra-ecr-credential-provider
+  # kube-system already permits the privileged, host-namespace pods the
+  # installer needs, and is where node-level DaemonSets conventionally live.
+  namespace: kube-system
+  # Deliberately the last release. Turning this on the first time restarts k0s
+  # on every node, which briefly takes the API server with it, so the restart
+  # has to land after KOTS has finished applying every other release rather
+  # than in the middle of one. Nothing else depends on it: the credential
+  # provider is only needed when a sandbox pod pulls from ECR, which happens
+  # long after the deploy, and a pull that races the restart just backs off and
+  # retries. Later deploys leave the node alone entirely, because the installer
+  # restarts k0s only when the kubelet flags actually change.
+  weight: 20
+  # No --wait: Helm must not be blocking on this DaemonSet while the API server
+  # it is talking to goes away. The DaemonSet converges on its own.
+  values:
+    # This release only carries the ECR credential provider installer;
+    # cert-manager and trust-manager are installed by their own releases.
+    cert-manager:
+      enabled: false
+    trust-manager:
+      enabled: false
+    ecrCredentialProvider:
+      # Off by default. The "Authenticate to Amazon ECR with Node IAM" config
+      # option flips it on below.
+      enabled: false
+      imagePullSecrets:
+        - name: '{{repl ImagePullSecretName }}'
+      image:
+        repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/docker.io/library/debian'
+
+  optionalValues:
+    - when: '{{repl ConfigOptionEquals "ecr_credential_provider_enabled" "1" }}'
+      recursiveMerge: true
+      values:
+        ecrCredentialProvider:
+          enabled: true
+    # Give the installer something real to prove the node's IAM identity
+    # against, but only when the sandbox image actually lives in ECR — pointing
+    # the self-test at a GHCR or Artifact Registry host would just report a
+    # failure the plugin was never meant to handle.
+    - when: '{{repl and (ConfigOptionEquals "ecr_credential_provider_enabled" "1") (ConfigOptionEquals "custom_sandbox_image_enabled" "1") (contains ".dkr.ecr." (ConfigOption "custom_sandbox_image_repository")) }}'
+      recursiveMerge: true
+      values:
+        ecrCredentialProvider:
+          selfTestImage: 'repl{{ ConfigOption "custom_sandbox_image_repository" }}'
+    # The plugin runs on the host as a child of the kubelet, so it needs the
+    # proxy settings the rest of the app gets. IMDS is pinned into NO_PROXY
+    # regardless of what the operator entered: it is a link-local address, and
+    # sending it to a proxy is what silently breaks instance-profile lookups.
+    - when: |
+        {{repl $computedNoProxy := "169.254.169.254" }}
+        {{repl if ne (ConfigOption "no_proxy") "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy (ConfigOption "no_proxy") }}{{repl end }}
+        {{repl and (ConfigOptionEquals "ecr_credential_provider_enabled" "1") (ConfigOptionEquals "proxy_enabled" "1") }}
+      recursiveMerge: true
+      values:
+        ecrCredentialProvider:
+          providerEnv:
+            HTTP_PROXY: '{{repl ConfigOption "http_proxy"}}'
+            HTTPS_PROXY: '{{repl ConfigOption "https_proxy"}}'
+            NO_PROXY: '{{repl $computedNoProxy}}'
+    - when: '{{repl HasLocalRegistry }}'
+      recursiveMerge: true
+      values:
+        ecrCredentialProvider:
+          image:
+            repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/debian'
+
+  builder:
+    # Render only the ECR credential provider installer so `replicated release`
+    # discovers its image; cert-manager/trust-manager images come from their own
+    # releases.
+    cert-manager:
+      enabled: false
+    trust-manager:
+      enabled: false
+    ecrCredentialProvider:
+      enabled: true

--- a/replicated/infra-ecr-credential-provider.yaml
+++ b/replicated/infra-ecr-credential-provider.yaml
@@ -55,10 +55,12 @@ spec:
     # proxy settings the rest of the app gets. IMDS is pinned into NO_PROXY
     # regardless of what the operator entered: it is a link-local address, and
     # sending it to a proxy is what silently breaks instance-profile lookups.
-    - when: |
-        {{repl $computedNoProxy := "169.254.169.254" }}
-        {{repl if ne (ConfigOption "no_proxy") "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy (ConfigOption "no_proxy") }}{{repl end }}
-        {{repl and (ConfigOptionEquals "ecr_credential_provider_enabled" "1") (ConfigOptionEquals "proxy_enabled" "1") }}
+    # Kept on one line on purpose. KOTS runs strconv.ParseBool over the rendered
+    # `when`, and a block scalar leaves the newlines in, so the assignments above
+    # the boolean render as "\n\nfalse\n" and ParseBool rejects it — which fails
+    # the whole release at app-pull time, for every config, whether or not this
+    # feature is switched on.
+    - when: '{{repl $computedNoProxy := "169.254.169.254" }}{{repl if ne (ConfigOption "no_proxy") "" }}{{repl $computedNoProxy = printf "%s,%s" $computedNoProxy (ConfigOption "no_proxy") }}{{repl end }}{{repl and (ConfigOptionEquals "ecr_credential_provider_enabled" "1") (ConfigOptionEquals "proxy_enabled" "1") }}'
       recursiveMerge: true
       values:
         ecrCredentialProvider:

--- a/scripts/test_ecr_credential_provider_contract.py
+++ b/scripts/test_ecr_credential_provider_contract.py
@@ -1,0 +1,225 @@
+"""Tests for the ECR credential provider contract.
+
+The installer is a host-level change driven from three places that have to agree:
+the KOTS config option, the Replicated HelmChart release that reads it, and the
+chart values the release turns on. A drift between them fails silently — nodes
+just keep failing ECR pulls — so it is asserted here rather than left to review.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INFRA_CHART = REPO_ROOT / "charts" / "infra"
+INFRA_VALUES = INFRA_CHART / "values.yaml"
+INSTALL_SCRIPT = INFRA_CHART / "files" / "install-ecr-credential-provider.sh"
+ECR_RELEASE = REPO_ROOT / "replicated" / "infra-ecr-credential-provider.yaml"
+OPENHANDS_RELEASE = REPO_ROOT / "replicated" / "openhands.yaml"
+CONFIG = REPO_ROOT / "replicated" / "config.yaml"
+SUPPORT_BUNDLE = (
+    REPO_ROOT / "charts" / "openhands" / "templates" / "troubleshoot" / "support-bundle.yaml"
+)
+
+CONFIG_OPTION = "ecr_credential_provider_enabled"
+
+
+def load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text())
+
+
+@pytest.fixture(scope="module")
+def infra_values() -> dict:
+    return load_yaml(INFRA_VALUES)["ecrCredentialProvider"]
+
+
+@pytest.fixture(scope="module")
+def ecr_release() -> dict:
+    return load_yaml(ECR_RELEASE)
+
+
+@pytest.fixture(scope="module")
+def config_items() -> dict:
+    config = load_yaml(CONFIG)
+    return {
+        item["name"]: item
+        for group in config["spec"]["groups"]
+        for item in group.get("items", [])
+    }
+
+
+def test_config_option_exists_and_defaults_off(config_items: dict) -> None:
+    """The node-level change must never be on unless an operator asked for it."""
+    item = config_items[CONFIG_OPTION]
+    assert item["type"] == "bool"
+    assert item["default"] == "0"
+
+
+def test_chart_default_is_off(infra_values: dict) -> None:
+    """A chart consumer that never heard of this feature must not get it."""
+    assert infra_values["enabled"] is False
+
+
+def test_release_enables_the_chart_from_the_config_option(ecr_release: dict) -> None:
+    enabling = [
+        entry
+        for entry in ecr_release["spec"]["optionalValues"]
+        if entry["values"].get("ecrCredentialProvider", {}).get("enabled") is True
+    ]
+    assert len(enabling) == 1, "exactly one optionalValues block should turn the installer on"
+    assert CONFIG_OPTION in enabling[0]["when"]
+
+
+def test_release_carries_only_the_installer(ecr_release: dict) -> None:
+    """cert-manager and trust-manager have their own weighted releases."""
+    values = ecr_release["spec"]["values"]
+    assert values["cert-manager"]["enabled"] is False
+    assert values["trust-manager"]["enabled"] is False
+    assert values["ecrCredentialProvider"]["enabled"] is False
+
+
+def test_release_is_weighted_after_every_other_release(ecr_release: dict) -> None:
+    """The first deploy restarts k0s, so it has to land after KOTS applies the rest."""
+    weights = []
+    for manifest in sorted((REPO_ROOT / "replicated").glob("*.yaml")):
+        doc = load_yaml(manifest)
+        if doc.get("kind") == "HelmChart" and manifest != ECR_RELEASE:
+            weights.append(doc["spec"]["weight"])
+    assert ecr_release["spec"]["weight"] > max(weights)
+
+
+def test_release_does_not_wait(ecr_release: dict) -> None:
+    """Helm must not be blocking on this DaemonSet while the API server bounces."""
+    assert "helmUpgradeFlags" not in ecr_release["spec"]
+
+
+def test_self_test_is_scoped_to_ecr_repositories(ecr_release: dict) -> None:
+    """Pointing the self-test at a non-ECR registry would report a bogus failure."""
+    entries = [
+        entry
+        for entry in ecr_release["spec"]["optionalValues"]
+        if "selfTestImage" in entry["values"].get("ecrCredentialProvider", {})
+    ]
+    assert len(entries) == 1
+    when = entries[0]["when"]
+    assert CONFIG_OPTION in when
+    assert ".dkr.ecr." in when
+
+
+def test_proxy_block_always_keeps_imds_off_the_proxy(ecr_release: dict) -> None:
+    """A proxied IMDS request is the quiet way instance-profile lookups break."""
+    entries = [
+        entry
+        for entry in ecr_release["spec"]["optionalValues"]
+        if "providerEnv" in entry["values"].get("ecrCredentialProvider", {})
+    ]
+    assert len(entries) == 1
+    assert "169.254.169.254" in entries[0]["when"]
+    assert set(entries[0]["values"]["ecrCredentialProvider"]["providerEnv"]) == {
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+    }
+
+
+def test_match_images_cover_the_aws_partitions(infra_values: dict) -> None:
+    globs = infra_values["matchImages"]
+    assert "*.dkr.ecr.*.amazonaws.com" in globs
+    assert "public.ecr.aws" in globs
+    for glob in globs:
+        # Each kubelet glob matches a single subdomain segment, so a wildcard
+        # spanning a dot would silently never match.
+        assert "*." in glob or "*" not in glob, glob
+
+
+def test_checksums_are_sha256_and_both_arches_present(infra_values: dict) -> None:
+    assert set(infra_values["checksums"]) == {"amd64", "arm64"}
+    for digest in infra_values["checksums"].values():
+        assert re.fullmatch(r"[0-9a-f]{64}", digest), digest
+
+
+def test_release_url_and_version_agree_with_the_installer(infra_values: dict) -> None:
+    """The installer builds the download URL, so the values must fit its layout."""
+    assert infra_values["version"].startswith("v")
+    assert infra_values["releaseBaseUrl"].endswith("/releases/download")
+    script = INSTALL_SCRIPT.read_text()
+    assert (
+        '$ECR_CP_RELEASE_BASE_URL/$ECR_CP_VERSION/ecr-credential-provider-linux-$ARCH' in script
+    )
+
+
+def test_installer_refuses_an_unverified_binary() -> None:
+    """The plugin comes from a third-party rebuild, so the pin is the trust boundary."""
+    script = INSTALL_SCRIPT.read_text()
+    assert 'err "checksum mismatch' in script
+
+
+def test_pull_secret_env_still_falls_back_when_no_registry_credentials() -> None:
+    """With node IAM there is no ECR pull secret, so the sandbox env must not demand one."""
+    text = OPENHANDS_RELEASE.read_text()
+    line = next(l for l in text.splitlines() if "RUNTIME_IMAGE_PULL_SECRETS" in l)
+    assert "ImagePullSecretName" in line
+
+
+def test_support_bundle_collects_the_installer_logs() -> None:
+    assert "ecr-credential-provider-installer" in SUPPORT_BUNDLE.read_text()
+
+
+def test_daemonset_renders_only_when_enabled() -> None:
+    def render(enabled: bool) -> str:
+        return subprocess.run(
+            [
+                "helm",
+                "template",
+                "infra",
+                str(INFRA_CHART),
+                "--set",
+                "cert-manager.enabled=false",
+                "--set",
+                "trust-manager.enabled=false",
+                "--set",
+                f"ecrCredentialProvider.enabled={'true' if enabled else 'false'}",
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        ).stdout
+
+    assert "ecr-credential-provider-installer" not in render(False)
+    assert "ecr-credential-provider-installer" in render(True)
+
+
+def test_rendered_install_script_is_byte_identical_to_the_source() -> None:
+    """The host runs whatever the pod spec carries, so the inlining must not mangle it."""
+    rendered = subprocess.run(
+        [
+            "helm",
+            "template",
+            "infra",
+            str(INFRA_CHART),
+            "--set",
+            "cert-manager.enabled=false",
+            "--set",
+            "trust-manager.enabled=false",
+            "--set",
+            "ecrCredentialProvider.enabled=true",
+            "--show-only",
+            "templates/ecr-credential-provider-installer.yaml",
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    ).stdout
+    daemonset = yaml.safe_load(rendered)
+    env = {
+        entry["name"]: entry.get("value", "")
+        for entry in daemonset["spec"]["template"]["spec"]["containers"][0]["env"]
+    }
+    assert env["INSTALL_SCRIPT"] == INSTALL_SCRIPT.read_text()

--- a/scripts/test_ecr_credential_provider_contract.py
+++ b/scripts/test_ecr_credential_provider_contract.py
@@ -223,3 +223,26 @@ def test_rendered_install_script_is_byte_identical_to_the_source() -> None:
         for entry in daemonset["spec"]["template"]["spec"]["containers"][0]["env"]
     }
     assert env["INSTALL_SCRIPT"] == INSTALL_SCRIPT.read_text()
+
+
+def test_no_when_conditional_survives_yaml_loading_with_a_newline() -> None:
+    """A block-scalar `when:` breaks every install of the release, not just this feature.
+
+    KOTS runs strconv.ParseBool over the rendered `when`, and it evaluates every
+    HelmChart's conditionals at app-pull time regardless of config. A `when: |`
+    keeps its newlines, so the value arrives as "\\n\\nfalse\\n" and ParseBool
+    rejects it, failing the install even with the feature switched off. Folded
+    (`>-`) and single-line scalars both load without newlines and are fine.
+    """
+    offenders = []
+    for manifest in sorted((REPO_ROOT / "replicated").glob("*.yaml")):
+        doc = load_yaml(manifest)
+        if not isinstance(doc, dict) or doc.get("kind") != "HelmChart":
+            continue
+        for index, entry in enumerate(doc.get("spec", {}).get("optionalValues") or []):
+            when = entry.get("when", "")
+            if "\n" in when:
+                offenders.append(f"{manifest.name}[{index}]: {when!r}")
+    assert not offenders, "block-scalar `when:` found (must load as a single line): " + "; ".join(
+        offenders
+    )


### PR DESCRIPTION
## Description

Operators running the embedded cluster installer with a custom agent server image in Amazon ECR have no good way to authenticate to it. ECR authorization tokens expire after 12 hours, so the registry password in the sandbox image config goes stale twice a day and someone has to paste a fresh one into the admin console.

This adds a config option, "Authenticate to Amazon ECR with Node IAM", that pulls from ECR using each node's own EC2 instance profile. Nothing in the cluster holds an ECR token, so nothing expires. Registry username and password can be left blank.

## Approach

The two settings kubelet needs, `--image-credential-provider-config` and `--image-credential-provider-bin-dir`, are command-line flags rather than `KubeletConfiguration` fields. That rules out the config paths you'd reach for first. k0s `workerProfiles` only merges into `KubeletConfiguration`, and embedded cluster's `unsupportedOverrides.k0s` only patches the k0s `ClusterConfig`. Embedded cluster hardcodes `--kubelet-extra-args` when it runs `k0s install`, and the k0s systemd unit bakes its arguments straight into `ExecStart=` with no `EnvironmentFile`, so there's no drop-in to hook either.

So a privileged DaemonSet rewrites the unit and restarts k0s once per node, keeping the original at `<installDir>/<unit>.service.orig`. The restart is what makes the flags take effect. k0s builds kubelet's argument list once at startup and its supervisor re-execs kubelet from that stored list, so killing kubelet alone changes nothing.

That restart briefly takes the API server down on a controller. The release is therefore weighted last and doesn't pass `--wait`, so it lands after KOTS has finished applying every other release. Only the first enable pays the cost. The installer compares desired against actual and restarts nothing once the flags are in place, and running containers survive the bounce because containerd's shims outlive containerd.

The plugin binary is downloaded on the host and checksum-pinned. There's no first-party artifact to use - `kubernetes/cloud-provider-aws` publishes no release binary and its `registry.k8s.io` repository carries no tags - so this pulls a rebuild of the upstream source and verifies the digest before installing it. Air-gapped installs need `ecrCredentialProvider.releaseBaseUrl` repointed at an internal mirror.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

`ecrCredentialProvider.enabled` defaults to `false` and the chart renders nothing when it's off, which a contract test asserts.

## Additional Notes

This needs EC2 nodes with an instance profile granting `ecr:GetAuthorizationToken`, plus `ecr:BatchGetImage` and `ecr:GetDownloadUrlForLayer` on the repository. A node outside EC2 has no credential source, so the installer runs a self-test on each node and logs loudly when the node's IAM identity can't obtain a token.

Verified on a clean embedded cluster install on EC2. A warm runtime pod failed two ECR pulls with `no basic auth credentials`, then pulled the same image successfully 50 seconds after the credential provider went in, with no credential added to the cluster in between.

`charts/infra/README.md` has a section on what the installer does to the node and how to undo it by hand.