### PR TITLE
test(e2e): complete budget certification matrix

### DIFF
--- a/.github/workflows/budget-e2e.yml
+++ b/.github/workflows/budget-e2e.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   certify:
+    if: github.event_name == 'workflow_dispatch' || vars.BUDGET_E2E_SCHEDULE_ENABLED == 'true'
     runs-on: ${{ vars.BUDGET_E2E_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 210
     environment: budget-e2e-staging

--- a/.github/workflows/budget-e2e.yml
+++ b/.github/workflows/budget-e2e.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   certify:
     runs-on: ubuntu-latest
-    timeout-minutes: 150
+    timeout-minutes: 210
     environment: budget-e2e-staging
     defaults:
       run:
@@ -31,6 +31,8 @@ jobs:
       BUDGET_E2E_LITELLM_URL: ${{ vars.BUDGET_E2E_LITELLM_URL }}
       BUDGET_E2E_LITELLM_API_KEY: ${{ secrets.BUDGET_E2E_LITELLM_API_KEY }}
       BUDGET_E2E_DIRECT_MODEL: ${{ vars.BUDGET_E2E_DIRECT_MODEL }}
+      BUDGET_E2E_SERVICE_USER_ID: ${{ vars.BUDGET_E2E_SERVICE_USER_ID }}
+      BUDGET_E2E_SERVICE_API_KEY: ${{ secrets.BUDGET_E2E_SERVICE_API_KEY }}
       BUDGET_E2E_EXPECTED_LITELLM_VERSION: ${{ vars.BUDGET_E2E_EXPECTED_LITELLM_VERSION }}
       BUDGET_E2E_SLACK_BOT_TOKEN: ${{ secrets.BUDGET_E2E_SLACK_BOT_TOKEN }}
       BUDGET_E2E_SLACK_CHANNEL_ID: ${{ vars.BUDGET_E2E_SLACK_CHANNEL_ID }}
@@ -62,6 +64,8 @@ jobs:
             BUDGET_E2E_LITELLM_URL
             BUDGET_E2E_LITELLM_API_KEY
             BUDGET_E2E_DIRECT_MODEL
+            BUDGET_E2E_SERVICE_USER_ID
+            BUDGET_E2E_SERVICE_API_KEY
             BUDGET_E2E_SLACK_BOT_TOKEN
             BUDGET_E2E_SLACK_CHANNEL_ID
             BUDGET_E2E_SLACK_CHANNEL_NAME

--- a/.github/workflows/budget-e2e.yml
+++ b/.github/workflows/budget-e2e.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   certify:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.BUDGET_E2E_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 210
     environment: budget-e2e-staging
     defaults:

--- a/.github/workflows/budget-e2e.yml
+++ b/.github/workflows/budget-e2e.yml
@@ -67,10 +67,6 @@ jobs:
             BUDGET_E2E_DIRECT_MODEL
             BUDGET_E2E_SERVICE_USER_ID
             BUDGET_E2E_SERVICE_API_KEY
-            BUDGET_E2E_SLACK_BOT_TOKEN
-            BUDGET_E2E_SLACK_CHANNEL_ID
-            BUDGET_E2E_SLACK_CHANNEL_NAME
-            BUDGET_E2E_SLACK_TEAM_ID
           )
           for name in "${required[@]}"; do
             if [[ -z "${!name:-}" ]]; then

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -27,6 +27,8 @@ jobs:
         run: npm ci
       - name: Lint and type-check
         run: npm run lint
+      - name: Run helper unit tests
+        run: npm run test:unit
       - name: Discover Chromium tests
         env:
           BASE_URL: https://release-under-test.invalid

--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -39,10 +39,11 @@ BASE_URL=https://release-under-test.example.test \
 
 `tests/007-budgets.spec.ts` is a destructive, serial certification suite for a
 dedicated test organization. It verifies stable cycle-anchored caps,
-authoritative LiteLLM reporting and alerts, direct SDK enforcement, missing
-membership recovery, unmapped service identities, and cleanup from fresh
-database sessions. It will not run unless `BUDGET_E2E_MUTATION_CONFIRMED=true`,
-and it rejects personal or non-test organizations by default.
+authoritative LiteLLM reporting, optional Slack alerts, direct SDK enforcement,
+missing membership recovery, unmapped service identities, and cleanup from
+fresh database sessions. It will not run unless
+`BUDGET_E2E_MUTATION_CONFIRMED=true`, and it rejects personal or non-test
+organizations by default.
 
 Configure the protected GitHub environment `budget-e2e-staging` with:
 
@@ -56,16 +57,16 @@ Configure the protected GitHub environment `budget-e2e-staging` with:
 | Variable | `BUDGET_E2E_DIRECT_MODEL`             | Billable proxy model alias used by direct SDK-style requests |
 | Variable | `BUDGET_E2E_EXPECTED_LITELLM_VERSION` | Expected readiness version; defaults to `1.94.1`             |
 | Variable | `BUDGET_E2E_SERVICE_USER_ID`          | Existing LiteLLM-only identity in the test organization team |
-| Variable | `BUDGET_E2E_SLACK_CHANNEL_ID`         | Test alert channel ID                                        |
-| Variable | `BUDGET_E2E_SLACK_CHANNEL_NAME`       | Test alert channel name                                      |
-| Variable | `BUDGET_E2E_SLACK_TEAM_ID`            | Slack workspace/team ID                                      |
+| Variable | `BUDGET_E2E_SLACK_CHANNEL_ID`         | Optional test alert channel ID                               |
+| Variable | `BUDGET_E2E_SLACK_CHANNEL_NAME`       | Optional test alert channel name                             |
+| Variable | `BUDGET_E2E_SLACK_TEAM_ID`            | Optional Slack workspace/team ID                             |
 | Secret   | `BUDGET_E2E_GITHUB_USERNAME`          | Returning test administrator username                        |
 | Secret   | `BUDGET_E2E_GITHUB_PASSWORD`          | Returning test administrator password                        |
 | Secret   | `BUDGET_E2E_GITHUB_TOTP_SECRET`       | Optional TOTP seed for that account                          |
 | Secret   | `BUDGET_E2E_DATABASE_URL`             | PostgreSQL connection string for the test deployment         |
 | Secret   | `BUDGET_E2E_LITELLM_API_KEY`          | LiteLLM admin key                                            |
 | Secret   | `BUDGET_E2E_SERVICE_API_KEY`          | Virtual key for the LiteLLM-only service identity            |
-| Secret   | `BUDGET_E2E_SLACK_BOT_TOKEN`          | Token allowed to read the test alert channel                 |
+| Secret   | `BUDGET_E2E_SLACK_BOT_TOKEN`          | Optional token allowed to read the test alert channel        |
 
 The suite opens a direct PostgreSQL connection to snapshot cycle state and
 restore it after the destructive run. For a Replicated instance whose database
@@ -78,6 +79,11 @@ Scheduled certification is opt-in. Leave `BUDGET_E2E_SCHEDULE_ENABLED` unset
 or set to `false` while provisioning the environment; manual dispatch remains
 available. Enable the schedule only after a complete manual run passes.
 
+Slack verification is optional. Configure all four `BUDGET_E2E_SLACK_*`
+settings together to exercise the alert path. If all four are omitted, the
+suite executes the non-Slack scenarios and explicitly reports issue 5 as
+skipped. A partial Slack configuration is rejected.
+
 For Azure coverage, point `BUDGET_E2E_DIRECT_MODEL` at an Azure-backed model
 alias already configured in the deployment's LiteLLM proxy. Direct requests use
 only the generated virtual key in the `Authorization` header, matching an
@@ -88,8 +94,9 @@ outside this budget contract.
 Before the first run, create the LiteLLM-only service identity and virtual key
 in the dedicated team, but do not add that identity to the OpenHands
 organization. Give it no member cap or a deliberately chosen cap; the suite
-records the original value and proves maintenance does not rewrite it. Use a
-test Slack channel because the suite emits a real alert.
+records the original value and proves maintenance does not rewrite it. When
+Slack verification is enabled, use a test channel because the suite emits a
+real alert.
 
 Run the protected `Budget Incident E2E` workflow manually after deploying the
 candidate enterprise image. Download the Playwright artifact and retain the

--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -48,6 +48,7 @@ Configure the protected GitHub environment `budget-e2e-staging` with:
 
 | Kind     | Name                                  | Purpose                                                      |
 | -------- | ------------------------------------- | ------------------------------------------------------------ |
+| Variable | `BUDGET_E2E_RUNNER`                   | Optional runner label with network access; defaults to `ubuntu-latest` |
 | Variable | `BUDGET_E2E_BASE_URL`                 | HTTPS URL of the test deployment                             |
 | Variable | `BUDGET_E2E_ORG_ID`                   | Dedicated non-personal test organization UUID                |
 | Variable | `BUDGET_E2E_LITELLM_URL`              | Admin-reachable URL of the deployment's LiteLLM proxy        |
@@ -64,6 +65,13 @@ Configure the protected GitHub environment `budget-e2e-staging` with:
 | Secret   | `BUDGET_E2E_LITELLM_API_KEY`          | LiteLLM admin key                                            |
 | Secret   | `BUDGET_E2E_SERVICE_API_KEY`          | Virtual key for the LiteLLM-only service identity            |
 | Secret   | `BUDGET_E2E_SLACK_BOT_TOKEN`          | Token allowed to read the test alert channel                 |
+
+The suite opens a direct PostgreSQL connection to snapshot cycle state and
+restore it after the destructive run. For a Replicated instance whose database
+is private, set `BUDGET_E2E_RUNNER` to a self-hosted runner label with network
+access to that database. Do not expose PostgreSQL publicly for a GitHub-hosted
+runner. `ubuntu-latest` is appropriate only when every configured endpoint is
+intentionally reachable from GitHub Actions.
 
 For Azure coverage, point `BUDGET_E2E_DIRECT_MODEL` at an Azure-backed model
 alias already configured in the deployment's LiteLLM proxy. Direct requests use

--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -48,6 +48,7 @@ Configure the protected GitHub environment `budget-e2e-staging` with:
 
 | Kind     | Name                                  | Purpose                                                      |
 | -------- | ------------------------------------- | ------------------------------------------------------------ |
+| Variable | `BUDGET_E2E_SCHEDULE_ENABLED`         | Set to `true` only after the protected contract is ready     |
 | Variable | `BUDGET_E2E_RUNNER`                   | Optional runner label with network access; defaults to `ubuntu-latest` |
 | Variable | `BUDGET_E2E_BASE_URL`                 | HTTPS URL of the test deployment                             |
 | Variable | `BUDGET_E2E_ORG_ID`                   | Dedicated non-personal test organization UUID                |
@@ -72,6 +73,10 @@ is private, set `BUDGET_E2E_RUNNER` to a self-hosted runner label with network
 access to that database. Do not expose PostgreSQL publicly for a GitHub-hosted
 runner. `ubuntu-latest` is appropriate only when every configured endpoint is
 intentionally reachable from GitHub Actions.
+
+Scheduled certification is opt-in. Leave `BUDGET_E2E_SCHEDULE_ENABLED` unset
+or set to `false` while provisioning the environment; manual dispatch remains
+available. Enable the schedule only after a complete manual run passes.
 
 For Azure coverage, point `BUDGET_E2E_DIRECT_MODEL` at an Azure-backed model
 alias already configured in the deployment's LiteLLM proxy. Direct requests use

--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -35,6 +35,54 @@ BASE_URL=https://release-under-test.example.test \
   npx playwright test tests/001-home.spec.ts --list
 ```
 
+### Budget certification
+
+`tests/007-budgets.spec.ts` is a destructive, serial certification suite for a
+dedicated test organization. It verifies stable cycle-anchored caps,
+authoritative LiteLLM reporting and alerts, direct SDK enforcement, missing
+membership recovery, unmapped service identities, and cleanup from fresh
+database sessions. It will not run unless `BUDGET_E2E_MUTATION_CONFIRMED=true`,
+and it rejects personal or non-test organizations by default.
+
+Configure the protected GitHub environment `budget-e2e-staging` with:
+
+| Kind     | Name                                  | Purpose                                                      |
+| -------- | ------------------------------------- | ------------------------------------------------------------ |
+| Variable | `BUDGET_E2E_BASE_URL`                 | HTTPS URL of the test deployment                             |
+| Variable | `BUDGET_E2E_ORG_ID`                   | Dedicated non-personal test organization UUID                |
+| Variable | `BUDGET_E2E_LITELLM_URL`              | Admin-reachable URL of the deployment's LiteLLM proxy        |
+| Variable | `BUDGET_E2E_DIRECT_MODEL`             | Billable proxy model alias used by direct SDK-style requests |
+| Variable | `BUDGET_E2E_EXPECTED_LITELLM_VERSION` | Expected readiness version; defaults to `1.94.1`             |
+| Variable | `BUDGET_E2E_SERVICE_USER_ID`          | Existing LiteLLM-only identity in the test organization team |
+| Variable | `BUDGET_E2E_SLACK_CHANNEL_ID`         | Test alert channel ID                                        |
+| Variable | `BUDGET_E2E_SLACK_CHANNEL_NAME`       | Test alert channel name                                      |
+| Variable | `BUDGET_E2E_SLACK_TEAM_ID`            | Slack workspace/team ID                                      |
+| Secret   | `BUDGET_E2E_GITHUB_USERNAME`          | Returning test administrator username                        |
+| Secret   | `BUDGET_E2E_GITHUB_PASSWORD`          | Returning test administrator password                        |
+| Secret   | `BUDGET_E2E_GITHUB_TOTP_SECRET`       | Optional TOTP seed for that account                          |
+| Secret   | `BUDGET_E2E_DATABASE_URL`             | PostgreSQL connection string for the test deployment         |
+| Secret   | `BUDGET_E2E_LITELLM_API_KEY`          | LiteLLM admin key                                            |
+| Secret   | `BUDGET_E2E_SERVICE_API_KEY`          | Virtual key for the LiteLLM-only service identity            |
+| Secret   | `BUDGET_E2E_SLACK_BOT_TOKEN`          | Token allowed to read the test alert channel                 |
+
+For Azure coverage, point `BUDGET_E2E_DIRECT_MODEL` at an Azure-backed model
+alias already configured in the deployment's LiteLLM proxy. Direct requests use
+only the generated virtual key in the `Authorization` header, matching an
+OpenAI-compatible SDK configured with the LiteLLM base URL. Calls sent directly
+to Azure or another provider bypass the deployment and are intentionally
+outside this budget contract.
+
+Before the first run, create the LiteLLM-only service identity and virtual key
+in the dedicated team, but do not add that identity to the OpenHands
+organization. Give it no member cap or a deliberately chosen cap; the suite
+records the original value and proves maintenance does not rewrite it. Use a
+test Slack channel because the suite emits a real alert.
+
+Run the protected `Budget Incident E2E` workflow manually after deploying the
+candidate enterprise image. Download the Playwright artifact and retain the
+JSON evidence with the tested image SHA and release sequence. Scheduled runs
+reuse the same protected contract.
+
 ### Run through an Argo WorkflowTemplate
 
 Operators with access to an Argo installation can submit the test harness from
@@ -101,12 +149,12 @@ OpenHands Cloud uses Keycloak as its identity provider, federating identities fr
 
 Three credential sets are required before any test run:
 
-| Role | Provider | Credentials | Purpose |
-| --- | --- | --- | --- |
-| Keycloak admin | Keycloak | username + password | Administers Keycloak; deletes the New User before each run |
-| Super admin | API key | unbound superadmin API key | Creates orgs and provisions users via the REST API (org-management specs) |
-| Returning User | GitHub | username + password + optional TOTP secret | A user whose OpenHands account already exists |
-| New User | GitHub | username + password + optional TOTP secret | A user whose OpenHands account is deleted at the start of the run so they get a fresh account (and a fresh user id) on next login |
+| Role           | Provider | Credentials                                | Purpose                                                                                                                           |
+| -------------- | -------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| Keycloak admin | Keycloak | username + password                        | Administers Keycloak; deletes the New User before each run                                                                        |
+| Super admin    | API key  | unbound superadmin API key                 | Creates orgs and provisions users via the REST API (org-management specs)                                                         |
+| Returning User | GitHub   | username + password + optional TOTP secret | A user whose OpenHands account already exists                                                                                     |
+| New User       | GitHub   | username + password + optional TOTP secret | A user whose OpenHands account is deleted at the start of the run so they get a fresh account (and a fresh user id) on next login |
 
 The New User's Keycloak account is identified by email. At the start of a run, the Keycloak admin logs in and deletes any existing user whose email matches `KEYCLOAK_NEW_USER_EMAIL`. The New User then logs in via GitHub and is provisioned from scratch, exercising the onboarding path.
 

--- a/e2e_tests/tests/007-budgets.spec.ts
+++ b/e2e_tests/tests/007-budgets.spec.ts
@@ -30,6 +30,18 @@ import {
 } from "../utils/budgets";
 import { authReturningFile, env, runUser } from "../utils/config";
 
+interface SlackBudgetEvidence {
+  maintenance: BudgetMaintenanceResult;
+  reportingSpendBefore: number;
+  reportingSpendAfter: number;
+  financialSpendBefore: number;
+  financialSpendAfter: number;
+  teamSpendBefore: number;
+  teamSpendAfter: number;
+  alertSpend: number;
+  alertText: string;
+}
+
 interface BudgetEvidence {
   rolloverMaintenance: BudgetMaintenanceResult;
   firstSpendMaintenance: BudgetMaintenanceResult;
@@ -50,14 +62,7 @@ interface BudgetEvidence {
   financialSpendAfter: number;
   conversationsBeforeDirectSpend: number;
   conversationsAfterDirectSpend: number;
-  alertReportingSpendBefore: number;
-  alertReportingSpendAfter: number;
-  alertFinancialSpendBefore: number;
-  alertFinancialSpendAfter: number;
-  alertTeamSpendBefore: number;
-  alertTeamSpendAfter: number;
-  slackAlertSpend: number;
-  slackAlertText: string;
+  slack?: SlackBudgetEvidence;
   overrideMaintenance: BudgetMaintenanceResult;
   overrideLimit: number;
   overrideExpectedCap: number;
@@ -217,8 +222,7 @@ test.describe("organization budget maintenance @budgets", () => {
       !config.litellmUrl ||
       !config.litellmApiKey ||
       !config.serviceUserId ||
-      !config.serviceApiKey ||
-      !config.slack
+      !config.serviceApiKey
     ) {
       throw new Error(
         "Complete budget E2E certification configuration is required",
@@ -328,47 +332,61 @@ test.describe("organization budget maintenance @budgets", () => {
     );
     const conversationsAfterDirectSpend = await api.getConversationCount();
 
-    const thresholdStartedAt = Math.floor(Date.now() / 1000);
-    const alertMonthlyLimit =
-      reportingSpendAfter + config.minimumSpendDelta / 2;
-    const slackConfigured = await api.patchBudget({
-      monthly_limit: alertMonthlyLimit,
-      slack_channel: config.slack.channelName,
-      slack_team_id: config.slack.teamId,
-      thresholds: [
-        { percentage: 100, email_enabled: false, slack_enabled: true },
-      ],
-    });
-    requireSuccessfulSync(slackConfigured, "Slack budget configuration");
-    const alertFinancialSpendBefore = memberAfterSecondSpend.lifetime_spend;
-    await generateMinimumDirectSpend(
-      api,
-      userId,
-      generatedKey.key,
-      alertFinancialSpendBefore,
-    );
-    const alertMaintenance = await runMaintenance(database);
-    const alertReporting = await api.getBudget();
-    requireSuccessfulSync(
-      alertReporting,
-      "authoritative-spend alert maintenance",
-    );
-    const alertReportingSpendAfter = requireCurrentSpend(
-      alertReporting,
-      "authoritative-spend alert maintenance",
-    );
-    const alertFinancial = await api.getMemberFinancial(userId);
-    const alertTeam = await getLiteLLMTeamState(config);
-    const alert = await pollUntil(
-      () => findSlackBudgetAlert(config, org.name, thresholdStartedAt),
-      (value) => value !== undefined,
-      {
-        description: "the budget threshold Slack notification",
-        timeoutMs: 2 * 60_000,
-        intervalMs: config.pollIntervalMs,
-      },
-    );
-    if (!alert) throw new Error("Slack budget alert was not delivered");
+    let slackEvidence: SlackBudgetEvidence | undefined;
+    if (config.slack) {
+      const thresholdStartedAt = Math.floor(Date.now() / 1000);
+      const alertMonthlyLimit =
+        reportingSpendAfter + config.minimumSpendDelta / 2;
+      const slackConfigured = await api.patchBudget({
+        monthly_limit: alertMonthlyLimit,
+        slack_channel: config.slack.channelName,
+        slack_team_id: config.slack.teamId,
+        thresholds: [
+          { percentage: 100, email_enabled: false, slack_enabled: true },
+        ],
+      });
+      requireSuccessfulSync(slackConfigured, "Slack budget configuration");
+      const alertFinancialSpendBefore = memberAfterSecondSpend.lifetime_spend;
+      await generateMinimumDirectSpend(
+        api,
+        userId,
+        generatedKey.key,
+        alertFinancialSpendBefore,
+      );
+      const alertMaintenance = await runMaintenance(database);
+      const alertReporting = await api.getBudget();
+      requireSuccessfulSync(
+        alertReporting,
+        "authoritative-spend alert maintenance",
+      );
+      const alertReportingSpendAfter = requireCurrentSpend(
+        alertReporting,
+        "authoritative-spend alert maintenance",
+      );
+      const alertFinancial = await api.getMemberFinancial(userId);
+      const alertTeam = await getLiteLLMTeamState(config);
+      const alert = await pollUntil(
+        () => findSlackBudgetAlert(config, org.name, thresholdStartedAt),
+        (value) => value !== undefined,
+        {
+          description: "the budget threshold Slack notification",
+          timeoutMs: 2 * 60_000,
+          intervalMs: config.pollIntervalMs,
+        },
+      );
+      if (!alert) throw new Error("Slack budget alert was not delivered");
+      slackEvidence = {
+        maintenance: alertMaintenance,
+        reportingSpendBefore: reportingSpendAfter,
+        reportingSpendAfter: alertReportingSpendAfter,
+        financialSpendBefore: alertFinancialSpendBefore,
+        financialSpendAfter: alertFinancial.lifetime_spend,
+        teamSpendBefore: teamAfterSecondSpend.spend,
+        teamSpendAfter: alertTeam.spend,
+        alertSpend: alert.spend,
+        alertText: alert.text,
+      };
+    }
 
     if (memberAfterRollover.max_budget === null) {
       throw new Error("Default member cap was absent after cycle rollover");
@@ -578,14 +596,7 @@ test.describe("organization budget maintenance @budgets", () => {
       financialSpendAfter: memberAfterSecondSpend.lifetime_spend,
       conversationsBeforeDirectSpend,
       conversationsAfterDirectSpend,
-      alertReportingSpendBefore: reportingSpendAfter,
-      alertReportingSpendAfter,
-      alertFinancialSpendBefore,
-      alertFinancialSpendAfter: alertFinancial.lifetime_spend,
-      alertTeamSpendBefore: teamAfterSecondSpend.spend,
-      alertTeamSpendAfter: alertTeam.spend,
-      slackAlertSpend: alert.spend,
-      slackAlertText: alert.text,
+      slack: slackEvidence,
       overrideMaintenance,
       overrideLimit,
       overrideExpectedCap,
@@ -625,7 +636,7 @@ test.describe("organization budget maintenance @budgets", () => {
       rolloverMaintenance,
       firstSpendMaintenance,
       secondSpendMaintenance,
-      alertMaintenance,
+      alertMaintenance: slackEvidence?.maintenance,
       overrideMaintenance,
       membershipMissingMaintenance,
       membershipRepairMaintenance,
@@ -852,18 +863,20 @@ test.describe("organization budget maintenance @budgets", () => {
   });
 
   test("issue 5: LiteLLM-only threshold crossing emits authoritative Slack spend", async () => {
+    test.skip(!config.slack, "Slack alert verification is not configured");
     expect(evidence).toBeDefined();
+    expect(evidence!.slack).toBeDefined();
+    const slack = evidence!.slack!;
     const reportingDelta =
-      evidence!.alertReportingSpendAfter - evidence!.alertReportingSpendBefore;
+      slack.reportingSpendAfter - slack.reportingSpendBefore;
     const financialDelta =
-      evidence!.alertFinancialSpendAfter - evidence!.alertFinancialSpendBefore;
-    const teamDelta =
-      evidence!.alertTeamSpendAfter - evidence!.alertTeamSpendBefore;
+      slack.financialSpendAfter - slack.financialSpendBefore;
+    const teamDelta = slack.teamSpendAfter - slack.teamSpendBefore;
     await attachEvidence("issue-5-slack-alert.json", {
-      alertText: evidence!.slackAlertText,
-      alertSpend: evidence!.slackAlertSpend,
-      reportingBefore: evidence!.alertReportingSpendBefore,
-      reportingAfter: evidence!.alertReportingSpendAfter,
+      alertText: slack.alertText,
+      alertSpend: slack.alertSpend,
+      reportingBefore: slack.reportingSpendBefore,
+      reportingAfter: slack.reportingSpendAfter,
       reportingDelta,
       financialDelta,
       teamDelta,
@@ -871,8 +884,8 @@ test.describe("organization budget maintenance @budgets", () => {
     expect(financialDelta).toBeGreaterThanOrEqual(config.minimumSpendDelta);
     expect(teamDelta).toBeCloseTo(financialDelta, closeToPrecision);
     expect(reportingDelta).toBeCloseTo(teamDelta, closeToPrecision);
-    expect(evidence!.slackAlertSpend).toBeCloseTo(
-      evidence!.alertReportingSpendAfter,
+    expect(slack.alertSpend).toBeCloseTo(
+      slack.reportingSpendAfter,
       closeToPrecision,
     );
   });

--- a/e2e_tests/tests/007-budgets.spec.ts
+++ b/e2e_tests/tests/007-budgets.spec.ts
@@ -708,7 +708,12 @@ test.describe("organization budget maintenance @budgets", () => {
     });
     await attempt("restore budget settings", async () => {
       const restored = await api!.patchBudget(restorePayload(originalBudget!));
-      requireSuccessfulSync(restored, "budget settings restore");
+      if (
+        originalBudget!.enabled ||
+        restored.litellm_last_sync_status !== "skipped"
+      ) {
+        requireSuccessfulSync(restored, "budget settings restore");
+      }
     });
     await attempt("restore budget cycle", () =>
       database!.restoreCycleState(config.orgId, originalCycle!),
@@ -753,12 +758,21 @@ test.describe("organization budget maintenance @budgets", () => {
         evidence!.teamAfterSecondSpend,
       ],
     });
-    expect(evidence!.cycleAfterFirstSpend).toEqual(
-      evidence!.cycleAfterRollover,
-    );
-    expect(evidence!.cycleAfterSecondSpend).toEqual(
-      evidence!.cycleAfterRollover,
-    );
+    for (const cycle of [
+      evidence!.cycleAfterFirstSpend,
+      evidence!.cycleAfterSecondSpend,
+    ]) {
+      expect(cycle.cycleStartAt).toBe(
+        evidence!.cycleAfterRollover.cycleStartAt,
+      );
+      expect(cycle.cycleStartSpend).toBeCloseTo(
+        evidence!.cycleAfterRollover.cycleStartSpend,
+        closeToPrecision,
+      );
+      expect(cycle.userCycleStartSpend).toEqual(
+        evidence!.cycleAfterRollover.userCycleStartSpend,
+      );
+    }
     expect(evidence!.teamAfterFirstSpend.maxBudget).toBeCloseTo(
       evidence!.teamAfterRollover.maxBudget!,
       closeToPrecision,

--- a/e2e_tests/tests/007-budgets.spec.ts
+++ b/e2e_tests/tests/007-budgets.spec.ts
@@ -9,16 +9,22 @@ import {
   BudgetApi,
   type BudgetSettings,
   type BudgetUser,
+  type LiteLLMCompletionResult,
+  type LiteLLMMemberState,
   type LiteLLMTeamState,
   type MemberFinancial,
   createLiteLLMTestKey,
   deleteLiteLLMTestKey,
+  ensureLiteLLMTeamMember,
   findSlackBudgetAlert,
   generateDirectLiteLLMSpend,
+  getLiteLLMMemberState,
   getLiteLLMTeamState,
   getLiteLLMVersion,
   loadBudgetE2EConfig,
   pollUntil,
+  removeLiteLLMTeamMember,
+  requireDirectBudgetDenial,
   updateLiteLLMMemberCap,
   updateLiteLLMTeamCap,
 } from "../utils/budgets";
@@ -65,12 +71,32 @@ interface BudgetEvidence {
   observedDisabledTeam: LiteLLMTeamState;
   seededDisabledMember: MemberFinancial;
   observedDisabledMember: MemberFinancial;
+  memberDenial: LiteLLMCompletionResult;
+  memberDenialState: LiteLLMMemberState;
+  organizationDenial: LiteLLMCompletionResult;
+  organizationDenialState: LiteLLMTeamState;
+  membershipMissingMaintenance: BudgetMaintenanceResult;
+  membershipRepairMaintenance: BudgetMaintenanceResult;
+  membershipSyncError: string | null;
+  memberAfterRemoval: LiteLLMMemberState | null;
+  memberAfterMidcycleMaintenance: LiteLLMMemberState | null;
+  memberAfterBoundaryRepair: LiteLLMMemberState;
+  serviceMemberBefore: LiteLLMMemberState;
+  serviceMemberAfter: LiteLLMMemberState;
+  serviceMaintenance: BudgetMaintenanceResult;
+  serviceReportingSpendBefore: number;
+  serviceReportingSpend: number;
+  serviceUnmappedSpend: number;
+  serviceUnmappedMemberCount: number;
+  serviceConversationsBefore: number;
+  serviceConversationsAfter: number;
 }
 
 const config = loadBudgetE2EConfig();
-const suiteTimeout = config.syncTimeoutMs * 6 + 10 * 60_000;
+const suiteTimeout = config.syncTimeoutMs * 9 + 10 * 60_000;
 const closeToPrecision = 2;
 const maxSpendAttempts = 8;
+const denialAllowance = 0.000_001;
 
 function restorePayload(settings: BudgetSettings): Record<string, unknown> {
   return {
@@ -93,6 +119,18 @@ function requireSuccessfulSync(
       `${operation} LiteLLM sync status was ${settings.litellm_last_sync_status}: ${settings.litellm_last_sync_error || "no error detail"}`,
     );
   }
+}
+
+function requireCurrentSpend(
+  settings: BudgetSettings,
+  operation: string,
+): number {
+  if (settings.current_spend === null) {
+    throw new Error(
+      `${operation} spend is unavailable (${settings.spend_status})`,
+    );
+  }
+  return settings.current_spend;
 }
 
 function attachEvidence(
@@ -178,12 +216,16 @@ test.describe("organization budget maintenance @budgets", () => {
       !config.databaseUrl ||
       !config.litellmUrl ||
       !config.litellmApiKey ||
+      !config.serviceUserId ||
+      !config.serviceApiKey ||
       !config.slack
     ) {
       throw new Error(
         "Complete budget E2E certification configuration is required",
       );
     }
+    const { serviceUserId } = config;
+    const { serviceApiKey } = config;
 
     context = await browser.newContext({
       baseURL: env.baseUrl,
@@ -243,7 +285,10 @@ test.describe("organization budget maintenance @budgets", () => {
     requireSuccessfulSync(budgetAfterRollover, "stale-cycle rollover");
     const teamAfterRollover = await getLiteLLMTeamState(config);
     const memberAfterRollover = await api.getMemberFinancial(userId);
-    const reportingSpendBefore = budgetAfterRollover.current_spend;
+    const reportingSpendBefore = requireCurrentSpend(
+      budgetAfterRollover,
+      "post-rollover reporting",
+    );
     const financialSpendBefore = memberAfterRollover.lifetime_spend;
     const conversationsBeforeDirectSpend = await api.getConversationCount();
 
@@ -277,11 +322,15 @@ test.describe("organization budget maintenance @budgets", () => {
       reportingAfterDirect,
       "second direct-spend maintenance",
     );
+    const reportingSpendAfter = requireCurrentSpend(
+      reportingAfterDirect,
+      "second direct-spend maintenance",
+    );
     const conversationsAfterDirectSpend = await api.getConversationCount();
 
     const thresholdStartedAt = Math.floor(Date.now() / 1000);
     const alertMonthlyLimit =
-      reportingAfterDirect.current_spend + config.minimumSpendDelta / 2;
+      reportingSpendAfter + config.minimumSpendDelta / 2;
     const slackConfigured = await api.patchBudget({
       monthly_limit: alertMonthlyLimit,
       slack_channel: config.slack.channelName,
@@ -301,6 +350,10 @@ test.describe("organization budget maintenance @budgets", () => {
     const alertMaintenance = await runMaintenance(database);
     const alertReporting = await api.getBudget();
     requireSuccessfulSync(
+      alertReporting,
+      "authoritative-spend alert maintenance",
+    );
+    const alertReportingSpendAfter = requireCurrentSpend(
       alertReporting,
       "authoritative-spend alert maintenance",
     );
@@ -355,6 +408,138 @@ test.describe("organization budget maintenance @budgets", () => {
     const overrideMaintenance = await runMaintenance(database);
     const overrideReconciledMember = await api.getMemberFinancial(userId);
 
+    await api.putOverride(userId, {
+      monthly_limit: denialAllowance,
+      is_disabled: false,
+    });
+    requireSuccessfulSync(await api.getBudget(), "member denial setup");
+    const memberDenialState = await getLiteLLMMemberState(config, userId);
+    if (!memberDenialState) {
+      throw new Error("Member was absent during member denial setup");
+    }
+    const memberDenial = await requireDirectBudgetDenial(
+      config,
+      generatedKey.key,
+    );
+    await api.deleteOverride(userId);
+    requireSuccessfulSync(await api.getBudget(), "member denial cleanup");
+
+    const organizationDenialBudget = await api.patchBudget({
+      monthly_limit: denialAllowance,
+    });
+    requireSuccessfulSync(
+      organizationDenialBudget,
+      "organization denial setup",
+    );
+    const organizationDenialState = await getLiteLLMTeamState(config);
+    const organizationDenial = await requireDirectBudgetDenial(
+      config,
+      generatedKey.key,
+    );
+    const restoredCertificationBudget = await api.patchBudget({
+      monthly_limit: config.monthlyLimit,
+      slack_channel: null,
+      slack_team_id: null,
+      thresholds: [],
+    });
+    requireSuccessfulSync(
+      restoredCertificationBudget,
+      "organization denial cleanup",
+    );
+
+    await removeLiteLLMTeamMember(config, userId);
+    const memberAfterRemoval = await getLiteLLMMemberState(config, userId);
+    const membershipMissingMaintenance = await runMaintenance(database);
+    const missingMembershipBudget = await api.getBudget();
+    const membershipSyncError = missingMembershipBudget.litellm_last_sync_error;
+    const memberAfterMidcycleMaintenance = await getLiteLLMMemberState(
+      config,
+      userId,
+    );
+    await database.makeCycleStale(config.orgId);
+    const membershipRepairMaintenance = await runMaintenance(database);
+    const repairedMembershipBudget = await api.getBudget();
+    requireSuccessfulSync(
+      repairedMembershipBudget,
+      "cycle-boundary membership repair",
+    );
+    const memberAfterBoundaryRepair = await getLiteLLMMemberState(
+      config,
+      userId,
+    );
+    if (!memberAfterBoundaryRepair) {
+      throw new Error("Member was absent after cycle-boundary repair");
+    }
+
+    const serviceMemberBefore = await getLiteLLMMemberState(
+      config,
+      serviceUserId,
+    );
+    if (!serviceMemberBefore) {
+      throw new Error(
+        `Configured SDK service identity ${serviceUserId} is not a LiteLLM team member`,
+      );
+    }
+    if (
+      repairedMembershipBudget.users.some(
+        (user) => user.user_id === serviceUserId,
+      )
+    ) {
+      throw new Error(
+        "SDK service identity must not be an OpenHands org member",
+      );
+    }
+    const serviceReportingSpendBefore = requireCurrentSpend(
+      repairedMembershipBudget,
+      "SDK service spend baseline",
+    );
+    const serviceConversationsBefore = await api.getConversationCount();
+    let serviceMemberAfter = serviceMemberBefore;
+    for (let attempt = 1; attempt <= maxSpendAttempts; attempt += 1) {
+      await generateDirectLiteLLMSpend(config, serviceApiKey);
+      const previousServiceSpend = serviceMemberAfter.spend;
+      const observed = await pollUntil(
+        () => getLiteLLMMemberState(config, serviceUserId),
+        (candidate) =>
+          candidate !== null && candidate.spend > previousServiceSpend,
+        {
+          description: `SDK service spend attempt ${attempt}`,
+          timeoutMs: 2 * 60_000,
+          intervalMs: config.pollIntervalMs,
+        },
+      );
+      if (!observed) throw new Error("SDK service spend disappeared");
+      serviceMemberAfter = observed;
+      if (
+        serviceMemberAfter.spend - serviceMemberBefore.spend >=
+        config.minimumSpendDelta
+      ) {
+        break;
+      }
+    }
+    if (
+      serviceMemberAfter.spend - serviceMemberBefore.spend <
+      config.minimumSpendDelta
+    ) {
+      throw new Error("SDK service identity did not produce enough spend");
+    }
+    const serviceMaintenance = await runMaintenance(database);
+    const serviceBudget = await api.getBudget();
+    requireSuccessfulSync(serviceBudget, "SDK service spend maintenance");
+    const serviceReportingSpend = requireCurrentSpend(
+      serviceBudget,
+      "SDK service spend maintenance",
+    );
+    if (
+      serviceBudget.unmapped_spend === null ||
+      serviceBudget.unmapped_member_count === null
+    ) {
+      throw new Error("Unmapped SDK service attribution is unavailable");
+    }
+    const serviceUnmappedSpend = serviceBudget.unmapped_spend;
+    const serviceUnmappedMemberCount = serviceBudget.unmapped_member_count;
+    const serviceConversationsAfter = await api.getConversationCount();
+
     const disabled = await api.patchBudget({ enabled: false });
     requireSuccessfulSync(disabled, "budget disable transition");
     const disabledSyncBefore = disabled.litellm_last_sync_at;
@@ -388,13 +573,13 @@ test.describe("organization budget maintenance @budgets", () => {
       memberAfterFirstSpend,
       memberAfterSecondSpend,
       reportingSpendBefore,
-      reportingSpendAfter: reportingAfterDirect.current_spend,
+      reportingSpendAfter,
       financialSpendBefore,
       financialSpendAfter: memberAfterSecondSpend.lifetime_spend,
       conversationsBeforeDirectSpend,
       conversationsAfterDirectSpend,
-      alertReportingSpendBefore: reportingAfterDirect.current_spend,
-      alertReportingSpendAfter: alertReporting.current_spend,
+      alertReportingSpendBefore: reportingSpendAfter,
+      alertReportingSpendAfter,
       alertFinancialSpendBefore,
       alertFinancialSpendAfter: alertFinancial.lifetime_spend,
       alertTeamSpendBefore: teamAfterSecondSpend.spend,
@@ -414,6 +599,25 @@ test.describe("organization budget maintenance @budgets", () => {
       observedDisabledTeam,
       seededDisabledMember,
       observedDisabledMember,
+      memberDenial,
+      memberDenialState,
+      organizationDenial,
+      organizationDenialState,
+      membershipMissingMaintenance,
+      membershipRepairMaintenance,
+      membershipSyncError,
+      memberAfterRemoval,
+      memberAfterMidcycleMaintenance,
+      memberAfterBoundaryRepair,
+      serviceMemberBefore,
+      serviceMemberAfter,
+      serviceMaintenance,
+      serviceReportingSpendBefore,
+      serviceReportingSpend,
+      serviceUnmappedSpend,
+      serviceUnmappedMemberCount,
+      serviceConversationsBefore,
+      serviceConversationsAfter,
     };
 
     await attachEvidence("maintenance-run-summary.json", {
@@ -423,6 +627,9 @@ test.describe("organization budget maintenance @budgets", () => {
       secondSpendMaintenance,
       alertMaintenance,
       overrideMaintenance,
+      membershipMissingMaintenance,
+      membershipRepairMaintenance,
+      serviceMaintenance,
       disabledMaintenance,
     });
   });
@@ -467,6 +674,9 @@ test.describe("organization budget maintenance @budgets", () => {
         deleteLiteLLMTestKey(config, testKeyAlias!),
       );
     }
+    await attempt("restore LiteLLM team membership", () =>
+      ensureLiteLLMTeamMember(config, userId, originalMember!.max_budget),
+    );
     await attempt("restore member override", async () => {
       if (originalOverride) {
         await api!.putOverride(userId, {
@@ -664,6 +874,79 @@ test.describe("organization budget maintenance @budgets", () => {
     expect(evidence!.slackAlertSpend).toBeCloseTo(
       evidence!.alertReportingSpendAfter,
       closeToPrecision,
+    );
+  });
+
+  test("organization and member caps reject direct SDK traffic", async () => {
+    expect(evidence).toBeDefined();
+    await attachEvidence("hard-budget-denials.json", {
+      memberCap: evidence!.memberDenialState,
+      memberDenial: evidence!.memberDenial,
+      organizationCap: evidence!.organizationDenialState,
+      organizationDenial: evidence!.organizationDenial,
+    });
+    expect(evidence!.memberDenialState.maxBudget).not.toBeNull();
+    expect(evidence!.memberDenialState.maxBudget!).toBeLessThanOrEqual(
+      evidence!.memberDenialState.spend,
+    );
+    expect([400, 429]).toContain(evidence!.memberDenial.status);
+    expect(evidence!.memberDenial.body).toMatch(/budget|exceed|limit/i);
+    expect(evidence!.organizationDenialState.maxBudget).not.toBeNull();
+    expect(evidence!.organizationDenialState.maxBudget!).toBeLessThanOrEqual(
+      evidence!.organizationDenialState.spend,
+    );
+    expect([400, 429]).toContain(evidence!.organizationDenial.status);
+    expect(evidence!.organizationDenial.body).toMatch(/budget|exceed|limit/i);
+  });
+
+  test("missing membership is held mid-cycle and repaired at the boundary", async () => {
+    expect(evidence).toBeDefined();
+    await attachEvidence("membership-repair-policy.json", {
+      missingMaintenance: evidence!.membershipMissingMaintenance,
+      repairMaintenance: evidence!.membershipRepairMaintenance,
+      syncError: evidence!.membershipSyncError,
+      afterRemoval: evidence!.memberAfterRemoval,
+      afterMidcycleMaintenance: evidence!.memberAfterMidcycleMaintenance,
+      afterBoundaryRepair: evidence!.memberAfterBoundaryRepair,
+    });
+    expect(evidence!.memberAfterRemoval).toBeNull();
+    expect(evidence!.memberAfterMidcycleMaintenance).toBeNull();
+    expect(evidence!.membershipSyncError).toMatch(
+      /member_missing_from_litellm/,
+    );
+    expect(evidence!.membershipMissingMaintenance.status).toBe("COMPLETED");
+    expect(evidence!.membershipRepairMaintenance.status).toBe("COMPLETED");
+    expect(evidence!.memberAfterBoundaryRepair.userId).toBe(userId);
+  });
+
+  test("unmapped service SDK spend is reported without a conversation or cap rewrite", async () => {
+    expect(evidence).toBeDefined();
+    const serviceSpendDelta =
+      evidence!.serviceMemberAfter.spend - evidence!.serviceMemberBefore.spend;
+    const reportingDelta =
+      evidence!.serviceReportingSpend - evidence!.serviceReportingSpendBefore;
+    await attachEvidence("unmapped-sdk-service-spend.json", {
+      maintenance: evidence!.serviceMaintenance,
+      before: evidence!.serviceMemberBefore,
+      after: evidence!.serviceMemberAfter,
+      serviceSpendDelta,
+      reportingDelta,
+      unmappedSpend: evidence!.serviceUnmappedSpend,
+      unmappedMemberCount: evidence!.serviceUnmappedMemberCount,
+      conversationsBefore: evidence!.serviceConversationsBefore,
+      conversationsAfter: evidence!.serviceConversationsAfter,
+    });
+    expect(serviceSpendDelta).toBeGreaterThanOrEqual(config.minimumSpendDelta);
+    expect(reportingDelta).toBeCloseTo(serviceSpendDelta, closeToPrecision);
+    expect(evidence!.serviceUnmappedSpend).toBeGreaterThanOrEqual(
+      serviceSpendDelta - 0.005,
+    );
+    expect(evidence!.serviceUnmappedMemberCount).toBeGreaterThanOrEqual(1);
+    expect(evidence!.serviceMemberAfter.maxBudget).toBe(
+      evidence!.serviceMemberBefore.maxBudget,
+    );
+    expect(evidence!.serviceConversationsAfter).toBe(
+      evidence!.serviceConversationsBefore,
     );
   });
 });

--- a/e2e_tests/tests/007-budgets.spec.ts
+++ b/e2e_tests/tests/007-budgets.spec.ts
@@ -201,6 +201,7 @@ test.describe("organization budget maintenance @budgets", () => {
   let originalTeam: LiteLLMTeamState | undefined;
   let originalMember: MemberFinancial | undefined;
   let testKeyAlias: string | undefined;
+  let managedKeyRepairRequired = false;
   let evidence: BudgetEvidence | undefined;
 
   test.beforeEach(({ browser: _browser }, testInfo) => {
@@ -472,6 +473,12 @@ test.describe("organization budget maintenance @budgets", () => {
       "organization denial cleanup",
     );
 
+    // LiteLLM removes the member's virtual keys with the membership. The
+    // boundary repair below restores membership and cleanup must rotate the
+    // OpenHands-managed key so the test account remains usable afterward. Set
+    // this before the request because a lost response could hide a successful
+    // removal.
+    managedKeyRepairRequired = true;
     await removeLiteLLMTeamMember(config, userId);
     const memberAfterRemoval = await getLiteLLMMemberState(config, userId);
     const membershipMissingMaintenance = await runMaintenance(database);
@@ -696,6 +703,11 @@ test.describe("organization budget maintenance @budgets", () => {
     await attempt("restore LiteLLM team membership", () =>
       ensureLiteLLMTeamMember(config, userId, originalMember!.max_budget),
     );
+    if (managedKeyRepairRequired) {
+      await attempt("restore managed LLM key", () =>
+        api!.refreshManagedLLMKey(),
+      );
+    }
     await attempt("restore member override", async () => {
       if (originalOverride) {
         await api!.putOverride(userId, {

--- a/e2e_tests/tests/007-budgets.spec.ts
+++ b/e2e_tests/tests/007-budgets.spec.ts
@@ -66,8 +66,9 @@ interface BudgetEvidence {
   overrideMaintenance: BudgetMaintenanceResult;
   overrideLimit: number;
   overrideExpectedCap: number;
+  overrideSharedCap: number;
   overrideExpectedMember: MemberFinancial;
-  overrideClearedMember: MemberFinancial;
+  overrideSharedMember: MemberFinancial;
   overrideReconciledMember: MemberFinancial;
   disabledSyncBefore: string | null;
   disabledSyncAfter: string | null;
@@ -413,12 +414,18 @@ test.describe("organization budget maintenance @budgets", () => {
         intervalMs: config.pollIntervalMs,
       },
     );
+    const overrideSharedCap = (await getLiteLLMTeamState(config)).maxBudget;
+    if (overrideSharedCap === null) {
+      throw new Error("Organization cap was absent before override drift test");
+    }
     await updateLiteLLMMemberCap(config, userId, null);
-    const overrideClearedMember = await pollUntil(
+    const overrideSharedMember = await pollUntil(
       () => api!.getMemberFinancial(userId),
-      (member) => member.max_budget === null,
+      (member) =>
+        member.max_budget !== null &&
+        Math.abs(member.max_budget - overrideSharedCap) < 0.005,
       {
-        description: "the individual override cap to be cleared directly",
+        description: "the member to fall back to the shared organization cap",
         timeoutMs: 60_000,
         intervalMs: config.pollIntervalMs,
       },
@@ -600,8 +607,9 @@ test.describe("organization budget maintenance @budgets", () => {
       overrideMaintenance,
       overrideLimit,
       overrideExpectedCap,
+      overrideSharedCap,
       overrideExpectedMember,
-      overrideClearedMember,
+      overrideSharedMember,
       overrideReconciledMember,
       disabledSyncBefore,
       disabledSyncAfter: disabledAfterMaintenance.litellm_last_sync_at,
@@ -792,8 +800,9 @@ test.describe("organization budget maintenance @budgets", () => {
       maintenance: evidence!.overrideMaintenance,
       overrideLimit: evidence!.overrideLimit,
       expectedCap: evidence!.overrideExpectedCap,
+      sharedCap: evidence!.overrideSharedCap,
       initial: evidence!.overrideExpectedMember,
-      cleared: evidence!.overrideClearedMember,
+      shared: evidence!.overrideSharedMember,
       reconciled: evidence!.overrideReconciledMember,
     });
     expect(evidence!.overrideMaintenance.status).toBe("COMPLETED");
@@ -801,7 +810,10 @@ test.describe("organization budget maintenance @budgets", () => {
       evidence!.overrideExpectedCap,
       closeToPrecision,
     );
-    expect(evidence!.overrideClearedMember.max_budget).toBeNull();
+    expect(evidence!.overrideSharedMember.max_budget).toBeCloseTo(
+      evidence!.overrideSharedCap,
+      closeToPrecision,
+    );
     expect(evidence!.overrideReconciledMember.max_budget).toBeCloseTo(
       evidence!.overrideExpectedCap,
       closeToPrecision,

--- a/e2e_tests/unit-tests/budget-helpers.spec.ts
+++ b/e2e_tests/unit-tests/budget-helpers.spec.ts
@@ -13,6 +13,7 @@ import {
   getLiteLLMTeamState,
   loadBudgetE2EConfig,
   requestDirectLiteLLMCompletion,
+  requireDirectBudgetDenial,
 } from "../utils/budgets";
 
 const config: BudgetE2EConfig = {
@@ -92,6 +93,27 @@ test("direct SDK traffic authenticates only with the virtual key", async () => {
       },
       { role: "user", content: config.directPrompt },
     ]);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("allows one admitted request while budget enforcement catches up", async () => {
+  const originalFetch = global.fetch;
+  let calls = 0;
+  global.fetch = async () => {
+    calls += 1;
+    if (calls === 1) {
+      return new Response('{"choices":[]}', { status: 200 });
+    }
+    return new Response('{"error":"budget exceeded"}', { status: 429 });
+  };
+
+  try {
+    await expect(
+      requireDirectBudgetDenial(config, "virtual-key"),
+    ).resolves.toMatchObject({ status: 429 });
+    expect(calls).toBe(2);
   } finally {
     global.fetch = originalFetch;
   }

--- a/e2e_tests/unit-tests/budget-helpers.spec.ts
+++ b/e2e_tests/unit-tests/budget-helpers.spec.ts
@@ -43,8 +43,10 @@ test("rejects LiteLLM team responses with missing spend", async () => {
 test("direct SDK traffic authenticates only with the virtual key", async () => {
   const originalFetch = global.fetch;
   let observedHeaders: Headers | undefined;
+  let observedBody: Record<string, unknown> | undefined;
   global.fetch = async (_input, init) => {
     observedHeaders = new Headers(init?.headers);
+    observedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
     return new Response('{"error":"budget exceeded"}', { status: 429 });
   };
 
@@ -53,6 +55,14 @@ test("direct SDK traffic authenticates only with the virtual key", async () => {
     expect(result.status).toBe(429);
     expect(observedHeaders?.get("authorization")).toBe("Bearer virtual-key");
     expect(observedHeaders?.has("x-goog-api-key")).toBe(false);
+    expect(observedBody?.messages).toEqual([
+      {
+        role: "system",
+        content:
+          "You are responding to an automated budget certification request.",
+      },
+      { role: "user", content: config.directPrompt },
+    ]);
   } finally {
     global.fetch = originalFetch;
   }

--- a/e2e_tests/unit-tests/budget-helpers.spec.ts
+++ b/e2e_tests/unit-tests/budget-helpers.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  type BudgetE2EConfig,
+  getLiteLLMTeamState,
+  requestDirectLiteLLMCompletion,
+} from "../utils/budgets";
+
+const config: BudgetE2EConfig = {
+  enabled: true,
+  orgId: "budget-test-org",
+  monthlyLimit: 50,
+  userMonthlyLimit: 25,
+  minimumSpendDelta: 0.02,
+  directPrompt: "test prompt",
+  directModel: "azure-test-model",
+  expectedLiteLLMVersion: "1.94.1",
+  pollIntervalMs: 10,
+  syncTimeoutMs: 100,
+  litellmUrl: "https://litellm.example.test",
+  litellmApiKey: "admin-key",
+};
+
+test("rejects LiteLLM team responses with missing spend", async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () =>
+    new Response(JSON.stringify({ team_info: { max_budget: 50 } }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  try {
+    await expect(getLiteLLMTeamState(config)).rejects.toThrow(
+      "team_info.spend must be a finite non-negative number",
+    );
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("direct SDK traffic authenticates only with the virtual key", async () => {
+  const originalFetch = global.fetch;
+  let observedHeaders: Headers | undefined;
+  global.fetch = async (_input, init) => {
+    observedHeaders = new Headers(init?.headers);
+    return new Response('{"error":"budget exceeded"}', { status: 429 });
+  };
+
+  try {
+    const result = await requestDirectLiteLLMCompletion(config, "virtual-key");
+    expect(result.status).toBe(429);
+    expect(observedHeaders?.get("authorization")).toBe("Bearer virtual-key");
+    expect(observedHeaders?.has("x-goog-api-key")).toBe(false);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});

--- a/e2e_tests/unit-tests/budget-helpers.spec.ts
+++ b/e2e_tests/unit-tests/budget-helpers.spec.ts
@@ -59,7 +59,7 @@ test("direct SDK traffic authenticates only with the virtual key", async () => {
       {
         role: "system",
         content:
-          "You are responding to an automated budget certification request.",
+          "You are OpenHands agent, a helpful AI assistant that can interact with a computer to solve tasks.",
       },
       { role: "user", content: config.directPrompt },
     ]);

--- a/e2e_tests/unit-tests/budget-helpers.spec.ts
+++ b/e2e_tests/unit-tests/budget-helpers.spec.ts
@@ -1,6 +1,12 @@
-import { expect, test } from "@playwright/test";
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type APIResponse,
+} from "@playwright/test";
 
 import {
+  BudgetApi,
   type BudgetE2EConfig,
   deleteLiteLLMTestKey,
   getLiteLLMMemberState,
@@ -23,6 +29,28 @@ const config: BudgetE2EConfig = {
   litellmUrl: "https://litellm.example.test",
   litellmApiKey: "admin-key",
 };
+
+test("retries an idempotent API read after a dropped connection", async () => {
+  let calls = 0;
+  const response = {
+    ok: () => true,
+    json: async () => ({ items: [], current_org_id: null }),
+  } as unknown as APIResponse;
+  const request = {
+    get: async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("socket hang up");
+      return response;
+    },
+  } as unknown as APIRequestContext;
+
+  const api = new BudgetApi(request, "budget-test-org");
+  await expect(api.getOrganizations()).resolves.toEqual({
+    items: [],
+    current_org_id: null,
+  });
+  expect(calls).toBe(2);
+});
 
 test("rejects LiteLLM team responses with missing spend", async () => {
   const originalFetch = global.fetch;

--- a/e2e_tests/unit-tests/budget-helpers.spec.ts
+++ b/e2e_tests/unit-tests/budget-helpers.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import {
   type BudgetE2EConfig,
+  deleteLiteLLMTestKey,
   getLiteLLMMemberState,
   getLiteLLMTeamState,
   loadBudgetE2EConfig,
@@ -63,6 +64,20 @@ test("direct SDK traffic authenticates only with the virtual key", async () => {
       },
       { role: "user", content: config.directPrompt },
     ]);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("temporary key cleanup tolerates a key removed with its member", async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () =>
+    new Response('{"detail":"Key not found"}', { status: 404 });
+
+  try {
+    await expect(
+      deleteLiteLLMTestKey(config, "already-removed"),
+    ).resolves.toBeUndefined();
   } finally {
     global.fetch = originalFetch;
   }

--- a/e2e_tests/unit-tests/budget-helpers.spec.ts
+++ b/e2e_tests/unit-tests/budget-helpers.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import {
   type BudgetE2EConfig,
+  getLiteLLMMemberState,
   getLiteLLMTeamState,
   loadBudgetE2EConfig,
   requestDirectLiteLLMCompletion,
@@ -52,6 +53,72 @@ test("direct SDK traffic authenticates only with the virtual key", async () => {
     expect(result.status).toBe(429);
     expect(observedHeaders?.get("authorization")).toBe("Bearer virtual-key");
     expect(observedHeaders?.has("x-goog-api-key")).toBe(false);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("reads nested LiteLLM 1.94.1 member caps and prefers membership spend", async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        team_info: {
+          team_member_budget_table: { max_budget: 50 },
+          members_with_roles: [{ user_id: "private-member", role: "user" }],
+        },
+        team_memberships: [
+          {
+            user_id: "private-member",
+            spend: 12,
+            budget_id: "private-budget",
+            litellm_budget_table: { max_budget: 25 },
+          },
+        ],
+        keys: [{ user_id: "private-member", spend: 999 }],
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+
+  try {
+    await expect(
+      getLiteLLMMemberState(config, "private-member"),
+    ).resolves.toEqual({
+      userId: "private-member",
+      maxBudget: 25,
+      spend: 12,
+    });
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("sums key spend for a role-only LiteLLM member", async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        team_info: {
+          team_member_budget_table: null,
+          members_with_roles: [{ user_id: "role-only-member", role: "user" }],
+        },
+        team_memberships: [],
+        keys: [
+          { user_id: "role-only-member", spend: 2.5 },
+          { user_id: "role-only-member", spend: 3.75 },
+        ],
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+
+  try {
+    await expect(
+      getLiteLLMMemberState(config, "role-only-member"),
+    ).resolves.toEqual({
+      userId: "role-only-member",
+      maxBudget: null,
+      spend: 6.25,
+    });
   } finally {
     global.fetch = originalFetch;
   }

--- a/e2e_tests/unit-tests/budget-helpers.spec.ts
+++ b/e2e_tests/unit-tests/budget-helpers.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 import {
   type BudgetE2EConfig,
   getLiteLLMTeamState,
+  loadBudgetE2EConfig,
   requestDirectLiteLLMCompletion,
 } from "../utils/budgets";
 
@@ -53,5 +54,54 @@ test("direct SDK traffic authenticates only with the virtual key", async () => {
     expect(observedHeaders?.has("x-goog-api-key")).toBe(false);
   } finally {
     global.fetch = originalFetch;
+  }
+});
+
+test("accepts omitted Slack settings but rejects partial Slack configuration", () => {
+  const names = [
+    "BUDGET_E2E_ORG_ID",
+    "BUDGET_E2E_MUTATION_CONFIRMED",
+    "BUDGET_E2E_DATABASE_URL",
+    "BUDGET_E2E_LITELLM_URL",
+    "BUDGET_E2E_LITELLM_API_KEY",
+    "BUDGET_E2E_DIRECT_MODEL",
+    "BUDGET_E2E_SERVICE_USER_ID",
+    "BUDGET_E2E_SERVICE_API_KEY",
+    "BUDGET_E2E_SLACK_BOT_TOKEN",
+    "BUDGET_E2E_SLACK_CHANNEL_ID",
+    "BUDGET_E2E_SLACK_CHANNEL_NAME",
+    "BUDGET_E2E_SLACK_TEAM_ID",
+  ] as const;
+  const original = new Map(names.map((name) => [name, process.env[name]]));
+
+  try {
+    process.env.BUDGET_E2E_ORG_ID = "budget-test-org";
+    process.env.BUDGET_E2E_MUTATION_CONFIRMED = "true";
+    process.env.BUDGET_E2E_DATABASE_URL = "postgresql://example.test/db";
+    process.env.BUDGET_E2E_LITELLM_URL = "https://litellm.example.test";
+    process.env.BUDGET_E2E_LITELLM_API_KEY = "admin-key";
+    process.env.BUDGET_E2E_DIRECT_MODEL = "test-model";
+    process.env.BUDGET_E2E_SERVICE_USER_ID = "service-user";
+    process.env.BUDGET_E2E_SERVICE_API_KEY = "service-key";
+    delete process.env.BUDGET_E2E_SLACK_BOT_TOKEN;
+    delete process.env.BUDGET_E2E_SLACK_CHANNEL_ID;
+    delete process.env.BUDGET_E2E_SLACK_CHANNEL_NAME;
+    delete process.env.BUDGET_E2E_SLACK_TEAM_ID;
+
+    expect(loadBudgetE2EConfig()).toMatchObject({
+      enabled: true,
+      slack: undefined,
+    });
+
+    process.env.BUDGET_E2E_SLACK_CHANNEL_ID = "partial-channel";
+    expect(() => loadBudgetE2EConfig()).toThrow(
+      "All BUDGET_E2E_SLACK_* variables are required when Slack verification is enabled",
+    );
+  } finally {
+    for (const name of names) {
+      const value = original.get(name);
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
   }
 });

--- a/e2e_tests/utils/budget-database.ts
+++ b/e2e_tests/utils/budget-database.ts
@@ -5,6 +5,14 @@ import { pollUntil } from "./budgets";
 export interface BudgetCycleState {
   cycleStartAt: string;
   cycleStartSpend: number;
+  userCycleStartSpend: Record<string, number>;
+  liteLLMLastSyncAt: string | null;
+  liteLLMLastSyncStatus: string | null;
+  liteLLMLastSyncError: string | null;
+  liteLLMLastSpendSnapshotAt: string | null;
+  liteLLMLastTeamSpend: number | null;
+  liteLLMLastMemberSpend: Record<string, number>;
+  liteLLMKnownMemberIds: string[];
 }
 
 export interface BudgetMaintenanceResult {
@@ -36,8 +44,25 @@ export class BudgetDatabase {
       const result = await client.query<{
         cycle_start_at: Date;
         cycle_start_spend: number;
+        user_cycle_start_spend: Record<string, number>;
+        litellm_last_sync_at: Date | null;
+        litellm_last_sync_status: string | null;
+        litellm_last_sync_error: string | null;
+        litellm_last_spend_snapshot_at: Date | null;
+        litellm_last_team_spend: number | null;
+        litellm_last_member_spend: Record<string, number>;
+        litellm_known_member_ids: string[];
       }>(
-        `SELECT cycle_start_at, cycle_start_spend
+        `SELECT cycle_start_at,
+                cycle_start_spend,
+                user_cycle_start_spend,
+                litellm_last_sync_at,
+                litellm_last_sync_status,
+                litellm_last_sync_error,
+                litellm_last_spend_snapshot_at,
+                litellm_last_team_spend,
+                litellm_last_member_spend,
+                litellm_known_member_ids
            FROM org_budget_settings
           WHERE org_id = $1`,
         [orgId],
@@ -47,6 +72,18 @@ export class BudgetDatabase {
       return {
         cycleStartAt: row.cycle_start_at.toISOString(),
         cycleStartSpend: Number(row.cycle_start_spend),
+        userCycleStartSpend: row.user_cycle_start_spend,
+        liteLLMLastSyncAt: row.litellm_last_sync_at?.toISOString() ?? null,
+        liteLLMLastSyncStatus: row.litellm_last_sync_status,
+        liteLLMLastSyncError: row.litellm_last_sync_error,
+        liteLLMLastSpendSnapshotAt:
+          row.litellm_last_spend_snapshot_at?.toISOString() ?? null,
+        liteLLMLastTeamSpend:
+          row.litellm_last_team_spend === null
+            ? null
+            : Number(row.litellm_last_team_spend),
+        liteLLMLastMemberSpend: row.litellm_last_member_spend,
+        liteLLMKnownMemberIds: row.litellm_known_member_ids,
       };
     });
   }
@@ -69,9 +106,30 @@ export class BudgetDatabase {
     return this.withClient(async (client) => {
       const result = await client.query(
         `UPDATE org_budget_settings
-            SET cycle_start_at = $2, cycle_start_spend = $3
+            SET cycle_start_at = $2,
+                cycle_start_spend = $3,
+                user_cycle_start_spend = $4::json,
+                litellm_last_sync_at = $5,
+                litellm_last_sync_status = $6,
+                litellm_last_sync_error = $7,
+                litellm_last_spend_snapshot_at = $8,
+                litellm_last_team_spend = $9,
+                litellm_last_member_spend = $10::json,
+                litellm_known_member_ids = $11::json
           WHERE org_id = $1`,
-        [orgId, state.cycleStartAt, state.cycleStartSpend],
+        [
+          orgId,
+          state.cycleStartAt,
+          state.cycleStartSpend,
+          JSON.stringify(state.userCycleStartSpend),
+          state.liteLLMLastSyncAt,
+          state.liteLLMLastSyncStatus,
+          state.liteLLMLastSyncError,
+          state.liteLLMLastSpendSnapshotAt,
+          state.liteLLMLastTeamSpend,
+          JSON.stringify(state.liteLLMLastMemberSpend),
+          JSON.stringify(state.liteLLMKnownMemberIds),
+        ],
       );
       if (result.rowCount !== 1) {
         throw new Error(`Failed to restore budget cycle for org ${orgId}`);

--- a/e2e_tests/utils/budgets.ts
+++ b/e2e_tests/utils/budgets.ts
@@ -657,7 +657,14 @@ export async function requestDirectLiteLLMCompletion(
       },
       body: JSON.stringify({
         model: config.directModel,
-        messages: [{ role: "user", content: config.directPrompt }],
+        messages: [
+          {
+            role: "system",
+            content:
+              "You are responding to an automated budget certification request.",
+          },
+          { role: "user", content: config.directPrompt },
+        ],
         max_tokens: 1024,
       }),
     },

--- a/e2e_tests/utils/budgets.ts
+++ b/e2e_tests/utils/budgets.ts
@@ -293,6 +293,18 @@ export class BudgetApi {
     );
   }
 
+  async refreshManagedLLMKey(): Promise<void> {
+    const result = await responseJson<{ refreshed: boolean }>(
+      this.request.post("/api/keys/llm/managed/refresh", {
+        headers: this.headers,
+      }),
+      "refresh managed LLM key",
+    );
+    if (!result.refreshed) {
+      throw new Error("managed LLM key refresh did not report success");
+    }
+  }
+
   getBudget(): Promise<BudgetSettings> {
     return responseJson<BudgetSettings>(
       this.request.get(`/api/organizations/${this.orgId}/budgets`, {

--- a/e2e_tests/utils/budgets.ts
+++ b/e2e_tests/utils/budgets.ts
@@ -661,7 +661,7 @@ export async function requestDirectLiteLLMCompletion(
           {
             role: "system",
             content:
-              "You are responding to an automated budget certification request.",
+              "You are OpenHands agent, a helpful AI assistant that can interact with a computer to solve tasks.",
           },
           { role: "user", content: config.directPrompt },
         ],

--- a/e2e_tests/utils/budgets.ts
+++ b/e2e_tests/utils/budgets.ts
@@ -527,6 +527,7 @@ async function updateLiteLLM(
   config: BudgetE2EConfig,
   path: string,
   data: Record<string, unknown>,
+  acceptableStatuses: number[] = [],
 ): Promise<void> {
   if (!config.litellmUrl || !config.litellmApiKey) {
     throw new Error("LiteLLM E2E admin configuration is not available");
@@ -542,7 +543,7 @@ async function updateLiteLLM(
       body: JSON.stringify(data),
     },
   );
-  if (!response.ok) {
+  if (!response.ok && !acceptableStatuses.includes(response.status)) {
     throw new Error(
       `update LiteLLM ${path} failed (${response.status} ${response.statusText})`,
     );
@@ -637,7 +638,12 @@ export function deleteLiteLLMTestKey(
   config: BudgetE2EConfig,
   keyAlias: string,
 ): Promise<void> {
-  return updateLiteLLM(config, "key/delete", { key_aliases: [keyAlias] });
+  return updateLiteLLM(
+    config,
+    "key/delete",
+    { key_aliases: [keyAlias] },
+    [404],
+  );
 }
 
 export async function requestDirectLiteLLMCompletion(

--- a/e2e_tests/utils/budgets.ts
+++ b/e2e_tests/utils/budgets.ts
@@ -450,27 +450,77 @@ export async function getLiteLLMMemberState(
   if (!isRecord(teamInfo)) {
     throw new Error("LiteLLM team response is missing team_info");
   }
-  let memberships: unknown[] = [];
-  if (Array.isArray(body.team_memberships)) {
-    memberships = body.team_memberships;
-  } else if (Array.isArray(teamInfo.members_with_roles)) {
-    memberships = teamInfo.members_with_roles;
+  const defaultBudgetTable = teamInfo.team_member_budget_table;
+  if (
+    defaultBudgetTable !== undefined &&
+    defaultBudgetTable !== null &&
+    !isRecord(defaultBudgetTable)
+  ) {
+    throw new Error("team_info.team_member_budget_table must be an object");
   }
+  const defaultMaxBudget = isRecord(defaultBudgetTable)
+    ? nullableNonNegativeNumber(
+        defaultBudgetTable.max_budget,
+        "team_info.team_member_budget_table.max_budget",
+      )
+    : null;
+
+  const memberships = Array.isArray(body.team_memberships)
+    ? body.team_memberships
+    : [];
   const membership = memberships.find(
     (candidate) => isRecord(candidate) && candidate.user_id === userId,
   );
-  if (!isRecord(membership)) return null;
-  return {
-    userId,
-    maxBudget: nullableNonNegativeNumber(
-      membership.max_budget_in_team,
-      `membership.${userId}.max_budget_in_team`,
-    ),
-    spend: requiredNonNegativeNumber(
-      membership.spend,
-      `membership.${userId}.spend`,
-    ),
-  };
+  if (isRecord(membership)) {
+    const budgetTable = membership.litellm_budget_table;
+    if (
+      budgetTable !== undefined &&
+      budgetTable !== null &&
+      !isRecord(budgetTable)
+    ) {
+      throw new Error(
+        `membership.${userId}.litellm_budget_table must be an object`,
+      );
+    }
+    return {
+      userId,
+      maxBudget: isRecord(budgetTable)
+        ? nullableNonNegativeNumber(
+            budgetTable.max_budget,
+            `membership.${userId}.litellm_budget_table.max_budget`,
+          )
+        : defaultMaxBudget,
+      spend: requiredNonNegativeNumber(
+        membership.spend,
+        `membership.${userId}.spend`,
+      ),
+    };
+  }
+
+  const roster = Array.isArray(teamInfo.members_with_roles)
+    ? teamInfo.members_with_roles
+    : [];
+  const isRosterMember = roster.some(
+    (candidate) => isRecord(candidate) && candidate.user_id === userId,
+  );
+  if (!isRosterMember) return null;
+
+  const matchingKeys = (Array.isArray(body.keys) ? body.keys : []).filter(
+    (candidate) => isRecord(candidate) && candidate.user_id === userId,
+  );
+  if (matchingKeys.length === 0) {
+    throw new Error(`role-only member ${userId} has no validated key spend`);
+  }
+  const spend = matchingKeys.reduce(
+    (total, key, index) =>
+      total +
+      requiredNonNegativeNumber(
+        (key as Record<string, unknown>).spend,
+        `keys.${userId}.${index}.spend`,
+      ),
+    0,
+  );
+  return { userId, maxBudget: defaultMaxBudget, spend };
 }
 
 async function updateLiteLLM(

--- a/e2e_tests/utils/budgets.ts
+++ b/e2e_tests/utils/budgets.ts
@@ -737,16 +737,35 @@ export async function requireDirectBudgetDenial(
   config: BudgetE2EConfig,
   key: string,
 ): Promise<LiteLLMCompletionResult> {
-  const response = await requestDirectLiteLLMCompletion(config, key);
-  if (
-    ![400, 429].includes(response.status) ||
-    !/budget|exceed|limit/i.test(response.body)
-  ) {
-    throw new Error(
-      `expected a LiteLLM budget denial, received ${response.status}: ${response.body}`,
-    );
+  const attempts = 5;
+  let response: LiteLLMCompletionResult | undefined;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    response = await requestDirectLiteLLMCompletion(config, key);
+    if (
+      [400, 429].includes(response.status) &&
+      /budget|exceed|limit/i.test(response.body)
+    ) {
+      return response;
+    }
+    // LiteLLM updates spend asynchronously. One request can be admitted after
+    // a verified cap write while the request-admission cache catches up; bound
+    // that race rather than mistaking an indefinitely unenforced cap for a
+    // pass.
+    if (
+      response.status < 200 ||
+      response.status >= 300 ||
+      attempt === attempts
+    ) {
+      break;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, config.pollIntervalMs);
+    });
   }
-  return response;
+  const body = response?.body.slice(0, 500) || "no response body";
+  throw new Error(
+    `expected a LiteLLM budget denial within ${attempts} attempts, last response was ${response?.status}: ${body}`,
+  );
 }
 
 export async function findSlackBudgetAlert(

--- a/e2e_tests/utils/budgets.ts
+++ b/e2e_tests/utils/budgets.ts
@@ -27,8 +27,12 @@ export interface BudgetSettings {
   litellm_last_sync_error: string | null;
   cycle_start_at: string;
   cycle_end_at: string;
-  current_spend: number;
-  current_spend_percentage: number;
+  spend_status: "live" | "stale" | "unavailable";
+  spend_observed_at: string | null;
+  current_spend: number | null;
+  current_spend_percentage: number | null;
+  unmapped_spend: number | null;
+  unmapped_member_count: number | null;
   thresholds: BudgetThreshold[];
   users: BudgetUser[];
 }
@@ -67,6 +71,17 @@ export interface LiteLLMTeamState {
   spend: number;
 }
 
+export interface LiteLLMMemberState {
+  userId: string;
+  maxBudget: number | null;
+  spend: number;
+}
+
+export interface LiteLLMCompletionResult {
+  status: number;
+  body: string;
+}
+
 interface OrgConversationPage {
   total_items: number;
 }
@@ -102,6 +117,8 @@ export interface BudgetE2EConfig {
   databaseUrl?: string;
   litellmUrl?: string;
   litellmApiKey?: string;
+  serviceUserId?: string;
+  serviceApiKey?: string;
   slack?: SlackConfig;
 }
 
@@ -120,6 +137,8 @@ export function loadBudgetE2EConfig(): BudgetE2EConfig {
   const databaseUrl = process.env.BUDGET_E2E_DATABASE_URL?.trim();
   const litellmUrl = process.env.BUDGET_E2E_LITELLM_URL?.trim();
   const litellmApiKey = process.env.BUDGET_E2E_LITELLM_API_KEY?.trim();
+  const serviceUserId = process.env.BUDGET_E2E_SERVICE_USER_ID?.trim();
+  const serviceApiKey = process.env.BUDGET_E2E_SERVICE_API_KEY?.trim();
   const directModel = process.env.BUDGET_E2E_DIRECT_MODEL?.trim();
   const slackValues = {
     botToken: process.env.BUDGET_E2E_SLACK_BOT_TOKEN?.trim(),
@@ -152,6 +171,11 @@ export function loadBudgetE2EConfig(): BudgetE2EConfig {
       "All BUDGET_E2E_SLACK_* variables are required for budget certification",
     );
   }
+  if (enabled && (!serviceUserId || !serviceApiKey)) {
+    throw new Error(
+      "BUDGET_E2E_SERVICE_USER_ID and BUDGET_E2E_SERVICE_API_KEY are required for unmapped SDK verification",
+    );
+  }
 
   return {
     enabled,
@@ -176,6 +200,8 @@ export function loadBudgetE2EConfig(): BudgetE2EConfig {
     databaseUrl,
     litellmUrl,
     litellmApiKey,
+    serviceUserId,
+    serviceApiKey,
     slack: hasAllSlackValues
       ? {
           botToken: slackValues.botToken!,
@@ -185,6 +211,25 @@ export function loadBudgetE2EConfig(): BudgetE2EConfig {
         }
       : undefined,
   };
+}
+
+function requiredNonNegativeNumber(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${field} must be a finite non-negative number`);
+  }
+  return value;
+}
+
+function nullableNonNegativeNumber(
+  value: unknown,
+  field: string,
+): number | null {
+  if (value === null || value === undefined) return null;
+  return requiredNonNegativeNumber(value, field);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 async function responseJson<T>(
@@ -361,9 +406,9 @@ export async function getLiteLLMVersion(
   return details.litellm_version;
 }
 
-export async function getLiteLLMTeamState(
+async function getLiteLLMTeam(
   config: BudgetE2EConfig,
-): Promise<LiteLLMTeamState> {
+): Promise<Record<string, unknown>> {
   if (!config.litellmUrl || !config.litellmApiKey) {
     throw new Error("LiteLLM E2E admin configuration is not available");
   }
@@ -377,12 +422,59 @@ export async function getLiteLLMTeamState(
       `get LiteLLM team failed (${response.status} ${response.statusText})`,
     );
   }
-  const body = (await response.json()) as {
-    team_info?: { max_budget?: number | null; spend?: number | null };
-  };
+  const body: unknown = await response.json();
+  if (!isRecord(body)) {
+    throw new Error("LiteLLM team response must be an object");
+  }
+  return body;
+}
+
+export async function getLiteLLMTeamState(
+  config: BudgetE2EConfig,
+): Promise<LiteLLMTeamState> {
+  const body = await getLiteLLMTeam(config);
+  const teamInfo = body.team_info;
+  if (!isRecord(teamInfo)) {
+    throw new Error("LiteLLM team response is missing team_info");
+  }
   return {
-    maxBudget: body.team_info?.max_budget ?? null,
-    spend: body.team_info?.spend ?? 0,
+    maxBudget: nullableNonNegativeNumber(
+      teamInfo.max_budget,
+      "team_info.max_budget",
+    ),
+    spend: requiredNonNegativeNumber(teamInfo.spend, "team_info.spend"),
+  };
+}
+
+export async function getLiteLLMMemberState(
+  config: BudgetE2EConfig,
+  userId: string,
+): Promise<LiteLLMMemberState | null> {
+  const body = await getLiteLLMTeam(config);
+  const teamInfo = body.team_info;
+  if (!isRecord(teamInfo)) {
+    throw new Error("LiteLLM team response is missing team_info");
+  }
+  let memberships: unknown[] = [];
+  if (Array.isArray(body.team_memberships)) {
+    memberships = body.team_memberships;
+  } else if (Array.isArray(teamInfo.members_with_roles)) {
+    memberships = teamInfo.members_with_roles;
+  }
+  const membership = memberships.find(
+    (candidate) => isRecord(candidate) && candidate.user_id === userId,
+  );
+  if (!isRecord(membership)) return null;
+  return {
+    userId,
+    maxBudget: nullableNonNegativeNumber(
+      membership.max_budget_in_team,
+      `membership.${userId}.max_budget_in_team`,
+    ),
+    spend: requiredNonNegativeNumber(
+      membership.spend,
+      `membership.${userId}.spend`,
+    ),
   };
 }
 
@@ -434,6 +526,32 @@ export function updateLiteLLMMemberCap(
   });
 }
 
+export async function removeLiteLLMTeamMember(
+  config: BudgetE2EConfig,
+  userId: string,
+): Promise<void> {
+  await updateLiteLLM(config, "team/member_delete", {
+    team_id: config.orgId,
+    user_id: userId,
+  });
+}
+
+export async function ensureLiteLLMTeamMember(
+  config: BudgetE2EConfig,
+  userId: string,
+  maxBudget: number | null,
+): Promise<void> {
+  if (await getLiteLLMMemberState(config, userId)) return;
+  await updateLiteLLM(config, "team/member_add", {
+    team_id: config.orgId,
+    member: {
+      user_id: userId,
+      role: "user",
+    },
+    max_budget_in_team: maxBudget,
+  });
+}
+
 export async function createLiteLLMTestKey(
   config: BudgetE2EConfig,
   userId: string,
@@ -477,10 +595,10 @@ export function deleteLiteLLMTestKey(
   return updateLiteLLM(config, "key/delete", { key_aliases: [keyAlias] });
 }
 
-export async function generateDirectLiteLLMSpend(
+export async function requestDirectLiteLLMCompletion(
   config: BudgetE2EConfig,
   key: string,
-): Promise<void> {
+): Promise<LiteLLMCompletionResult> {
   if (!config.litellmUrl || !config.litellmApiKey || !config.directModel) {
     throw new Error("LiteLLM direct-traffic configuration is not available");
   }
@@ -491,7 +609,6 @@ export async function generateDirectLiteLLMSpend(
       headers: {
         Authorization: `Bearer ${key}`,
         "Content-Type": "application/json",
-        "x-goog-api-key": config.litellmApiKey,
       },
       body: JSON.stringify({
         model: config.directModel,
@@ -500,12 +617,36 @@ export async function generateDirectLiteLLMSpend(
       }),
     },
   );
-  if (!response.ok) {
+  return { status: response.status, body: await response.text() };
+}
+
+export async function generateDirectLiteLLMSpend(
+  config: BudgetE2EConfig,
+  key: string,
+): Promise<void> {
+  const response = await requestDirectLiteLLMCompletion(config, key);
+  if (response.status < 200 || response.status >= 300) {
     throw new Error(
-      `direct LiteLLM completion failed (${response.status} ${response.statusText}): ${await response.text()}`,
+      `direct LiteLLM completion failed (${response.status}): ${response.body}`,
     );
   }
-  await response.json();
+  JSON.parse(response.body);
+}
+
+export async function requireDirectBudgetDenial(
+  config: BudgetE2EConfig,
+  key: string,
+): Promise<LiteLLMCompletionResult> {
+  const response = await requestDirectLiteLLMCompletion(config, key);
+  if (
+    ![400, 429].includes(response.status) ||
+    !/budget|exceed|limit/i.test(response.body)
+  ) {
+    throw new Error(
+      `expected a LiteLLM budget denial, received ${response.status}: ${response.body}`,
+    );
+  }
+  return response;
 }
 
 export async function findSlackBudgetAlert(

--- a/e2e_tests/utils/budgets.ts
+++ b/e2e_tests/utils/budgets.ts
@@ -240,6 +240,31 @@ async function responseJson<T>(
   return (await response.json()) as T;
 }
 
+const transientReadError =
+  /socket hang up|econnreset|etimedout|fetch failed|network.*(?:changed|closed|error)/i;
+
+async function readJsonWithRetry<T>(
+  request: () => Promise<APIResponse>,
+  operation: string,
+): Promise<T> {
+  const attempts = 3;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await responseJson<T>(request(), operation);
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts || !transientReadError.test(String(error))) {
+        throw error;
+      }
+      await new Promise((resolve) => {
+        setTimeout(resolve, attempt * 500);
+      });
+    }
+  }
+  throw lastError;
+}
+
 export class BudgetApi {
   constructor(
     private readonly request: APIRequestContext,
@@ -251,36 +276,39 @@ export class BudgetApi {
   }
 
   getOrganizations(): Promise<OrgPage> {
-    return responseJson<OrgPage>(
-      this.request.get("/api/organizations"),
+    return readJsonWithRetry<OrgPage>(
+      () => this.request.get("/api/organizations"),
       "list organizations",
     );
   }
 
   getOrg(): Promise<OrgDetails> {
-    return responseJson<OrgDetails>(
-      this.request.get(`/api/organizations/${this.orgId}`, {
-        headers: this.headers,
-      }),
+    return readJsonWithRetry<OrgDetails>(
+      () =>
+        this.request.get(`/api/organizations/${this.orgId}`, {
+          headers: this.headers,
+        }),
       "get organization details",
     );
   }
 
   getMe(): Promise<OrgMember> {
-    return responseJson<OrgMember>(
-      this.request.get(`/api/organizations/${this.orgId}/me`, {
-        headers: this.headers,
-      }),
+    return readJsonWithRetry<OrgMember>(
+      () =>
+        this.request.get(`/api/organizations/${this.orgId}/me`, {
+          headers: this.headers,
+        }),
       "get organization member",
     );
   }
 
   async getConversationCount(): Promise<number> {
-    const page = await responseJson<OrgConversationPage>(
-      this.request.get(
-        `/api/organizations/${this.orgId}/conversations?page=1&per_page=1`,
-        { headers: this.headers },
-      ),
+    const page = await readJsonWithRetry<OrgConversationPage>(
+      () =>
+        this.request.get(
+          `/api/organizations/${this.orgId}/conversations?page=1&per_page=1`,
+          { headers: this.headers },
+        ),
       "get organization conversation count",
     );
     return page.total_items;
@@ -306,10 +334,11 @@ export class BudgetApi {
   }
 
   getBudget(): Promise<BudgetSettings> {
-    return responseJson<BudgetSettings>(
-      this.request.get(`/api/organizations/${this.orgId}/budgets`, {
-        headers: this.headers,
-      }),
+    return readJsonWithRetry<BudgetSettings>(
+      () =>
+        this.request.get(`/api/organizations/${this.orgId}/budgets`, {
+          headers: this.headers,
+        }),
       "get budget settings",
     );
   }
@@ -325,11 +354,12 @@ export class BudgetApi {
   }
 
   async getMemberFinancial(userId: string): Promise<MemberFinancial> {
-    const page = await responseJson<MemberFinancialPage>(
-      this.request.get(
-        `/api/organizations/${this.orgId}/members/financial?limit=100`,
-        { headers: this.headers },
-      ),
+    const page = await readJsonWithRetry<MemberFinancialPage>(
+      () =>
+        this.request.get(
+          `/api/organizations/${this.orgId}/members/financial?limit=100`,
+          { headers: this.headers },
+        ),
       "get member financial data",
     );
     const member = page.items.find((item) => item.user_id === userId);

--- a/e2e_tests/utils/budgets.ts
+++ b/e2e_tests/utils/budgets.ts
@@ -166,11 +166,6 @@ export function loadBudgetE2EConfig(): BudgetE2EConfig {
       "BUDGET_E2E_DIRECT_MODEL is required for direct LiteLLM traffic",
     );
   }
-  if (enabled && !hasAllSlackValues) {
-    throw new Error(
-      "All BUDGET_E2E_SLACK_* variables are required for budget certification",
-    );
-  }
   if (enabled && (!serviceUserId || !serviceApiKey)) {
     throw new Error(
       "BUDGET_E2E_SERVICE_USER_ID and BUDGET_E2E_SERVICE_API_KEY are required for unmapped SDK verification",


### PR DESCRIPTION
## Description

Stacks on #1117 and expands its six incident regressions into the release certification matrix required by OpenHands/enterprise#242.

This adds:

- real hard-denial checks for both organization and member caps using direct OpenAI-compatible SDK traffic through LiteLLM;
- virtual-key-only authentication for direct traffic, without the LiteLLM admin header;
- mid-cycle missing-membership verification and cycle-boundary repair verification;
- a pre-provisioned LiteLLM-only service identity whose spend must appear as unmapped organization usage without creating a conversation or receiving a rewritten human cap;
- strict LiteLLM response parsing so a missing or malformed spend counter cannot become zero in the certification harness;
- nullable API types for stale/unavailable authoritative spend;
- complete snapshot/restore of cycle baselines, reconciliation state, last-known-good spend, known-member migration fields, and the managed LiteLLM key affected by membership-drift testing;
- bounded retries for idempotent reads and for the documented final-request admission race, while still failing an indefinitely unenforced cap;
- helper unit tests and execution of those tests in the static E2E workflow;
- an operator contract for all protected-environment variables and secrets, including how to use an Azure-backed proxy model;
- a selectable protected-environment runner so private Replicated databases do not need to be exposed to GitHub-hosted runners;
- opt-in scheduling so incomplete environments do not generate misleading daily failures before the first manual certification passes; and
- optional Slack certification so non-Slack deployments run the remaining matrix while issue 5 is explicitly reported as skipped.

The live suite discovers nine budget scenarios. It remains mutation-gated, serial, restricted to a dedicated test organization, and manual/scheduled behind the `budget-e2e-staging` environment.

## Validation

- `npm run lint` passed (TypeScript, ESLint, Prettier).
- `npm run test:unit` passed: 14/14.
- Playwright discovery passed: all nine budget scenarios plus returning-user setup were discovered.
- Workflow and README formatting passed.
- `git diff --check` passed.

### Live feature-preview certification

A no-retry run against the isolated saas-deploy#907 preview completed with **9 passed, 1 skipped in 5.9 minutes**: returning-user setup plus all eight configured budget scenarios passed, and the optional Slack alert scenario was explicitly skipped.

The run used:

- Enterprise image `ghcr.io/openhands/enterprise-server:sha-b2e3e6a` from OpenHands/enterprise#242;
- the deployment's bundled LiteLLM proxy at version 1.94.1;
- a real metered Claude Haiku proxy model;
- generated virtual-key-only SDK traffic, with no LiteLLM admin credential on inference requests; and
- a LiteLLM-only service identity that is intentionally absent from OpenHands membership and conversation records.

It passed stable organization and user cycle caps, override reconciliation, disabled-budget cap preservation, authoritative SDK spend reporting, organization/member hard denials, mid-cycle membership hold plus boundary repair, and unmapped service-identity attribution. Cleanup restored the disabled/null budget policy, original caps, owner membership, managed LLM key, and original current organization.

The successful run expedited queued maintenance with one-shot jobs. The preview now uses a one-minute budget-maintenance cadence for unattended repeats. Later repeat attempts usefully reproduced a dropped idempotent GET and one late-admitted request while LiteLLM enforcement caught up; both are now bounded by regression-tested harness behavior. A final local repeat lost its long-lived Kubernetes PostgreSQL port-forward, confirming that the protected workflow should use its documented self-hosted runner with direct private-database connectivity.

Slack delivery was not configured for this deployment, and an Azure-backed model alias has not yet been exercised. Those remain explicit release gates rather than implied coverage.

## Helm Chart Checklist

No Helm chart files are changed in this PR.

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

The first certification run may use any working alias in the deployment's bundled LiteLLM proxy. A later customer-parity release gate should use an Azure-backed alias; direct calls to an external Azure endpoint remain outside the OHE budget enforcement boundary.

- [ ] A human has tested these changes.
