### PR TITLE
test: harden 003 legacy conversations spec (from #1176, without 005 canvas spec)

### DIFF
--- a/e2e_tests/tests/003-conversations-legacy.spec.ts
+++ b/e2e_tests/tests/003-conversations-legacy.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { HomePage, ConversationPage } from "../pages";
-import { runUser } from "../utils/config";
+import { env, runUser } from "../utils/config";
 
 /**
  * Legacy conversation controls specs.
@@ -92,7 +92,12 @@ test.describe("legacy conversations @conversations", () => {
     // the timeout to give waitForTaskCompleteMessage's budget room to apply.
     test.setTimeout(240_000);
 
-    const TEST_REPO_URL = "https://github.com/OpenHands/OpenHands";
+    // Use the shared fixture repo (env.testRepoUrl, default
+    // OpenHands/deploy ~12 MiB) rather than hardcoding OpenHands/OpenHands
+    // (~407 MiB). The clone is the dominant cost in this test; the smaller
+    // repo keeps it well under the timeout budget while still exercising the
+    // full clone → edit → diff-viewer → VSCode flow.
+    const TEST_REPO_URL = env.testRepoUrl;
 
     await homePage.goto();
 
@@ -108,7 +113,7 @@ test.describe("legacy conversations @conversations", () => {
     await conversationPage.waitForConversationReady();
 
     const prompt =
-      "Append a poem about developers to the end of README.md — actually edit the file and save it.";
+      "Append the phrase 'Terms and Conditions May Apply!' to the end of README.md in the current working directory (the repo root) — actually edit the file and save it.";
     console.log(`Sending prompt: "${prompt}"`);
     await conversationPage.sendMessage(prompt);
 
@@ -118,7 +123,7 @@ test.describe("legacy conversations @conversations", () => {
 
     await conversationPage.waitForTaskCompleteMessage();
     console.log(
-      "Status is 'Agent has finished the task' - poem task completed",
+      "Status is 'Agent has finished the task' - README append task completed",
     );
 
     await page.screenshot({
@@ -156,7 +161,7 @@ test.describe("legacy conversations @conversations", () => {
     await expect(readMe).toBeVisible();
     await readMe.click();
 
-    // Adding a poem should have inserted at least one new line.
+    // Appending a phrase should have inserted at least one new line.
     await expect(page.locator(".cdr.line-insert").first()).toBeVisible({
       timeout: 10_000,
     });
@@ -178,12 +183,16 @@ test.describe("legacy conversations @conversations", () => {
     const elapsed = Date.now() - startTime;
     const remainingTimeout = Math.max(totalTimeout - elapsed, 0);
 
+    // VS Code's explorer shows the cloned repo's top-level folder, which is
+    // named after the repo (e.g. "deploy" for OpenHands/deploy) — not a fixed
+    // string — so derive the expected name from the configured repo URL.
+    const repoFolderName = TEST_REPO_URL.split("/").pop() ?? "";
     const vsCodeFrame = vsCodeFrameLocator.contentFrame();
     const explorerViewlet = vsCodeFrame
       .locator("a")
-      .filter({ hasText: "OpenHands" });
+      .filter({ hasText: repoFolderName });
     await expect(explorerViewlet).toBeVisible({ timeout: remainingTimeout });
-    console.log("VSCode loaded with OpenHands repository");
+    console.log(`VSCode loaded with repository folder: ${repoFolderName}`);
 
     await page.screenshot({
       path: "test-results/screenshots/vscode-openhands.png",
@@ -240,15 +249,15 @@ test.describe("legacy conversations @conversations", () => {
     await conversationPage.waitForConversationReady();
 
     const prompt =
-      "Using Tavily search, please tell me who is the prime minister of Ireland.";
+      "Using Tavily search, please tell me who is the prime minister of Ireland. Use the default search parameters — do not set a topic/category field (Tavily only accepts 'general', and other values are rejected).";
     console.log(`Sending prompt: "${prompt}"`);
-    await conversationPage.executePrompt(prompt, 120_000);
+    await conversationPage.executePrompt(prompt, 180_000);
 
     // Match the name with a regex so accent ("Micheál" vs "Micheal") and casing
     // variants in the agent's response don't cause spurious failures.
     const message = await conversationPage.waitForMessageContaining(
       /miche[aá]l martin/i,
-      120_000,
+      180_000,
     );
     console.log(
       `Found expected response containing 'Micheál Martin': "${message.substring(0, 100)}..."`,


### PR DESCRIPTION
## Description

Ports the **hardening fixes** to `003-conversations-legacy.spec.ts` from #1176, extracted into their own PR so they can land before the new `005-conversations-canvas.spec.ts`, which still needs work and will continue to live in #1176.

**Only `e2e_tests/tests/003-conversations-legacy.spec.ts` is changed here.** The new canvas page objects (`CanvasHomePage.ts`, `CanvasConversationPage.ts`), the `pages/index.ts` export additions, and `005-conversations-canvas.spec.ts` from #1176 are intentionally **excluded** — those exist solely to support the 005 spec and are left in #1176.

## Changes (003 hardening only)

- **Use `env.testRepoUrl`** (default `OpenHands/deploy`, ~12 MiB) instead of hardcoding `OpenHands/OpenHands` (~407 MiB). The clone is the dominant cost in this test; the smaller fixture repo keeps it well under the timeout budget while still exercising the full clone → edit → diff-viewer → VSCode flow.
- **Derive the VSCode explorer folder name** from the configured repo URL instead of hardcoding `"OpenHands"`, since the explorer shows the repo's top-level folder (e.g. `deploy`).
- **Make the README edit prompt** less ambiguous ("Append the phrase 'Terms and Conditions May Apply!'…") and align the surrounding log/comment text.
- **Instruct Tavily search** to use default parameters (avoid invalid `topic`/`category` fields — Tavily only accepts `general`) and raise the search waits from `120_000` → `180_000`.

## Verification

- Diff of `003-conversations-legacy.spec.ts` is byte-for-byte identical to the corresponding hunk in #1176.
- The changes depend only on `env.testRepoUrl`, which already exists on `main` (`e2e_tests/utils/config.ts`), so this PR is self-contained and does not require the canvas page objects.
- No new files, no `pages/index.ts` changes, no 005 spec.

## Helm Chart Checklist

- [x] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

_(No Helm chart changes — this PR only touches an e2e test file.)_

## Additional Notes

This is the hardening subset of #1176, split out so it can merge independently. The 005 canvas spec remains tracked in #1176.

_This PR was created by an AI agent (OpenHands) on behalf of the user._