### PR TITLE
feat: enable appConversationStartTaskClean CronJob by default

### DIFF
--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -341,7 +341,7 @@ proactiveConvoClean:
       cpu: 200m
 
 appConversationStartTaskClean:
-  enabled: false
+  enabled: true
   schedule: "0 3 * * *" # Daily at 3 AM UTC
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
Closes #1190

## Summary

Flips `appConversationStartTaskClean.enabled` from `false` → `true` in the chart's `values.yaml` so the cleanup CronJob runs out of the box, per issue #1190.

PR #1196 added the CronJob template but defaulted `enabled: false` (mirroring `proactiveConvoClean`). That opt-in default is why the job never appeared after #1196 was deployed — each environment would have had to opt in via per-env overlays. Defaulting to `enabled: true` means the job renders by default in every deployment.

It can still be disabled via the chart when needed:

```yaml
appConversationStartTaskClean:
  enabled: false
```

## Changes

- `charts/openhands/values.yaml`: `appConversationStartTaskClean.enabled: false` → `true` (one line). No `Chart.yaml` version bump — release-please owns that.

## Verification

- `helm template` (defaults, no `--set`) renders the CronJob with `command: ["python", "-m", "sync.clean_app_conversation_start_tasks"]`, schedule `0 3 * * *`, component `app-conversation-start-task-clean`.
- `helm template --set appConversationStartTaskClean.enabled=false` suppresses the CronJob entirely (opt-out works).
- No helm-unittest cases reference this value, so no test changes needed.

## Image dependency note

The `sync.clean_app_conversation_start_tasks` module ships in the enterprise server image from **1.58.0** onward (enterprise PR #290, released #300). The chart's `appVersion` is already `1.58.0`, so deployments using the chart-default image tag have the module. Environments that pin the image to an older tag (e.g. staging in `saas-deploy` pins `sha-45c134c` = 1.57.0) will render the CronJob but the pod will fail with `ModuleNotFoundError` until they bump to 1.58.0.

## Related

- Issue: https://github.com/OpenHands/OpenHands-Cloud/issues/1190
- Linear: OHE-3189
- Chart template PR: https://github.com/OpenHands/OpenHands-Cloud/pull/1196
- Enterprise script PR: https://github.com/OpenHands/enterprise/pull/290
- Enterprise release (1.58.0): https://github.com/OpenHands/enterprise/pull/300

_This PR was created by an AI agent (OpenHands) on behalf of the user._
