### PR TITLE
fix: OHE-3186 : render reaper archive volume under a volumes: key (staging reaper outage)

### DIFF
--- a/charts/openhands/charts/runtime-api/templates/cleanup-cronjob.yaml
+++ b/charts/openhands/charts/runtime-api/templates/cleanup-cronjob.yaml
@@ -3,6 +3,7 @@
 {{- $jobs := dict "reaper" .Values.cleanup.jobs.reaper "k8s-garbage" (index .Values.cleanup.jobs "k8s-garbage") "snapshotter" .Values.cleanup.jobs.snapshotter "retention" .Values.cleanup.jobs.retention }}
 {{- range $phase, $cfg := $jobs }}
 {{- if $cfg.enabled }}
+{{- $archiveVol := and (eq $phase "reaper") $.Values.runtimeFileArchive.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -32,16 +33,18 @@ spec:
           affinity:
             {{- . | nindent 12 }}
           {{- end }}
-          {{- if $.Values.ingressBase.enabled }}
+          {{- if or $.Values.ingressBase.enabled $archiveVol }}
           volumes:
+            {{- if $.Values.ingressBase.enabled }}
             - name: ingress-base-config
               configMap:
                 name: {{ include "runtime-api.fullname" $ }}-ingress-base
-          {{- end }}
-          {{- if and (eq $phase "reaper") $.Values.runtimeFileArchive.enabled }}
+            {{- end }}
+            {{- if $archiveVol }}
             - name: archive-tmp
               emptyDir:
                 sizeLimit: {{ $.Values.runtimeFileArchive.tmpSizeLimit | default "10Gi" | quote }}
+            {{- end }}
           {{- end }}
           containers:
           - name: cleanup-{{ $phase }}
@@ -54,18 +57,20 @@ spec:
                 value: {{ $.Values.database.poolSize.cronjobs | default 2 | quote }}
               - name: DB_MAX_OVERFLOW
                 value: {{ $.Values.database.maxOverflow.cronjobs | default 5 | quote }}
-              {{- if and (eq $phase "reaper") $.Values.runtimeFileArchive.enabled }}
+              {{- if $archiveVol }}
               - name: RUNTIME_FILE_ARCHIVE_TMPDIR
                 value: {{ $.Values.runtimeFileArchive.tmpDir | default "/archive-tmp" | quote }}
               {{- end }}
-            {{- if $.Values.ingressBase.enabled }}
+            {{- if or $.Values.ingressBase.enabled $archiveVol }}
             volumeMounts:
+              {{- if $.Values.ingressBase.enabled }}
               - name: ingress-base-config
                 mountPath: /ingress-base
-            {{- end }}
-            {{- if and (eq $phase "reaper") $.Values.runtimeFileArchive.enabled }}
+              {{- end }}
+              {{- if $archiveVol }}
               - name: archive-tmp
                 mountPath: {{ $.Values.runtimeFileArchive.tmpDir | default "/archive-tmp" | quote }}
+              {{- end }}
             {{- end }}
             resources:
               {{- toYaml $.Values.jobSettings.resources | nindent 14 }}

--- a/charts/openhands/charts/runtime-api/tests/cleanup_archive_volumes_test.yaml
+++ b/charts/openhands/charts/runtime-api/tests/cleanup_archive_volumes_test.yaml
@@ -17,13 +17,16 @@ tests:
       ingressBase.enabled: false
       runtimeFileArchive.enabled: true
     asserts:
-      # imagePullSecrets must contain only the ghcr-login-secret, NOT the
-      # archive-tmp emptyDir volume (the regression merged it in here).
-      - equal:
-          path: spec.jobTemplate.spec.template.spec.imagePullSecrets[0].name
-          value: ghcr-login-secret
-      - notExists:
-          path: spec.jobTemplate.spec.template.spec.imagePullSecrets[1]
+      # The regression merged the archive-tmp emptyDir volume into
+      # imagePullSecrets (because the `volumes:` key was gated on
+      # ingressBase.enabled). Assert the archive-tmp entry is NOT present
+      # here. notContains is robust to imagePullSecrets being empty (the
+      # umbrella parent clears it to []) or holding the chart-default
+      # ghcr-login-secret (standalone subchart render).
+      - notContains:
+          path: spec.jobTemplate.spec.template.spec.imagePullSecrets
+          content:
+            name: archive-tmp
       - exists:
           path: spec.jobTemplate.spec.template.spec.volumes
       - equal:

--- a/charts/openhands/charts/runtime-api/tests/cleanup_archive_volumes_test.yaml
+++ b/charts/openhands/charts/runtime-api/tests/cleanup_archive_volumes_test.yaml
@@ -1,0 +1,129 @@
+suite: cleanup CronJob archive volume rendering
+templates:
+  - templates/cleanup-cronjob.yaml
+tests:
+  # Regression for the bug where, with ingressBase.enabled=false and
+  # runtimeFileArchive.enabled=true, the archive-tmp volume list item was
+  # emitted without a `volumes:` key and merged into imagePullSecrets (and the
+  # archive-tmp volumeMount merged into env), producing an invalid Pod spec so
+  # the reaper CronJob could never start. See staging reaper outage.
+  - it: reaper archive volume is a real volume, not an imagePullSecret, when ingressBase is off
+    template: templates/cleanup-cronjob.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-runtime-api-cleanup-reaper
+    set:
+      cleanup.enabled: true
+      ingressBase.enabled: false
+      runtimeFileArchive.enabled: true
+    asserts:
+      # imagePullSecrets must contain only the ghcr-login-secret, NOT the
+      # archive-tmp emptyDir volume (the regression merged it in here).
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.imagePullSecrets[0].name
+          value: ghcr-login-secret
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.imagePullSecrets[1]
+      - exists:
+          path: spec.jobTemplate.spec.template.spec.volumes
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.volumes[0].name
+          value: archive-tmp
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.volumes[0].emptyDir.sizeLimit
+          value: 10Gi
+
+  - it: reaper archive mount is a real volumeMount, not an env entry, when ingressBase is off
+    template: templates/cleanup-cronjob.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-runtime-api-cleanup-reaper
+    set:
+      cleanup.enabled: true
+      ingressBase.enabled: false
+      runtimeFileArchive.enabled: true
+    asserts:
+      - exists:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts[0].name
+          value: archive-tmp
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: /archive-tmp
+      # The regression merged the archive-tmp mount into env as a malformed
+      # entry; assert no env var is named archive-tmp.
+      - notContains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: archive-tmp
+
+  - it: reaper has RUNTIME_FILE_ARCHIVE_TMPDIR env when archiving is on
+    template: templates/cleanup-cronjob.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-runtime-api-cleanup-reaper
+    set:
+      cleanup.enabled: true
+      runtimeFileArchive.enabled: true
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: RUNTIME_FILE_ARCHIVE_TMPDIR
+            value: /archive-tmp
+
+  - it: reaper has no volumes and no volumeMounts when both ingressBase and archiving are off
+    template: templates/cleanup-cronjob.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-runtime-api-cleanup-reaper
+    set:
+      cleanup.enabled: true
+      ingressBase.enabled: false
+      runtimeFileArchive.enabled: false
+    asserts:
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.volumes
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts
+
+  - it: reaper has both ingress-base-config and archive-tmp volumes when both are on
+    template: templates/cleanup-cronjob.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-runtime-api-cleanup-reaper
+    set:
+      cleanup.enabled: true
+      ingressBase.enabled: true
+      runtimeFileArchive.enabled: true
+    asserts:
+      - exists:
+          path: spec.jobTemplate.spec.template.spec.volumes
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.volumes[0].name
+          value: ingress-base-config
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.volumes[1].name
+          value: archive-tmp
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts[0].name
+          value: ingress-base-config
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts[1].name
+          value: archive-tmp
+
+  - it: non-reaper phases never get the archive-tmp volume even when archiving is on
+    template: templates/cleanup-cronjob.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-runtime-api-cleanup-snapshotter
+    set:
+      cleanup.enabled: true
+      ingressBase.enabled: false
+      runtimeFileArchive.enabled: true
+    asserts:
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.volumes
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts


### PR DESCRIPTION
## Summary

The runtime-api `cleanup-reaper` CronJob has been silently failing on **staging**: no reaper pods were appearing (while `k8s-garbage`, `snapshotter`, and `retention` ran fine), so idle runtimes stopped being reclaimed. This PR fixes the chart template bug that caused it.

## Root cause

In `charts/openhands/charts/runtime-api/templates/cleanup-cronjob.yaml`, the `volumes:` and `volumeMounts:` keys were gated behind `ingressBase.enabled`, but the reaper's `archive-tmp` volume/mount entries were appended under a **separate** `{{- if }}` that did **not** emit the key:

```go
{{- if $.Values.ingressBase.enabled }}      // emits "volumes:" key
volumes:
  - name: ingress-base-config
    ...
{{- end }}
{{- if and (eq $phase "reaper") $.Values.runtimeFileArchive.enabled }}   // emits ONLY the list item
  - name: archive-tmp
    emptyDir:
      sizeLimit: ...
{{- end }}
```

When `ingressBase.enabled` was **false** (the chart default) but `runtimeFileArchive.enabled` was **true** (staging's config), the bare `- name: archive-tmp` list item had no parent key and merged into the previous list — `imagePullSecrets` at the pod level and `env` at the container level — producing an **invalid Pod spec**:

```yaml
imagePullSecrets:
  - name: ghcr-login-secret
  - name: archive-tmp        # emptyDir volume illegally here
    emptyDir:
      sizeLimit: "10Gi"
# (no "volumes:" key exists)
```

…and the container `volumeMounts:` similarly merged into `env`:

```yaml
            - name: RUNTIME_FILE_ARCHIVE_TMPDIR
              value: "/archive-tmp"
            - name: archive-tmp          # a volumeMount, illegally inside env
              mountPath: "/archive-tmp"
```

Kubernetes rejects the spec, so the reaper CronJob could never start a Job. This is exactly the staging symptom observed: `k8s-garbage`, `snapshotter`, and `retention` pods completed, but no reaper pod ever appeared.

## Why production was unaffected

Production runs with `runtimeFileArchive.enabled: false` (chart default), so the buggy `{{- if }}` block was skipped entirely and the reaper rendered cleanly — which is why prod shows a healthy reaper (`...-helm-cleanup-reaper-...` pods, including one `Running`).

## The fix

Emit `volumes:` / `volumeMounts:` whenever **either** source (ingressBase or the reaper archive volume) is needed, and gate the individual entries. A `$archiveVol` local avoids recomputing the condition.

## Verification

- `helm lint charts/openhands` ✅
- `helm unittest charts/openhands/charts/runtime-api` — all 18 tests pass (4 suites), including a new regression suite ✅
- Confirmed the new regression tests **fail** against the pre-fix template (2/7 cases) and **pass** with the fix ✅
- Rendered the umbrella with staging-like values (`ingressBase.enabled=false`, `runtimeFileArchive.enabled=true`): the reaper now produces a valid spec with a proper `volumes:` key, `archive-tmp` emptyDir volume, `archive-tmp` volumeMount, and `RUNTIME_FILE_ARCHIVE_TMPDIR` env var — and no pollution of `imagePullSecrets`/`env` ✅
- Tested all 4 combinations of `(ingressBase.enabled, runtimeFileArchive.enabled)` for both the reaper and non-reaper phases ✅

## After merge

Once this lands and is cut into a new `openhands` chart release, saas-deploy's runtime-api wrappers (staging in particular) should be bumped to pick up the fix. Staging's reaper will start running again without any saas-deploy `values.yaml` change.

_This PR was created by an AI agent (OpenHands) on behalf of the user._