### PR TITLE
fix: give the Runtime API admin password a real KOTS field with a generated default

### DIFF
--- a/charts/openhands/charts/runtime-api/templates/deployment.yaml
+++ b/charts/openhands/charts/runtime-api/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
       {{- include "runtime-api.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "runtime-api.selectorLabels" . | nindent 8 }}
         {{- /* Distinguishes API pods from the warm-runtimes CronJob pods

--- a/charts/openhands/charts/runtime-api/tests/pod_annotations_test.yaml
+++ b/charts/openhands/charts/runtime-api/tests/pod_annotations_test.yaml
@@ -1,0 +1,17 @@
+suite: pod annotations
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: renders configured pod annotations
+    set:
+      podAnnotations:
+        checksum/admin-password: password-hash
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["checksum/admin-password"]
+          value: password-hash
+
+  - it: omits pod annotations by default
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -10,6 +10,10 @@ fullnameOverride: ""
 
 replicaCount: 1
 
+# Extra pod-template annotations, e.g. a checksum of secret-backed config so a
+# credential change forces a rollout (env from secretKeyRef is not live-reloaded).
+podAnnotations: {}
+
 databaseMigrations:
   waitForDatabase: true
   createDatabases: false

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -608,11 +608,6 @@ spec:
       description: Configure passwords and secrets for various services
       when: false
       items:
-        - name: admin_password
-          title: Admin Password
-          help_text: Admin password for Runtime API
-          type: password
-          hidden: true
         - name: postgres_username
           title: PostgreSQL Username
           help_text: Username for embedded PostgreSQL database
@@ -1276,6 +1271,11 @@ spec:
             regex:
               pattern: ^(0|[1-9][0-9]*)$
               message: Must be a non-negative integer
+        - name: admin_password
+          title: Runtime API Admin Password
+          help_text: Password for the Runtime API admin endpoints, used to manage warm runtime configurations (for example, running multiple custom sandbox images side by side). A random password is generated at install; to use the admin API, set your own password here and deploy. Changing this password restarts the runtime-api service.
+          type: password
+          value: '{{repl RandomString 32}}'
         - name: sandbox_max_num_sandboxes
           title: Max Concurrent Sandboxes
           help_text: >-

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -293,6 +293,10 @@ spec:
       replicaCount: 1
       autoscaling:
         enabled: false
+      # ADMIN_PASSWORD comes from a secretKeyRef, so a password change needs a
+      # rollout to take effect (same pattern as checksum/litellm-credentials).
+      podAnnotations:
+        checksum/admin-password: 'repl{{ sha256sum (ConfigOption "admin_password") }}'
       image:
         repository: 'images.r9.all-hands.dev/proxy/{{repl LicenseFieldValue "appSlug"}}/ghcr.io/openhands/runtime-api'
         # Do not override the image tag here. Pin to a stable version in the chart.


### PR DESCRIPTION
## Summary

The `admin_password` item was hidden in a disabled config group and had no generated value. Stock Replicated installs therefore rendered an empty Secret, manual Secret patches were overwritten on deploy, and password changes did not restart runtime-api even though the value is consumed through `secretKeyRef`.

## Changes

- Move `admin_password` into the visible Sandbox Configuration group as a masked Runtime API Admin Password.
- Seed unset installs with `value: '{{repl RandomString 32}}'`. With a non-readonly password item, KOTS persists the generated value and user-set values win on later deploys.
- Add runtime-api `podAnnotations` support.
- Add `checksum/admin-password` to the runtime-api pod template so only password changes alter that checksum and roll the deployment.
- Add Helm unit coverage proving annotations render and remain absent by default.

`admin_password` remains in the existing `admin-password` Secret template and in the global secrets checksum. OpenHands/runtime-api#730 independently fails closed if an existing install still has an empty stored value.

## Testing

- Runtime-api Helm unit tests: 14 passed.
- Runtime-api Helm lint: clean.
- `scripts/check_secret_checksum.py`: all 43 password fields covered.
- Replicated manifest validation remains covered by PR CI.
