### PR TITLE
feat: add CronJob to clean stale app_conversation_start_task rows

### DIFF
--- a/charts/openhands/templates/app-conversation-start-task-clean-cronjob.yaml
+++ b/charts/openhands/templates/app-conversation-start-task-clean-cronjob.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.enabled .Values.appConversationStartTaskClean.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-app-conversation-start-task-clean
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: app-conversation-start-task-clean
+    app: {{ .Release.Name }}-app-conversation-start-task-clean
+spec:
+  schedule: {{ .Values.appConversationStartTaskClean.schedule | quote }}
+  concurrencyPolicy: {{ .Values.appConversationStartTaskClean.concurrencyPolicy }}
+  failedJobsHistoryLimit: {{ .Values.appConversationStartTaskClean.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.appConversationStartTaskClean.successfulJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.appConversationStartTaskClean.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "openhands.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: app-conversation-start-task-clean
+            app: {{ .Release.Name }}-app-conversation-start-task-clean
+        spec:
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ .Values.serviceAccount.name }}
+          restartPolicy: OnFailure
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with (include "openhands.affinity" .) }}
+          affinity:
+            {{- . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: {{ .Release.Name }}-app-conversation-start-task-clean
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+              command: ["python", "-m", "sync.clean_app_conversation_start_tasks"]
+              resources:
+                {{- toYaml .Values.appConversationStartTaskClean.resources | nindent 16 }}
+              env:
+                {{- include "openhands.env" . | nindent 16 }}
+{{- end }}

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -340,6 +340,20 @@ proactiveConvoClean:
       memory: 512Mi
       cpu: 200m
 
+appConversationStartTaskClean:
+  enabled: false
+  schedule: "0 3 * * *" # Daily at 3 AM UTC
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 1
+  backoffLimit: 3
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 100m
+    limits:
+      memory: 512Mi
+
 resendSync:
   enabled: false
   schedule: "0 1 * * *" # Daily at 1 AM


### PR DESCRIPTION
Closes #1190

## Summary

Adds a CronJob template and values block to the OpenHands-Cloud helm chart that invokes the enterprise `sync.clean_app_conversation_start_tasks` cleanup script once a day, mirroring the existing `proactive-convo-clean-cronjob.yaml`.

The cleanup script itself ships in the enterprise server image (merged in OpenHands/enterprise#290, released as `enterprise-server:1.58.0`). This PR wires it into the Cloud helm chart.

## Changes

- **New template:** `charts/openhands/templates/app-conversation-start-task-clean-cronjob.yaml`
  - `command: ["python", "-m", "sync.clean_app_conversation_start_tasks"]`
  - `app.kubernetes.io/component: app-conversation-start-task-clean`
  - Gated on `.Values.appConversationStartTaskClean.enabled`
- **Values:** Added an `appConversationStartTaskClean` block to `charts/openhands/values.yaml` (default `enabled: false`, daily at 3 AM UTC)

## Verification

- `helm template` with `appConversationStartTaskClean.enabled=true` renders the CronJob correctly with the expected command, schedule, component label, and resources.
- With the flag disabled (default), the CronJob template is not rendered.

## Related

- Issue: https://github.com/OpenHands/OpenHands-Cloud/issues/1190
- Linear: OHE-3189
- Enterprise PR (script + version bump): https://github.com/OpenHands/enterprise/pull/290
- Enterprise release: https://github.com/OpenHands/enterprise/pull/300
- Existing analog: `proactive-convo-clean-cronjob.yaml`

_This PR was created by an AI agent (OpenHands) on behalf of the user._