### PR TITLE
ci: make the Replicated deploy check blocking, with a break-glass label [PLTF-3535]

### DIFF
--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -1,15 +1,20 @@
 name: Replicated deploy status
 
-# Visibility only, not a merge gate. Asserts the invariant behind the README
-# badges: whatever should have triggered a deploy actually got a run, and that
-# run succeeded. The "no run" case is what a badge cannot show -- GitHub renders
-# the last real conclusion forever, so a workflow that stopped firing stays green.
+# Merge gate on every PR. Asserts the invariant behind the README badges:
+# whatever should have triggered a deploy actually got a run, and that run
+# succeeded. The "no run" case is what a badge cannot show -- GitHub renders the
+# last real conclusion forever, so a workflow that stopped firing stays green.
 #
-# To make it blocking, add the check context `last-deploy` to the `main` ruleset
-# under Settings -> Rules -> Rulesets. No change to this file needed.
+# Required via the check context `last-deploy` in the `main` ruleset.
+# No paths: filter -- a required check that never runs blocks every merge.
 
 on:
   pull_request:
+    # labeled/unlabeled: without them the override label never re-runs this.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+env:
+  OVERRIDE_LABEL: deploy-gate-override
 
 jobs:
   last-deploy:
@@ -18,15 +23,42 @@ jobs:
     permissions:
       actions: read
       contents: read
+      issues: write  # repo-level label definitions are an Issues resource
     steps:
-      # Repo idiom: release-replicated-unstable.yml installs yq the same way.
-      - name: Install yq
-        uses: mikefarah/yq@v4
-
-      - name: Assert both lanes deployed their newest trigger
+      # Upserted every run so it survives deletion; a label API blip must
+      # never redden the gate.
+      - name: Ensure override label exists
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+        run: |
+          gh label create "$OVERRIDE_LABEL" --repo "$REPO" --color FBCA04 \
+            --description "Override label for fixing or bypassing the Replicated Deploy requirement" --force
+
+      # Not stripped on synchronize: this gate tracks main's lanes, not the
+      # PR's diff, so re-arming would force a re-label after every push.
+      - name: Break-glass override
+        if: contains(github.event.pull_request.labels.*.name, env.OVERRIDE_LABEL)
+        run: |
+          echo "::warning::deploy gate overridden by the ${OVERRIDE_LABEL} label"
+          {
+            echo "### Replicated deploy status: overridden"
+            echo ""
+            echo "Bypassed by the \`${OVERRIDE_LABEL}\` label"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Repo idiom: release-replicated-unstable.yml installs yq the same way.
+      - name: Install yq
+        if: ${{ !contains(github.event.pull_request.labels.*.name, env.OVERRIDE_LABEL) }}
+        uses: mikefarah/yq@v4
+
+      - name: Assert both lanes deployed their newest trigger
+        if: ${{ !contains(github.event.pull_request.labels.*.name, env.OVERRIDE_LABEL) }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
         run: |
           FAILED=0
           {
@@ -99,14 +131,22 @@ jobs:
             echo "| beta | no openhands/* release | skipped | — |" >> "$GITHUB_STEP_SUMMARY"
           fi
 
-          # TEMPORARY BYPASS: exit 0 so the required `last-deploy` check on the
-          # `main` ruleset does not block PRs. The unstable deploy on main has
-          # been failing intermittently with an empty KOTS deploy response (see
-          # run https://github.com/OpenHands/OpenHands-Cloud/actions/runs/33497185018
-          # and the prior failures 33452723202, 33428909029) — an
-          # infrastructure-side issue unrelated to the PRs being gated.
-          # Platform team has been notified; track the fix in the Linear ticket
-          # linked in #logistics-platform-team. Revert this to `exit "$FAILED"`
-          # once the unstable deploy lane is healthy again.
-          echo "Failed: $FAILED"
-          exit 0
+          if [ "$FAILED" = 1 ]; then
+            {
+              echo ""
+              echo "#### This check is about \`main\`, not your PR"
+              echo ""
+              echo "A replicated deploy is failing (beta or unstable). This gate blocks **every** open PR until it is healthy"
+              echo ""
+              echo "**Fix the deployment** — open the run linked in the table above, or ask the most recent person to merge a PR."
+              echo ""
+              echo "**Or merge anyway** — if this PR *is* the fix, or cannot wait, apply the override label:"
+              echo ""
+              echo "    gh pr edit ${PR} --add-label ${OVERRIDE_LABEL}"
+              echo ""
+              echo "It re-runs this check green, is recorded on the PR, and stays until removed. Drop it if the lane recovers first."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::A Replicated deploy on main is unhealthy — this blocks all PRs and is not caused by your changes. Fix the deploy, or run: gh pr edit ${PR} --add-label ${OVERRIDE_LABEL}"
+          fi
+
+          exit "$FAILED"


### PR DESCRIPTION
## Description

`last-deploy` is now a required check on the `main` ruleset — already flipped in Settings, so this PR is the other half.

The Replicated deploy badges can't show the failure mode we actually care about: GitHub renders the last real conclusion forever, so a lane that *stops firing* stays green indefinitely. `last-deploy` already asserted the real invariant — the newest trigger on each lane got a run, and that run passed — but it was advisory. Blocking means an unhealthy lane stops the line for everyone, so we find out within one PR instead of whenever someone next looks at the README, and we keep a known-good rollback point close behind.

That creates a catch-22. The gate reflects `main`'s health, not the PR's diff, so a broken lane blocks *every* open PR — including the PR that fixes the lane. Org admins can bypass the ruleset, but that's invisible and needs the right person awake. Hence the break-glass label.

### `.github/workflows/deploy-gate.yml`

- **`deploy-gate-override` label bypasses the check.** The yq and assert steps skip when it's present, and the job posts a `::warning::` plus a step summary saying the lanes went unchecked — a bypassed run is loud, not quietly green.
- **`labeled`/`unlabeled` added to `types`.** Without them, applying the label doesn't re-run the check and the PR stays red until someone pushes a commit. Costs one extra run per PR, since `pr.yml`'s auto `type:` label trips it.
- **The job creates the label itself** (`gh label create --force`, `continue-on-error`), so it survives deletion or a repo restore and nobody discovers mid-incident that it doesn't exist. Needs `issues: write` — repo-level label definitions are an Issues resource, not a Pull Requests one.
- **Deliberately not stripped on `synchronize`.** saas-deploy's `check-chart-tag-overrides.yml` does strip its override on new commits, which is right there because its finding is about the PR's own diff. Here the finding is about `main`, so re-arming would force a re-label after every push to the PR that's fixing the lane.
- **The failure message explains itself.** Most people who hit this won't know the check exists and won't have caused it. On failure, the annotation and step summary say exactly that, link the failing run and CODEOWNERS, and give the ready-to-paste `gh pr edit <n> --add-label deploy-gate-override`.

## Helm Chart Checklist

N/A — no chart changes.

## Additional Notes

Sequencing: the ruleset is already live, so until this merges a red lane has no escape but an org-admin bypass. Worth merging promptly.

Verified with `actionlint` 1.7.12 — the version `lint-workflows.yml` pins — with shellcheck present, so the `run` blocks were linted too. I also executed the failure-message block with `FAILED=1` to render the summary rather than eyeballing the escaping.
