### PR TITLE
fix: rename warm-runtime default config to v1_current to match the app default spec lookup

### DIFF
--- a/charts/openhands/charts/runtime-api/templates/warm-runtimes-configmap.yaml
+++ b/charts/openhands/charts/runtime-api/templates/warm-runtimes-configmap.yaml
@@ -10,7 +10,11 @@
 {{- if not $configs }}
 {{- $configs = list }}
 {{- range $name, $config := .Values.warmRuntimes.configsByName }}
-{{- $configs = append $configs (merge (dict "name" $name) $config) }}
+{{- $entry := deepCopy $config }}
+{{- if not (hasKey $entry "name") }}
+{{- $_ := set $entry "name" $name }}
+{{- end }}
+{{- $configs = append $configs $entry }}
 {{- end }}
 {{- end }}
 {{- /* Default image for any entry that omits one: the global agent-server image. */ -}}

--- a/charts/openhands/charts/runtime-api/tests/warm_runtimes_configmap_test.yaml
+++ b/charts/openhands/charts/runtime-api/tests/warm_runtimes_configmap_test.yaml
@@ -21,3 +21,21 @@ tests:
       - notMatchRegex:
           path: data["warm-runtimes.json"]
           pattern: fuse_s3_mount
+
+  - it: preserves legacy default-key overrides while rendering v1_current
+    set:
+      warmRuntimes.enabled: true
+      warmRuntimes.configsByName.default.count: 4
+    asserts:
+      - matchRegex:
+          path: data["warm-runtimes.json"]
+          pattern: '"name": "v1_current"'
+      - matchRegex:
+          path: data["warm-runtimes.json"]
+          pattern: '"working_dir": "/workspace/project"'
+      - matchRegex:
+          path: data["warm-runtimes.json"]
+          pattern: '"count": 4'
+      - notMatchRegex:
+          path: data["warm-runtimes.json"]
+          pattern: '"name": "default"'

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -283,16 +283,16 @@ warmRuntimes:
   # Legacy list form. Kept for backwards compatibility: when non-empty it takes
   # precedence over configsByName. Prefer configsByName for new configuration.
   configs: []
-  # Canonical map form. Each key is the config's name (promoted to "name" in the
-  # rendered JSON). Maps merge cleanly across values layers, so consumers can
-  # override one field of one entry without re-declaring every entry.
+  # Canonical map form. Each key becomes the config name unless the entry sets
+  # `name` explicitly. Maps merge cleanly across values layers.
   # Set `fuse_s3_mount: true` on an entry for fusey warm pods: dormant startup,
   # /workspace FUSE-mounted from object storage instead of a PVC. Needs the
   # FUSEY_* env on runtime-api and /dev/fuse on the sandbox nodes (see the
   # device-plugin subchart).
   configsByName:
-    # Entry name must match the app's OH_SANDBOX_SPEC_DEFAULT_SPEC_NAME.
-    v1_current:
+    # Keep the map key stable for existing Helm overrides.
+    default:
+      name: v1_current
       # image omitted -> defaults to global.agentServerImage (repo:tag).
       working_dir: "/workspace/project"
       environment:

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -291,7 +291,8 @@ warmRuntimes:
   # FUSEY_* env on runtime-api and /dev/fuse on the sandbox nodes (see the
   # device-plugin subchart).
   configsByName:
-    default:
+    # Entry name must match the app's OH_SANDBOX_SPEC_DEFAULT_SPEC_NAME.
+    v1_current:
       # image omitted -> defaults to global.agentServerImage (repo:tag).
       working_dir: "/workspace/project"
       environment:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -939,9 +939,9 @@ runtime-api:
     # Map form keyed by config name; see runtime-api subchart values for the
     # legacy `configs` list and precedence rules.
     configsByName:
-      # Entry name must match OH_SANDBOX_SPEC_DEFAULT_SPEC_NAME (_env.yaml) so the
-      # app's default sandbox spec lookup resolves by name instead of list order.
-      v1_current:
+      # Keep the map key stable for existing Helm overrides.
+      default:
+        name: v1_current
         # image omitted -> defaults to global.agentServerImage (repo:tag).
         # Must match the app's sandbox spec working_dir, or no warm pod is ever claimable.
         working_dir: "/workspace/project"

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -939,7 +939,9 @@ runtime-api:
     # Map form keyed by config name; see runtime-api subchart values for the
     # legacy `configs` list and precedence rules.
     configsByName:
-      default:
+      # Entry name must match OH_SANDBOX_SPEC_DEFAULT_SPEC_NAME (_env.yaml) so the
+      # app's default sandbox spec lookup resolves by name instead of list order.
+      v1_current:
         # image omitted -> defaults to global.agentServerImage (repo:tag).
         # Must match the app's sandbox spec working_dir, or no warm pod is ever claimable.
         working_dir: "/workspace/project"

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -379,7 +379,9 @@ spec:
         enabled: true
         count: repl{{ ConfigOption "sandbox_warm_runtime_count" }}
         configsByName:
-          default:
+          # Entry name must match the app's OH_SANDBOX_SPEC_DEFAULT_SPEC_NAME
+          # (and the chart values' entry, or the layers stop merging).
+          v1_current:
             # image omitted -> inherits global.agentServerImage. Proxy by
             # default; when custom_sandbox_image_enabled / HasLocalRegistry are
             # active, the optionalValues blocks below override the global instead.
@@ -735,7 +737,7 @@ spec:
         global:
           imageRegistry: '{{repl LocalRegistryHost }}'
           # agent-server comes from the local registry; runtime.image and the
-          # warmRuntimes default entry both inherit this. Tag pinned in the chart.
+          # warmRuntimes v1_current entry both inherit this. Tag pinned in the chart.
           agentServerImage:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server'
         image:

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -379,9 +379,9 @@ spec:
         enabled: true
         count: repl{{ ConfigOption "sandbox_warm_runtime_count" }}
         configsByName:
-          # Entry name must match the app's OH_SANDBOX_SPEC_DEFAULT_SPEC_NAME
-          # (and the chart values' entry, or the layers stop merging).
-          v1_current:
+          # Keep this key aligned with the chart values for Helm merging.
+          default:
+            name: v1_current
             # image omitted -> inherits global.agentServerImage. Proxy by
             # default; when custom_sandbox_image_enabled / HasLocalRegistry are
             # active, the optionalValues blocks below override the global instead.
@@ -737,7 +737,7 @@ spec:
         global:
           imageRegistry: '{{repl LocalRegistryHost }}'
           # agent-server comes from the local registry; runtime.image and the
-          # warmRuntimes v1_current entry both inherit this. Tag pinned in the chart.
+          # warmRuntimes default entry both inherit this. Tag pinned in the chart.
           agentServerImage:
             repository: '{{repl LocalRegistryHost }}/{{repl LocalRegistryNamespace }}/agent-server'
         image:

--- a/scripts/test_warm_runtime_default_name.py
+++ b/scripts/test_warm_runtime_default_name.py
@@ -1,0 +1,44 @@
+"""Guard the default sandbox-spec name across app and installer layers."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _yaml(path: str) -> dict:
+    return yaml.safe_load((REPO_ROOT / path).read_text(encoding="utf-8"))
+
+
+def test_default_sandbox_spec_matches_every_warm_runtime_default() -> None:
+    env_template = (REPO_ROOT / "charts/openhands/templates/_env.yaml").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(
+        r"- name: OH_SANDBOX_SPEC_DEFAULT_SPEC_NAME\s+value: ([^\s]+)",
+        env_template,
+    )
+    assert match is not None
+
+    umbrella = _yaml("charts/openhands/values.yaml")
+    subchart = _yaml("charts/openhands/charts/runtime-api/values.yaml")
+    replicated = _yaml("replicated/openhands.yaml")
+
+    names = {
+        "app env": match.group(1),
+        "umbrella chart": umbrella["runtime-api"]["warmRuntimes"]["configsByName"][
+            "default"
+        ]["name"],
+        "runtime-api subchart": subchart["warmRuntimes"]["configsByName"]["default"][
+            "name"
+        ],
+        "Replicated values": replicated["spec"]["values"]["runtime-api"][
+            "warmRuntimes"
+        ]["configsByName"]["default"]["name"],
+    }
+
+    assert set(names.values()) == {"v1_current"}, names

--- a/scripts/update_openhands_charts/conftest.py
+++ b/scripts/update_openhands_charts/conftest.py
@@ -352,7 +352,8 @@ runtime-api:
     enabled: true
     count: 1
     configsByName:
-      v1_current:
+      default:
+        name: v1_current
         working_dir: "/openhands/code/"
 
 global:
@@ -404,7 +405,8 @@ warmRuntimes:
   configMapName: warm-runtimes-config
   count: 0
   configsByName:
-    v1_current:
+    default:
+      name: v1_current
       working_dir: "/openhands/code/"
       environment: {}
 

--- a/scripts/update_openhands_charts/conftest.py
+++ b/scripts/update_openhands_charts/conftest.py
@@ -352,7 +352,7 @@ runtime-api:
     enabled: true
     count: 1
     configsByName:
-      default:
+      v1_current:
         working_dir: "/openhands/code/"
 
 global:
@@ -404,7 +404,7 @@ warmRuntimes:
   configMapName: warm-runtimes-config
   count: 0
   configsByName:
-    default:
+    v1_current:
       working_dir: "/openhands/code/"
       environment: {}
 


### PR DESCRIPTION
## Summary

The app looks up its default sandbox spec by `OH_SANDBOX_SPEC_DEFAULT_SPEC_NAME=v1_current`, while the installer-managed warm-runtime entry rendered as `default`. With multiple configs the lookup missed and fell back to list order.

This aligns the rendered runtime name without breaking the existing Helm values contract:

- Keep `configsByName.default` as the stable map key in the runtime-api subchart, umbrella values, and KOTS helmValues.
- Add `name: v1_current` to that entry.
- Update the map normalizer so an explicit entry name wins; map keys are still promoted when no explicit name is present.
- Preserve Helm-direct partial overrides such as `configsByName.default.count=4`.
- Add a cross-layer invariant test tying the app env default to the umbrella, subchart, and Replicated warm-runtime entry names.

The app, reconciler, list API, and docs now see `v1_current`, while existing customer values continue merging into the complete installer entry.

## Upgrade impact

- Helm-direct installs do not need to rename existing `configsByName.default.*` overrides.
- The config entry inside `warm-runtimes.json` changes to `v1_current`; the ConfigMap object remains `warm-runtimes-config`.
- Warm pod claiming is content-based (image, command, working directory, and environment), so the name-only change does not churn otherwise matching pods.

## Testing

- Runtime-api subchart Helm unit tests: 13 passed.
- Umbrella Helm unit tests: 109 passed.
- Full script suite: 479 passed.
- Runtime-api Helm lint: clean.
- Direct render with `configsByName.default.count=4`: valid JSON, one complete `v1_current` entry, count 4.
