### PR TITLE
fix: advertise the runtime API ingress to fuse mounts

### DIFF
--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -334,7 +334,7 @@ spec:
         # it; "." nests it under the runtime base. The path-routing block below
         # overrides this to "/", which the runtime-api reads as path mode.
         RUNTIME_URL_SEPARATOR: '{{repl ConfigOption "computed_runtime_hostname_separator" }}'
-        RUNTIME_API_BASE_URL: 'https://{{repl ConfigOption "computed_runtime_base_hostname" }}'
+        RUNTIME_API_BASE_URL: 'https://{{repl ConfigOption "computed_runtime_api_hostname" }}'
         RUNTIME_IMAGE_PULL_SECRETS: '{{repl if and (ConfigOptionEquals "custom_sandbox_image_enabled" "1") (ne (ConfigOption "custom_sandbox_image_registry_server") "") (ne (ConfigOption "custom_sandbox_image_registry_username") "") (ne (ConfigOption "custom_sandbox_image_registry_password") "") }}sandbox-image-pull-secret{{repl else}}{{repl ImagePullSecretName }}{{repl end}}'
         STORAGE_CLASS: "openebs-hostpath"
         INGRESS_CLASS: "traefik"

--- a/scripts/test_replicated_dns_layout.py
+++ b/scripts/test_replicated_dns_layout.py
@@ -20,6 +20,7 @@ REPLICATED_CONFIG = REPO_ROOT / "replicated" / "config.yaml"
 
 SEPARATOR_OPTION = '{{repl ConfigOption "computed_runtime_hostname_separator" }}'
 BASE_OPTION = '{{repl ConfigOption "computed_runtime_base_hostname" }}'
+API_HOST_OPTION = '{{repl ConfigOption "computed_runtime_api_hostname" }}'
 
 
 @pytest.fixture(scope="module")
@@ -55,6 +56,14 @@ def test_installer_sets_the_separator_rather_than_inheriting_a_chart_default(
 
     assert runtime_api_env["RUNTIME_URL_SEPARATOR"] == SEPARATOR_OPTION
     assert runtime_api_env["RUNTIME_BASE_URL"] == BASE_OPTION
+
+
+def test_runtime_api_advertises_its_own_ingress_for_storage_callbacks(
+    helm_chart_cr: dict,
+) -> None:
+    runtime_api_env = helm_chart_cr["spec"]["values"]["runtime-api"]["env"]
+
+    assert runtime_api_env["RUNTIME_API_BASE_URL"] == f"https://{API_HOST_OPTION}"
 
 
 def test_app_sandbox_url_is_built_from_the_same_separator_and_base(


### PR DESCRIPTION
## Summary

Set OHE's `RUNTIME_API_BASE_URL` to `computed_runtime_api_hostname`, the hostname actually rendered on `openhands-runtime-api-ingress`.

The current value uses `computed_runtime_base_hostname`, which is the wildcard base for sandbox runtimes. runtime-api uses `RUNTIME_API_BASE_URL` only to construct fuse storage-broker callback URLs, so those callbacks are sent to the sandbox ingress instead of the runtime API.

## History

- runtime-api#619 introduced fuse/S3 warm pools and defined this variable as the URL of the Runtime API as seen from runtime pods.
- OpenHands-Cloud#926 added the OHE value on 2026-07-20, but assumed the derived API URL was `https://runtime.<base>` and wired it to the sandbox base from its first commit.
- OpenHands-Cloud#985 added `computed_runtime_api_hostname` for the actual API ingress on 2026-07-31, but mechanically preserved the old `RUNTIME_API_BASE_URL`/runtime-base pairing.

This is therefore a pre-existing fuse integration bug, independent of config-overlay activation in #1183, and can ship or be backported independently.

## Live evidence

On a fresh R02 Replicated install:

- `RUNTIME_API_BASE_URL=https://runtime.replicated-02...`
- the runtime API ingress host was `runtime-api.replicated-02...`
- requests to the configured host returned 404
- the same runtime API route on the ingress host succeeded

PVC-backed warm pools do not use this callback, which is why the main Gap 2 overlay validation still passed. Fuse-backed pools would fail when attempting to use the broker URL.

## Risk

The variable has one functional consumer in runtime-api: fuse broker URL construction during a fuse-backed claim. It is not used for PVC-backed pools, overlay resolution, admin auth, sandbox ingress naming, or the normal API/list path. All supported OHE hostname modes already put `computed_runtime_api_hostname` on the runtime-api Ingress and include it in proxy/TLS wiring.

The Deployment rolls once because an env value changes. The only plausible compatibility edge is an unsupported hand-patched install that routes the sandbox hostname to runtime-api and relies on the incorrect value; the shipped templates do not do that.

## Testing

- Added a Replicated DNS-contract regression test requiring `RUNTIME_API_BASE_URL` to use `computed_runtime_api_hostname`.
- Targeted DNS tests: 7 passed.
- Full script suite: 479 passed.
- Umbrella Helm unit tests: 108 passed.
