### PR TITLE
test: increase Tavily search timeouts to 3 minutes

### DIFF
--- a/e2e_tests/tests/003-conversations-legacy.spec.ts
+++ b/e2e_tests/tests/003-conversations-legacy.spec.ts
@@ -242,13 +242,13 @@ test.describe("legacy conversations @conversations", () => {
     const prompt =
       "Using Tavily search, please tell me who is the prime minister of Ireland.";
     console.log(`Sending prompt: "${prompt}"`);
-    await conversationPage.executePrompt(prompt, 120_000);
+    await conversationPage.executePrompt(prompt, 180_000);
 
     // Match the name with a regex so accent ("Micheál" vs "Micheal") and casing
     // variants in the agent's response don't cause spurious failures.
     const message = await conversationPage.waitForMessageContaining(
       /miche[aá]l martin/i,
-      120_000,
+      180_000,
     );
     console.log(
       `Found expected response containing 'Micheál Martin': "${message.substring(0, 100)}..."`,


### PR DESCRIPTION
## Description

Increases the Tavily search test timeouts in `003-conversations-legacy.spec.ts` from 2 minutes (`120_000`ms) to 3 minutes (`180_000`ms). The Tavily search service can be slow, causing flaky test failures at the 2-minute mark. This applies to both the `executePrompt` and `waitForMessageContaining` calls in the test.

## Helm Chart Checklist

<!-- REQUIRED: Complete this checklist if you have modified any Helm charts -->

- [x] N/A — no Helm chart changes (e2e test only)

## Additional Notes

Follows up on #1176, where the Tavily search test was observed to be flaky due to slow service response times.

_This pull request was created by an AI agent (OpenHands) on behalf of the user._