### PR TITLE
feat(runtime-api): sync split cleanup CronJob from runtime-api#729

### DIFF
--- a/charts/openhands/charts/runtime-api/templates/_helpers.tpl
+++ b/charts/openhands/charts/runtime-api/templates/_helpers.tpl
@@ -10,6 +10,13 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
+{{- define "runtime-api.cronjobName" -}}
+{{- $suffix := printf "-%s" .suffix -}}
+{{- $maxLen := int (sub 52 (len $suffix)) -}}
+{{- $fullname := include "runtime-api.fullname" .root -}}
+{{- printf "%s%s" ($fullname | trunc $maxLen | trimSuffix "-") $suffix -}}
+{{- end -}}
+
 {{- define "runtime-api.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}

--- a/charts/openhands/charts/runtime-api/templates/cleanup-cronjob.yaml
+++ b/charts/openhands/charts/runtime-api/templates/cleanup-cronjob.yaml
@@ -1,56 +1,76 @@
 
 {{- if .Values.cleanup.enabled }}
+{{- $jobs := dict "reaper" .Values.cleanup.jobs.reaper "k8s-garbage" (index .Values.cleanup.jobs "k8s-garbage") "snapshotter" .Values.cleanup.jobs.snapshotter "retention" .Values.cleanup.jobs.retention }}
+{{- range $phase, $cfg := $jobs }}
+{{- if $cfg.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "runtime-api.fullname" . }}-cleanup
+  name: {{ include "runtime-api.cronjobName" (dict "root" $ "suffix" (printf "cleanup-%s" $phase)) }}
   labels:
-    {{- include "runtime-api.labels" . | nindent 4 }}
+    {{- include "runtime-api.labels" $ | nindent 4 }}
 spec:
-  schedule: {{ .Values.cleanup.schedule | quote }}
+  schedule: {{ $cfg.schedule | quote }}
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: {{ .Values.jobSettings.successfulJobsHistoryLimit }}
-  failedJobsHistoryLimit: {{ .Values.jobSettings.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ $.Values.jobSettings.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ $.Values.jobSettings.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
-      activeDeadlineSeconds: {{ .Values.jobSettings.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ $cfg.activeDeadlineSeconds }}
       template:
         spec:
-          {{- with .Values.securityContext }}
+          {{- with $.Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          serviceAccountName: {{ .Values.serviceAccount.name }}
-          {{- with .Values.imagePullSecrets }}
+          serviceAccountName: {{ $.Values.serviceAccount.name }}
+          {{- with $.Values.imagePullSecrets }}
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with (include "runtime-api.affinity" .) }}
+          {{- with (include "runtime-api.affinity" $) }}
           affinity:
             {{- . | nindent 12 }}
           {{- end }}
-          {{- if .Values.ingressBase.enabled }}
+          {{- if $.Values.ingressBase.enabled }}
           volumes:
             - name: ingress-base-config
               configMap:
-                name: {{ include "runtime-api.fullname" . }}-ingress-base
+                name: {{ include "runtime-api.fullname" $ }}-ingress-base
+          {{- end }}
+          {{- if and (eq $phase "reaper") $.Values.runtimeFileArchive.enabled }}
+            - name: archive-tmp
+              emptyDir:
+                sizeLimit: {{ $.Values.runtimeFileArchive.tmpSizeLimit | default "10Gi" | quote }}
           {{- end }}
           containers:
-          - name: cleanup
-            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-            command: ["python", "cleanup.py"]
+          - name: cleanup-{{ $phase }}
+            image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+            imagePullPolicy: {{ $.Values.image.pullPolicy }}
+            command: ["python", "cleanup.py", "{{ $phase }}"]
             env:
-              {{- include "runtime-api.env" . | nindent 14 }}
+              {{- include "runtime-api.env" $ | nindent 14 }}
               - name: DB_POOL_SIZE
-                value: {{ .Values.database.poolSize.cronjobs | default 2 | quote }}
+                value: {{ $.Values.database.poolSize.cronjobs | default 2 | quote }}
               - name: DB_MAX_OVERFLOW
-                value: {{ .Values.database.maxOverflow.cronjobs | default 5 | quote }}
-            {{- if .Values.ingressBase.enabled }}
+                value: {{ $.Values.database.maxOverflow.cronjobs | default 5 | quote }}
+              {{- if and (eq $phase "reaper") $.Values.runtimeFileArchive.enabled }}
+              - name: RUNTIME_FILE_ARCHIVE_TMPDIR
+                value: {{ $.Values.runtimeFileArchive.tmpDir | default "/archive-tmp" | quote }}
+              {{- end }}
+            {{- if $.Values.ingressBase.enabled }}
             volumeMounts:
               - name: ingress-base-config
                 mountPath: /ingress-base
             {{- end }}
+            {{- if and (eq $phase "reaper") $.Values.runtimeFileArchive.enabled }}
+              - name: archive-tmp
+                mountPath: {{ $.Values.runtimeFileArchive.tmpDir | default "/archive-tmp" | quote }}
+            {{- end }}
             resources:
-              {{- toYaml .Values.jobSettings.resources | nindent 14 }}
+              {{- toYaml $.Values.jobSettings.resources | nindent 14 }}
           restartPolicy: OnFailure
+---
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -202,9 +202,39 @@ autoscaling:
 
 cleanup:
   enabled: true
-  schedule: "*/5 * * * *"
+  schedule: "*/5 * * * *" # legacy: used by run_cleanup() if cleanup.jobs is absent
   idle_seconds: 1200 # Default to 20 minutes
   dead_seconds: 5184000 # Default to 60 days (stopgap until workspace archiving ships; runtime-api#624)
+  # Split per-phase CronJobs. Each phase runs in its own pod so a problem in
+  # one can't starve the others, and each gets its own schedule, deadline and
+  # concurrency policy. The phases map 1:1 to the run_* entrypoints in
+  # cleanup.py and are invoked as `python cleanup.py <phase>`.
+  #
+  # reaper       — pause/stop/remove idle runtimes. Highest urgency, tight cadence.
+  # k8s-garbage  — reap pods stuck terminating, then their stuck PVCs (serial:
+  #                pods before PVCs, a mounted PVC can't finish deleting).
+  # snapshotter  — snapshot + delete PVCs for long-paused runtimes. Own deadline.
+  # retention    — delete dead runtimes + expired fuse workspaces. Hourly.
+  #
+  # Stagger the two K8s-list-heavy jobs (reaper, k8s-garbage) to avoid
+  # simultaneous full namespace pod/PVC lists against the apiserver.
+  jobs:
+    reaper:
+      enabled: true
+      schedule: "*/5 * * * *"
+      activeDeadlineSeconds: 900 # 15 min; reaper must stay responsive
+    k8s-garbage:
+      enabled: true
+      schedule: "2-59/5 * * * *" # offset ~2 min from the reaper to stagger apiserver lists
+      activeDeadlineSeconds: 600 # 10 min; light, fast K8s reaps
+    snapshotter:
+      enabled: true
+      schedule: "*/10 * * * *" # slower than the reaper; snapshots lag pause by design
+      activeDeadlineSeconds: 1200 # 20 min; must exceed SNAPSHOT_WAIT_DEADLINE_SECONDS (300)
+    retention:
+      enabled: true
+      schedule: "0 */1 * * *" # hourly; long-horizon sweeps
+      activeDeadlineSeconds: 1800 # 30 min; DB + object-storage heavy
 
 # Workspace archiving (primary, pause/reap path): before the cleanup CronJob
 # pauses/stops a runtime — while its pod is still reachable — copy the workspace
@@ -223,6 +253,8 @@ runtimeFileArchive:
   bucket: ""
   prefix: workspace-archives # Key prefix within the bucket.
   path: /workspace/project # Source path to archive (git repo root).
+  tmpDir: /archive-tmp # Mount path for the archive scratch volume (reaper phase only).
+  tmpSizeLimit: 10Gi # Size limit for the archive scratch emptyDir.
   # Safe default: capture BOTH the compact git-delta and a self-contained
   # tar.gz. git-delta alone is lossy (respects .gitignore, needs the base tree
   # to reconstruct); narrow to git-delta only with a bucket lifecycle policy.


### PR DESCRIPTION
## Problem

PR [OpenHands/runtime-api#729](https://github.com/OpenHands/runtime-api/pull/729) (merged in release [v0.9.0](https://github.com/OpenHands/runtime-api/releases/tag/v0.9.0)) split the single cleanup CronJob into four per-phase CronJobs (`reaper`, `k8s-garbage`, `snapshotter`, `retention`) for independent failure isolation.

The runtime-api chart was published as OCI artifact `0.2.12`, but the **vendored copy** of the runtime-api subchart in `charts/openhands/charts/runtime-api/` was never updated — PR #1177 only bumped the `image.tag` (`0.8.2` → `0.9.0`) in `values.yaml`. As a result, no published `openhands` umbrella version (including `0.57.0`) contains the split. Deployed clusters still see the old single `…-cleanup` CronJob.

## Changes

This PR syncs the three changed files from the runtime-api source into the vendored subchart:

### `cleanup-cronjob.yaml`
Rewritten from a single CronJob to a `range`-driven template rendering four CronJobs, each with its own `schedule`, `activeDeadlineSeconds`, and `python cleanup.py <phase>` command.

**Preserves the vendored chart's existing features** that are not in the runtime-api source chart:
- `runtime-api.affinity` include
- `ingressBase.enabled` volumes/volumeMounts

The archive `emptyDir` volume/mount is scoped to the reaper phase only (the only phase that archives workspaces).

### `_helpers.tpl`
Adds the `runtime-api.cronjobName` helper (truncates the fullname to stay under K8s' 63-char name limit with the `-cleanup-<phase>` suffix).

### `values.yaml`
- Adds `cleanup.jobs.{reaper,k8s-garbage,snapshotter,retention}` with per-job `enabled`/`schedule`/`activeDeadlineSeconds`.
- Adds `runtimeFileArchive.tmpDir`/`tmpSizeLimit` (referenced by the new template, with `default` fallbacks for backwards compat).
- Preserves existing defaults (`dead_seconds: 5184000`, etc.).

## Schedules

| Job | Phase(s) | Schedule | Deadline |
|---|---|---|---|
| `cleanup-reaper` | pause/stop/remove idle runtimes | `*/5 * * * *` | 900s |
| `cleanup-k8s-garbage` | reap pods then stuck PVCs (serial) | `2-59/5 * * * *` | 600s |
| `cleanup-snapshotter` | snapshot + delete PVCs | `*/10 * * * *` | 1200s |
| `cleanup-retention` | delete dead runtimes + expired fuse workspaces | `0 */1 * * *` | 1800s |

The two K8s-list-heavy jobs (reaper `*/5`, k8s-garbage `2-59/5`) are staggered to avoid simultaneous full namespace pod/PVC lists against the apiserver.

## Validation

- `helm lint` on the runtime-api subchart: **passed** (0 errors)
- `helm template` renders all 4 CronJobs with correct names, schedules, deadlines, and commands
- Archive `emptyDir` volume/mount confirmed scoped to reaper phase only
- `ingressBase` volumes confirmed present in all phases when enabled

## After merge

The next `openhands` umbrella release (e.g. `0.58.0`) will bundle this updated subchart. `saas-deploy` must then bump its `Chart.yaml` pin to that version and re-deploy.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._
