### PR TITLE
feat(agent-server): bump image tag to 1.44.1-python

### DIFF
--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -1,7 +1,7 @@
 # Agent-server image the loader pre-pulls onto nodes; keep tag in sync with the sandbox runtime.
 image:
   repository: ghcr.io/openhands/agent-server
-  tag: 1.43.1-python
+  tag: 1.44.1-python
   pullPolicy: Always
 
 resources:

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -358,7 +358,7 @@ global:
   # global wins; this default only applies when rendering the subchart alone.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.43.1-python
+    tag: 1.44.1-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1319,7 +1319,7 @@ global:
   # either of those for per-use exceptions; set it here to move them together.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.43.1-python
+    tag: 1.44.1-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1329,9 +1329,9 @@ spec:
           required: true
         - name: custom_sandbox_image_tag
           title: Sandbox Image Tag
-          help_text: Image tag, e.g. 1.43.1-python
+          help_text: Image tag, e.g. 1.44.1-python
           type: text
-          default: "1.43.1-python"
+          default: "1.44.1-python"
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: true
         - name: custom_sandbox_image_registry_server


### PR DESCRIPTION
## Problem

`scripts/check_agent_server_sync.py` fails because the `agent-server` image tags pinned in the Helm charts drifted from the `software-agent-sdk` version that the pinned `enterprise-server` release was built against:

- **enterprise-server 1.57.0** (`charts/openhands/values.yaml` -> `.image.tag`) was built against **software-agent-sdk 1.44.1**.
- The charts pinned **agent-server `1.43.1-python`** in three places.

The enterprise server imports the agent-server as a Python package and talks to it over HTTP in every sandbox. The client the app ships and the server image the sandbox runs are the same codebase, so a version split is a protocol split that silently breaks sandbox communication.

## Fix

Bump every agent-server tag from `1.43.1-python` to `1.44.1-python`:

- `charts/image-loader/values.yaml` -> `.image.tag`
- `charts/openhands/charts/runtime-api/values.yaml` -> `.global.agentServerImage.tag`
- `charts/openhands/values.yaml` -> `.global.agentServerImage.tag`
- `replicated/config.yaml` -> `custom_sandbox_image_tag` default + help text (kept in sync with the same convention as PR #1165)

## Verification

`uv run scripts/check_agent_server_sync.py` now passes:

```
enterprise-server pin:  1.57.0  (tag 1.57.0 in OpenHands/enterprise, 45c134c)
software-agent-sdk pin: 1.44.1  (openhands-agent-server in pyproject.toml)
chart agent-server tag: 1.44.1-python

agent-server and software-agent-sdk pins are in sync.
```

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._
