### PR TITLE
fix(replicated): drop the KOTS update check that ruins the target cursor

### DIFF
--- a/scripts/replicated_deploy.sh
+++ b/scripts/replicated_deploy.sh
@@ -19,6 +19,8 @@ fail() { echo "::error::$*"; exit 1; }
 api()  { curl -sS -k --max-time "${TMO:-30}" -b "$JAR" -c "$JAR" "$@"; }
 post() { api -H 'Content-Type: application/json' -X POST "$@"; }
 ok()   { jq -e '.success == true' >/dev/null 2>&1; }
+# KOTS returns its rejection reason in .error; print that, not just "rejected".
+why()  { local b; b="$(cat)"; jq -re '.error // empty' <<<"$b" 2>/dev/null || printf '%s' "${b:-<empty response>}"; }
 
 # A 401 still sets a cookie, so a non-empty jar proves nothing.
 # Retried: kotsadm is often mid-restart when a release lands back-to-back with
@@ -37,20 +39,24 @@ done
 
 # --- select --------------------------------------------------------------
 # KOTS_CURSOR is the channel sequence; versionLabel is not unique.
-# A restarted kotsadm serves `updates: null` until a check repopulates its
-# cache, so re-issue the check rather than trusting the first read. `// []`
-# keeps an absent key from failing the pipe under pipefail, which would exit
-# before the message below.
-# Capped at 3m, not the whole budget: a cursor absent this long is a real
-# problem, not a restart settling. TMO=60 so the cap allows several tries.
+# Never POST /updatecheck here: on embedded cluster it downloads the pending
+# release, which advances the store's update cursor to the target, after which
+# start-upgrade-service can no longer find it upstream. GET /updates fetches
+# live from replicated.app, so there is no cache a check would populate.
+# `// []` keeps an absent key from failing the pipe under pipefail.
+# Capped at 3m: a cursor absent this long is a real problem, not a settling restart.
 TARGET=""
 SELECT_DEADLINE=$(( $(date +%s) + 180 ))
 while :; do
-  TMO=60 post -d '{}' "$KOTS_BASE/api/v1/app/$APP/updatecheck" >/dev/null || true
   TARGET="$( (api "$KOTS_BASE/api/v1/app/$APP/updates" || true) \
     | jq -c --arg c "$KOTS_CURSOR" '(.updates // [])[] | select(.updateCursor == $c)' || true)"
   [ -n "$TARGET" ] && break
   if [ "$(date +%s)" -ge "$SELECT_DEADLINE" ] || ! waiting; then
+    # A downloaded cursor is a pending version and no longer an upstream update;
+    # no wait recovers it. Deploying it needs the console (skips cluster upgrade).
+    SEQ="$( (api "$KOTS_BASE/api/v1/apps" || true) | jq -r --arg c "$KOTS_CURSOR" \
+      '.apps[0].downstream.pendingVersions[]? | select(.updateCursor == $c) | .sequence' | head -1)"
+    [ -n "$SEQ" ] && fail "cursor $KOTS_CURSOR was already downloaded as pending sequence $SEQ, so it is no longer an upstream update — deploy that version from the admin console"
     fail "cursor $KOTS_CURSOR never became an available update for $APP"
   fi
   echo "  cursor $KOTS_CURSOR not in the update list yet, rechecking"
@@ -64,9 +70,15 @@ echo "budget: ${TIMEOUT_MINUTES}m"
 echo "deploying: $FROM -> $(jq -r .versionLabel <<<"$TARGET") @ $KOTS_CURSOR"
 
 # --- boot the upgrade service -------------------------------------------
-post --data "$(jq -c '{versionLabel, updateCursor, channelId}' <<<"$TARGET")" \
-  "$KOTS_BASE/api/v1/app/$APP/start-upgrade-service" | ok \
-  || fail "start-upgrade-service rejected"
+R="$(post --data "$(jq -c '{versionLabel, updateCursor, channelId}' <<<"$TARGET")" \
+  "$KOTS_BASE/api/v1/app/$APP/start-upgrade-service" || true)"
+if ! ok <<<"$R"; then
+  # The reason is a cursor or license-channel mismatch; show both sides.
+  L="$(TMO=30 api "$KOTS_BASE/api/v1/app/$APP/license" || true)"
+  echo "  license: $(jq -c '.license | {channelName, licenseSequence, lastSyncedAt}' <<<"${L:-\{\}}" 2>/dev/null)"
+  echo "  release: $(jq -c '{versionLabel, updateCursor, channelId}' <<<"$TARGET")"
+  fail "start-upgrade-service rejected: $(why <<<"$R")"
+fi
 
 # Task goes "starting" then EMPTY once up. Empty means ready, not pending.
 META=""
@@ -81,8 +93,8 @@ done
 # --- config: read values, write them straight back -----------------------
 if [ "$(jq -r .isConfigurable <<<"$META")" = true ]; then
   TMO=60 api "$UP/config" | jq -c '{configGroups}' >/tmp/cfg.json
-  TMO=60 api -H 'Content-Type: application/json' -X PUT --data-binary @/tmp/cfg.json "$UP/config" | ok \
-    || fail "config rejected — new release likely added a required item with no default"
+  R="$(TMO=60 api -H 'Content-Type: application/json' -X PUT --data-binary @/tmp/cfg.json "$UP/config" || true)"
+  ok <<<"$R" || fail "config rejected: $(why <<<"$R") — new release likely added a required item with no default"
 fi
 
 # --- preflights ----------------------------------------------------------
@@ -102,8 +114,8 @@ if [ "$(jq -r .hasPreflight <<<"$META")" = true ]; then
 fi
 
 # --- deploy --------------------------------------------------------------
-TMO=120 post -d '{"isSkipPreflights":false,"continueWithFailedPreflights":false}' "$UP/deploy" | ok \
-  || fail "deploy rejected"
+R="$(TMO=120 post -d '{"isSkipPreflights":false,"continueWithFailedPreflights":false}' "$UP/deploy" || true)"
+ok <<<"$R" || fail "deploy rejected: $(why <<<"$R")"
 
 # The task stays empty for the whole deploy; downstream currentVersion is the
 # only progress signal. An unreachable console means kotsadm is restarting.


### PR DESCRIPTION
## Description

`Release Replicated to Unstable` has been failing intermittently with a bare `start-upgrade-service rejected` and no reason. Both attempts of [run 33182707258](https://github.com/OpenHands/OpenHands-Cloud/actions/runs/33182707258) died that way, ~1.5s after the script's own precheck had confirmed the release was deployable.

**The deploy script was hiding its own release from KOTS.**

1. `POST /updatecheck` — on embedded cluster this **downloads** the pending release, in a goroutine.
2. The download writes an `app_version` row, and `GetCurrentUpdateCursor` returns the highest *downloaded* cursor — now the target itself.
3. `start-upgrade-service` asks replicated.app for releases *after* that cursor: `GET /release/openhands/pending?channelSequence=446` → `[]`.
4. KOTS replies `update not found`, HTTP 400.

Downloading the release is what removes it from the list the next call queries. `GET /updates` ran before the download landed and reported `isDeployable: true`; `start-upgrade-service` ran after it landed. Success came down to whether the download was slow.

Caught in the act on the instance — the `app_version` row for cursor 446 was created at `17:03:27`, the same second the call was rejected:

```
cursor 443  seq 67  pending    ← download (junk)      cursor 445  seq 71  pending  14:57:58  ← attempt 1
cursor 443  seq 68  deployed   ← upgrade service      cursor 446  seq 72  pending  17:03:27  ← attempt 2
cursor 444  seq 69  pending    ← download (junk)
cursor 444  seq 70  deployed   ← upgrade service
```

The update check was never needed. `GET /updates` calls `license.Sync` then `update.GetAvailableUpdates`, which hits replicated.app live on every request — there is no cache for a check to populate. The old comment was reading a transient 500 (`updates: null`) as a cache miss.

### Changes — `scripts/replicated_deploy.sh`

- **Drop `POST /updatecheck` from the select loop.** This is the fix.
- **Print KOTS's `.error` on rejection** at all three call sites (`start-upgrade-service`, config `PUT`, `deploy`). The reason was always in the response body; `| ok` discarded it, which is why a day of failures produced zero diagnosis.
- A cursor that's missing from `/updates` but present as a pending version now fails with that fact and the sequence number, instead of "never became an available update".
- Dump license channel vs. release channel on a start rejection, for the license-mismatch variant.

Deliberately **not** done: auto-deploying the pending sequence as a fallback. `DeployAppVersion` has no embedded-cluster guard so it would work, but it's the app-only path and silently skips the cluster upgrade — wrong for any release that bumps the Embedded Cluster version. Failing loudly and clicking Deploy in the console is the right call there.

### Verification

`bash -n` and `shellcheck -S warning` clean. **Not exercised against a live instance** — first real proof is the next push to `main`.

Cursor 446 stays stuck either way: its cursor is already burned and no script change recovers it. PLTF-3456 is cumulative from `main`, so the next release carries it forward.

## Helm Chart Checklist

<!-- No Helm charts touched in this PR. -->

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

No Helm chart changes.

Two adjacent issues found while digging, both out of scope here:

- **"Re-run all jobs" cuts a new release every time.** It re-executes `make release`, so attempt 1 produced release 1539 (cursor 445) and attempt 2 produced 1540 (cursor 446). That's where the "missing" 445 came from. Retry with **"Re-run failed jobs"** (preserves the release job's outputs, deploy reuses the same cursor), or dispatch `deploy-replicated.yml` directly with a known cursor.
- **Every past successful deploy left a junk pending `app_version` row** from the download (seq 67, 69, 71, 72 above). Harmless once the check is gone — the upgrade service always creates its own row rather than deploying the downloaded one.

One thing I could not verify: dropping the check also stops refreshing `app.LastUpdateCheckAt`, which is sent to replicated.app as a `lastUpdateCheckAt` query param on the pending-releases call. Nothing in the KOTS source gates the response on it, but the server side isn't inspectable from here. If the next release doesn't show up in `GET /updates`, that's the first thing to suspect.
