### PR TITLE
feat: enable warm-runtime config overlay mode for Replicated

### DIFF
--- a/charts/openhands/charts/runtime-api/tests/warm_runtime_overlay_env_test.yaml
+++ b/charts/openhands/charts/runtime-api/tests/warm_runtime_overlay_env_test.yaml
@@ -38,3 +38,8 @@ tests:
           content:
             name: WARM_RUNTIME_CONFIG_OVERLAY
             value: "0"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WARM_RUNTIME_CONFIG_OVERLAY
+            value: "1"

--- a/charts/openhands/charts/runtime-api/tests/warm_runtime_overlay_env_test.yaml
+++ b/charts/openhands/charts/runtime-api/tests/warm_runtime_overlay_env_test.yaml
@@ -3,8 +3,11 @@ templates:
   - templates/deployment.yaml
   - templates/warm-runtimes-cronjob.yaml
 tests:
-  - it: enables overlay mode in the API deployment
+  - it: passes OHE overlay mode into the API deployment with warm pools enabled
     template: templates/deployment.yaml
+    set:
+      warmRuntimes.enabled: true
+      env.WARM_RUNTIME_CONFIG_OVERLAY: "1"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -12,13 +15,26 @@ tests:
             name: WARM_RUNTIME_CONFIG_OVERLAY
             value: "1"
 
-  - it: enables overlay mode in the reconciler CronJob
+  - it: passes OHE overlay mode into the reconciler CronJob
     template: templates/warm-runtimes-cronjob.yaml
     set:
       warmRuntimes.enabled: true
+      env.WARM_RUNTIME_CONFIG_OVERLAY: "1"
     asserts:
       - contains:
           path: spec.jobTemplate.spec.template.spec.containers[0].env
           content:
             name: WARM_RUNTIME_CONFIG_OVERLAY
             value: "1"
+
+  - it: preserves an explicit overlay opt-out
+    template: templates/deployment.yaml
+    set:
+      warmRuntimes.enabled: true
+      env.WARM_RUNTIME_CONFIG_OVERLAY: "0"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WARM_RUNTIME_CONFIG_OVERLAY
+            value: "0"

--- a/charts/openhands/charts/runtime-api/tests/warm_runtime_overlay_env_test.yaml
+++ b/charts/openhands/charts/runtime-api/tests/warm_runtime_overlay_env_test.yaml
@@ -1,0 +1,24 @@
+suite: warm runtime overlay environment
+templates:
+  - templates/deployment.yaml
+  - templates/warm-runtimes-cronjob.yaml
+tests:
+  - it: enables overlay mode in the API deployment
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WARM_RUNTIME_CONFIG_OVERLAY
+            value: "1"
+
+  - it: enables overlay mode in the reconciler CronJob
+    template: templates/warm-runtimes-cronjob.yaml
+    set:
+      warmRuntimes.enabled: true
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: WARM_RUNTIME_CONFIG_OVERLAY
+            value: "1"

--- a/charts/openhands/charts/runtime-api/tests/warm_runtime_overlay_env_test.yaml
+++ b/charts/openhands/charts/runtime-api/tests/warm_runtime_overlay_env_test.yaml
@@ -43,3 +43,20 @@ tests:
           content:
             name: WARM_RUNTIME_CONFIG_OVERLAY
             value: "1"
+
+  - it: preserves an explicit overlay opt-out in the reconciler CronJob
+    template: templates/warm-runtimes-cronjob.yaml
+    set:
+      warmRuntimes.enabled: true
+      env.WARM_RUNTIME_CONFIG_OVERLAY: "0"
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: WARM_RUNTIME_CONFIG_OVERLAY
+            value: "0"
+      - notContains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: WARM_RUNTIME_CONFIG_OVERLAY
+            value: "1"

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -50,6 +50,9 @@ service:
   port: 5000
 
 env:
+  # Database warm-runtime configs overlay the installer-managed ConfigMap by
+  # name instead of replacing it (runtime-api#731). Inert on older images.
+  WARM_RUNTIME_CONFIG_OVERLAY: "1"
   PYTHONDONTWRITEBYTECODE: "1"
   PYTHONUNBUFFERED: "1"
   DEV_MODE: "false"

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -50,9 +50,6 @@ service:
   port: 5000
 
 env:
-  # Database warm-runtime configs overlay the installer-managed ConfigMap by
-  # name instead of replacing it (runtime-api#731). Inert on older images.
-  WARM_RUNTIME_CONFIG_OVERLAY: "1"
   PYTHONDONTWRITEBYTECODE: "1"
   PYTHONUNBUFFERED: "1"
   DEV_MODE: "false"

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -328,6 +328,10 @@ spec:
         PGSSLMODE: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_ssl_mode"}}{{repl else}}prefer{{repl end}}'
         DB_USER: '{{repl if ConfigOptionEquals "postgres_type" "external_postgres"}}{{repl ConfigOption "external_postgres_username"}}{{repl else}}postgres{{repl end}}'
         DB_NAME: "runtime_api_db"
+        # Admin-API warm configs overlay installer-managed entries by name:
+        # same-named rows override them and differently-named rows run beside
+        # them. Older runtime-api images ignore this variable.
+        WARM_RUNTIME_CONFIG_OVERLAY: "1"
         RUNTIME_BASE_URL: '{{repl ConfigOption "computed_runtime_base_hostname" }}'
         # Joins the sandbox ID to RUNTIME_BASE_URL. "-" keeps each sandbox one
         # label deep ({id}-runtime.<base>) so a single *.<base> wildcard covers

--- a/scripts/test_replicated_warm_runtime_overlay.py
+++ b/scripts/test_replicated_warm_runtime_overlay.py
@@ -14,6 +14,7 @@ def _yaml(path: str) -> dict:
 def test_replicated_enables_overlay_without_changing_shared_chart_defaults() -> None:
     replicated = _yaml("replicated/openhands.yaml")
     subchart = _yaml("charts/openhands/charts/runtime-api/values.yaml")
+    umbrella = _yaml("charts/openhands/values.yaml")
 
     assert (
         replicated["spec"]["values"]["runtime-api"]["env"][
@@ -22,3 +23,4 @@ def test_replicated_enables_overlay_without_changing_shared_chart_defaults() -> 
         == "1"
     )
     assert "WARM_RUNTIME_CONFIG_OVERLAY" not in subchart["env"]
+    assert "WARM_RUNTIME_CONFIG_OVERLAY" not in umbrella["runtime-api"]["env"]

--- a/scripts/test_replicated_warm_runtime_overlay.py
+++ b/scripts/test_replicated_warm_runtime_overlay.py
@@ -1,0 +1,24 @@
+"""Keep warm-runtime overlay activation scoped to Replicated installs."""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _yaml(path: str) -> dict:
+    return yaml.safe_load((REPO_ROOT / path).read_text(encoding="utf-8"))
+
+
+def test_replicated_enables_overlay_without_changing_shared_chart_defaults() -> None:
+    replicated = _yaml("replicated/openhands.yaml")
+    subchart = _yaml("charts/openhands/charts/runtime-api/values.yaml")
+
+    assert (
+        replicated["spec"]["values"]["runtime-api"]["env"][
+            "WARM_RUNTIME_CONFIG_OVERLAY"
+        ]
+        == "1"
+    )
+    assert "WARM_RUNTIME_CONFIG_OVERLAY" not in subchart["env"]


### PR DESCRIPTION
## Summary

Enable `WARM_RUNTIME_CONFIG_OVERLAY=1` in the Replicated/OHE runtime-api helmValues so OpenHands Enterprise uses the effective ConfigMap-plus-database behavior from OpenHands/runtime-api#731.

The shared runtime-api env helper passes the Replicated value to both consumers that resolve warm configs:

- the runtime-api Deployment that serves `GET /api/warm-runtime-configs`; and
- the warm-runtimes reconciler CronJob.

Activation is intentionally scoped to Replicated. The shared runtime-api subchart default remains unset, so this PR does not silently change SaaS or Helm-direct installs. Consumers can still set the variable explicitly to `0` or `1`.

Under overlay semantics, a same-named database row overrides the installer entry, a differently-named row runs beside it, and deleting a same-name override reveals the live installer entry again.

## Rollout

The variable is inert on runtime-api images that predate #731, so this chart change can land before the runtime-api pin is updated. Overlay behavior activates for OHE only when its pinned image contains #731.

## Validation

A fresh R02 Replicated/OHE install using a combined validation image confirmed:

- `v1_current` from the KOTS ConfigMap remained visible after adding `custom-ghcr` through the admin API;
- the effective list reported `source: file` and `source: db` respectively;
- the reconciler maintained one ready pool for each image;
- a same-name `v1_current` database row overrode the file entry; and
- deleting that row immediately restored the ConfigMap entry.

The full browser smoke stopped at an unexpected Bitbucket Data Center auth redirect, so the feature-specific live API/reconciler checks pass but the overall click test is not marked PASS.

## Testing

- Runtime-api subchart Helm unit tests: 15 passed, including API, reconciler, and explicit opt-out propagation.
- Umbrella Helm unit tests: 111 passed.
- Full script suite: 479 passed, including a scope guard that requires Replicated to enable the flag while the shared subchart default remains unset.
