### PR TITLE
feat(skills): PLTF-3531 add eks-install cluster-install skill

### DIFF
--- a/.agents/skills/eks-install.md
+++ b/.agents/skills/eks-install.md
@@ -1,0 +1,194 @@
+---
+name: eks-install
+description: Stand up an OpenHands Enterprise Helm install on a throwaway AWS EKS cluster (ghcr chart source, Traefik behind an NLB, cert-manager, real Let's Encrypt TLS, embedded Postgres on a gp3 EBS PVC) using eks-install/. Use when a reproduction needs real cloud behaviour KinD cannot provide - PVC expansion, enforced volume capacity, real ingress and TLS - and specifically when the target environment is AWS/EKS.
+---
+
+# EKS test Helm install
+
+Reach for this over `local-kind-install` only when the reproduction needs
+something KinD genuinely cannot do (real EBS capacity/expansion, a real load
+balancer, publicly trusted certs) and the target environment is AWS/EKS. KinD is
+faster and free for most chart work.
+
+Everything lives in `eks-install/`. The scripts encode the non-obvious AWS fixes
+below — run them rather than reimplementing. `eks-install/values.yaml.tmpl` is the
+values file and `../local-kind/create-secrets.sh` is reused unchanged.
+
+**What KinD cannot reproduce** (all real on EBS):
+
+- `df` inside the Postgres pod reports the node filesystem, not the volume,
+  because `local-path` is a host bind mount. On EBS it reports the real volume.
+- Volume capacity is not enforced, so a "full disk" cannot be reproduced. EBS
+  enforces it.
+- `kubectl patch pvc` is a silent no-op on `local-path`. With the gp3 CSI class
+  (`allowVolumeExpansion: true`) expansion actually happens.
+- Real ingress, real DNS, and publicly trusted certificates.
+
+## Non-obvious EKS setup (read this first)
+
+These are the EKS specifics that actually bite; the chart-level constraints are
+shared and listed further down.
+
+- **The load balancer is a hostname, not an IP.** AWS's Traefik `LoadBalancer`
+  yields `.status.loadBalancer.ingress[0].hostname` (an ELB DNS name), not
+  `[0].ip`. So the DNS record is a **CNAME** (or a Route53 alias A record), never
+  an `A` with a literal IP. `create-cluster.sh` reads `.hostname` and writes a
+  wildcard CNAME.
+- **The EBS CSI driver is not installed by default.** EKS does not ship EBS CSI,
+  so without the addon (and its IRSA role) every PVC stays `Pending` forever. `create-cluster.sh` installs it via
+  `eksctl create iamserviceaccount` + `eksctl create addon`.
+- **The default `gp2` StorageClass does not allow expansion.** It uses the
+  deprecated in-tree provisioner `kubernetes.io/aws-ebs` with
+  `allowVolumeExpansion` unset — so a `kubectl patch pvc` to grow is *rejected*
+  (not silently ignored like KinD, but it still won't grow). Create a gp3 CSI
+  class (`gp3-storageclass.yaml`) and make it default; point
+  `runtime-api.env.STORAGE_CLASS` at it.
+- **IRSA needs the cluster's OIDC provider.** `eksctl create cluster --with-oidc`
+  provisions it. Both the EBS CSI role and any cert-manager Route53 DNS-01 role
+  depend on it.
+- **DNS-01 uses Route53, not Cloud DNS.** The wildcard sandbox cert (if you get
+  that far) comes from a cert-manager issuer with a `route53` solver bound to an
+  IRSA service account; flat per-host certs use HTTP-01 over the NLB.
+
+## Ask the user before starting
+
+- **AWS region** and **cluster name**. Never invent these.
+- **Base domain**, which must be a **Route53 hosted zone** in that account so the
+  wildcard record can be created without a manual step. Have the **hosted zone
+  id** too (`aws route53 list-hosted-zones`).
+- **GitHub App credentials** from `scripts/create_github_app`, plus the base
+  domain it was created with. This is the single most common cause of a broken
+  login — see the callback constraint below.
+- **Anthropic API key**, placed in a file or env var by the user, not pasted in
+  chat.
+
+`aws sso login` / credential setup is the user's responsibility; if the CLI
+returns `ExpiredToken`, ask them to refresh rather than trying to drive it.
+
+## Sequence
+
+Substitute your own values. Every `kubectl`/`helm` call pins `--context`.
+
+```bash
+export CLUSTER=openhands-eks-install REGION=us-east-1
+export BASE_DOMAIN=oh.example.com HOSTED_ZONE_ID=ZXXXXXXXXXXXXX
+export NAMESPACE=openhands
+
+# 1. cluster + EBS CSI + gp3 default class + Traefik/NLB + Route53 wildcard +
+#    cert-manager. ~15 min (EKS control plane is the slow part).
+./eks-install/create-cluster.sh
+
+# 2. secrets — the KinD script works as-is against any context/namespace.
+export GITHUB_APP_ID=... GITHUB_APP_SLUG=... GITHUB_APP_CLIENT_ID=... \
+       GITHUB_APP_CLIENT_SECRET=... GITHUB_APP_WEBHOOK_SECRET=... \
+       GITHUB_APP_PRIVATE_KEY_FILE=./scripts/create_github_app/keys/<app>.pem \
+       ANTHROPIC_API_KEY=sk-ant-...
+./local-kind/create-secrets.sh
+
+# 3. install (public ghcr chart + images; no pull secret, no license).
+export CTX=${CLUSTER}.${REGION}.eksctl.io STORAGE_CLASS=gp3 CLUSTER_ISSUER=letsencrypt
+./eks-install/install.sh
+```
+
+Then open `https://app.$BASE_DOMAIN`, log in with GitHub, and start a conversation.
+Set `REGISTRY=replicated LICENSE_EMAIL=... LICENSE_ID=...` on `install.sh` to pull
+from `registry.replicated.com` instead of ghcr.
+
+## Constraints that bite (do not "fix" these away)
+
+### AWS-specific
+
+- **Tear the NLB down before the cluster.** An orphaned NLB keeps ENIs and
+  security groups attached to the VPC, and eksctl's VPC CloudFormation stack
+  cannot delete while they exist — the teardown hangs or fails half-done.
+  `delete-cluster.sh` `helm uninstall`s Traefik (releasing the NLB) and waits
+  before `eksctl delete cluster`.
+- **A straight `eksctl delete cluster` can orphan EBS volumes.** PVCs on the gp3
+  class use `reclaimPolicy: Delete`, so `helm uninstall` removes their volumes —
+  but deleting the cluster without uninstalling first leaves them behind, still
+  billing. `delete-cluster.sh` uninstalls first and then lists anything tagged
+  `kubernetes.io/cluster/$CLUSTER` so you can confirm nothing leaked.
+- **Never add a deeper wildcard record.** `*.$BASE_DOMAIN` already matches at any
+  depth when no closer name exists, so it covers `auth.app.$BASE_DOMAIN` and every
+  `{id}-runtime.$BASE_DOMAIN`. Adding `*.app.$BASE_DOMAIN` creates an empty
+  non-terminal node at `app.$BASE_DOMAIN` that **blocks wildcard synthesis**, and
+  the app's own hostname starts returning NODATA — the site goes unreachable while
+  the service is healthy. Route53 negative caching makes it persist past the undo.
+- **`get-credentials`/`update-kubeconfig` will leave a usable context behind, and
+  a shared account holds other people's clusters with similar names.** Pin
+  `--context` on everything; pod and namespace names are identical across
+  clusters, which makes a wrong reading look plausible. Print the exact match and
+  the keep-list before deleting (the teardown script does this).
+- **Let's Encrypt HTTP-01 validates over the NLB, so the wildcard record must
+  resolve first.** If certs stay `Pending`, check the CNAME propagated
+  (`dig +short app.$BASE_DOMAIN`) before blaming cert-manager. Use the LE staging
+  issuer while iterating to avoid rate limits.
+
+### Chart-level (shared with the local-kind skill)
+
+- **`RUNTIME_ROUTING_MODE: path` requires ingress-nginx or Gateway API.** On
+  Traefik with standard ingresses, runtime-api raises `create_ingress_manifest
+  failed because path mode is only supported with ingress-nginx` and every sandbox
+  fails to start. Use subdomain routing (`RUNTIME_URL_SEPARATOR: "-"`,
+  `RUNTIME_URL_PATTERN: https://{runtime_id}-runtime.<base>`), which the values
+  template already does. Subdomain routing needs a **wildcard certificate**;
+  HTTP-01 cannot issue wildcards, so it needs the Route53 DNS-01 solver and
+  `runtime-api.env.RUNTIME_CERT_SECRET`. **This wildcard/sandbox path is not yet
+  validated on EKS** — conversations were never confirmed working end to end.
+- **The GitHub App callback is derived from the base domain passed to
+  `create_github_app`**, not your ingress host. It sets `url:
+  https://app.{base_domain}` and registers exactly one callback,
+  `https://auth.{base_domain}/realms/allhands/broker/github/endpoint` for the flat
+  layout. Keycloak's hostname must match that string exactly. To recover the base
+  domain from an existing app, mint an app JWT and read `external_url` from
+  `GET /app`. Do **not** probe GitHub with a bogus `redirect_uri` to test it — a
+  302 proves nothing; only a real login round trip does.
+- **`postgresql.primary.resourcesPreset` is inert on its own.** The umbrella chart
+  pins `postgresql.primary.resources`, and Bitnami prefers explicit resources over
+  any preset, so the container gets a 1Gi limit regardless. Add `resources: null`
+  to delete the pinned block and let the preset apply. `shared_buffers = 1GB`
+  inside a 1Gi limit OOM-kills Postgres under load while looking healthy at idle
+  (`1/1 Running`, ~60 MiB), because shared pages are charged to the cgroup as they
+  are touched.
+- **Leaving `persistence.size` unset yields 8Gi** (the Bitnami subchart default;
+  the umbrella chart never sets a size). A StatefulSet's `volumeClaimTemplates` is
+  immutable — adding `size:` and upgrading fails whole and applies nothing else in
+  that upgrade. Grow the PVC first with `kubectl patch pvc` (works on gp3), then
+  `kubectl delete sts <release>-postgresql --cascade=orphan` and upgrade; pods
+  survive.
+- **MinIO deadlocks on upgrade.** Its Deployment uses `RollingUpdate` with an RWO
+  PVC, so the new pod cannot attach (`Multi-Attach error`, and on EBS the volume
+  is also AZ-pinned) until the old one is deleted by hand. It wants `Recreate`.
+- **`replicated.enabled` defaults to true**, and the SDK license is injected only
+  at pull time by `registry.replicated.com`. On a ghcr install the pod crashloops
+  with `either license in the config file or integration license id must be
+  specified`. The values template sets it false.
+- **Recreating the Postgres database needs two manual nudges.** Keycloak only
+  bootstraps its admin user on first start, so `keycloak-config` fails with
+  `Couldn't login using either the "admin" or "tmpadmin" accounts` until the
+  Keycloak pod is restarted. LiteLLM needs a restart too, or `litellm-config`
+  hangs creating its team against an empty schema.
+
+## Verifying an install
+
+- `https://app.$BASE_DOMAIN` serves the login page (200, publicly trusted cert).
+- Login with the GitHub App completes.
+- A conversation gets a `runtime-*` pod, an ingress at `<id>-runtime.$BASE_DOMAIN`,
+  and an agent reply. (Blocked until the wildcard cert path above is validated.)
+
+## Teardown
+
+Roughly $0.70–$0.85/hr: EKS control plane ($0.10/hr) + 3× m5.xlarge (~$0.58/hr) +
+the NLB + EBS. Tear down when finished.
+
+```bash
+export CLUSTER=openhands-eks-install REGION=us-east-1 \
+       BASE_DOMAIN=oh.example.com HOSTED_ZONE_ID=ZXXXXXXXXXXXXX
+./eks-install/delete-cluster.sh
+```
+
+The script uninstalls the releases (releasing the NLB and EBS volumes), removes
+the wildcard CNAME, deletes the cluster, and lists any orphaned volumes tagged for
+the cluster so you can delete them by hand. Confirm no `elb`/`elbv2` load balancer
+survived (`aws elbv2 describe-load-balancers` / `aws elb describe-load-balancers`)
+— a stranded one keeps charging and can block a later VPC cleanup.

--- a/eks-install/README.md
+++ b/eks-install/README.md
@@ -1,0 +1,70 @@
+# EKS test Helm install
+
+Scripts to stand up an OpenHands Enterprise Helm install on a
+throwaway [EKS](https://aws.amazon.com/eks/) cluster — real EBS storage with
+expansion, an NLB in front of Traefik, and publicly trusted Let's Encrypt certs.
+The AWS counterpart of `../local-kind/` and the GKE flow.
+
+Read `.agents/skills/eks-install.md` for the reasoning and the constraints
+that bite; this README is the quick command reference.
+
+## Prerequisites
+
+- `awscli` (v2), `eksctl`, `kubectl`, `helm`, `envsubst`, `python3`.
+- AWS credentials with EKS/EC2/IAM/Route53 permission for the target account.
+- A **Route53 hosted zone** you control for the base domain, and its zone id.
+- A GitHub App from `scripts/create_github_app --base-domain <base>`.
+- An Anthropic API key.
+
+## Bring it up
+
+```bash
+export CLUSTER=openhands-eks-install REGION=us-east-1
+export BASE_DOMAIN=oh.example.com HOSTED_ZONE_ID=ZXXXXXXXXXXXXX
+
+# Edit letsencrypt-issuer.yaml's email before this creates the ClusterIssuer.
+./create-cluster.sh
+
+export GITHUB_APP_ID=... GITHUB_APP_SLUG=... GITHUB_APP_CLIENT_ID=... \
+       GITHUB_APP_CLIENT_SECRET=... GITHUB_APP_WEBHOOK_SECRET=... \
+       GITHUB_APP_PRIVATE_KEY_FILE=../scripts/create_github_app/keys/<app>.pem \
+       ANTHROPIC_API_KEY=sk-ant-...
+../local-kind/create-secrets.sh          # reused unchanged
+
+export CTX=${CLUSTER}.${REGION}.eksctl.io STORAGE_CLASS=gp3 CLUSTER_ISSUER=letsencrypt
+./install.sh                             # first run pulls several GB of images
+```
+
+Then open `https://app.$BASE_DOMAIN`, log in with GitHub, and start a
+conversation. Add `REGISTRY=replicated LICENSE_EMAIL=... LICENSE_ID=...` to
+`install.sh` to install from `registry.replicated.com` instead of ghcr.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `create-cluster.sh` | eksctl cluster, EBS CSI addon (IRSA), gp3 default class, Traefik/NLB, Route53 wildcard, cert-manager |
+| `gp3-storageclass.yaml` | gp3 CSI storage class with `allowVolumeExpansion: true`, set default |
+| `letsencrypt-issuer.yaml` | HTTP-01 ClusterIssuer (+ optional Route53 DNS-01 for the sandbox wildcard) |
+| `values.yaml.tmpl` | chart values, rendered with `envsubst` |
+| `install.sh` | render values and `helm upgrade --install` (ghcr or replicated) |
+| `delete-cluster.sh` | ordered teardown (release NLB → cluster → Route53 → check for orphaned EBS) |
+
+## Tear down
+
+```bash
+export CLUSTER=openhands-eks-install REGION=us-east-1 \
+       BASE_DOMAIN=oh.example.com HOSTED_ZONE_ID=ZXXXXXXXXXXXXX
+./delete-cluster.sh
+```
+
+Order matters: the NLB must be released before the VPC/cluster can delete, and
+PVCs must be uninstalled (not just the cluster deleted) or their EBS volumes leak.
+The script handles both and prints anything left over.
+
+## Not yet validated
+
+The sandbox subdomain routing path (wildcard cert via Route53 DNS-01,
+`RUNTIME_CERT_SECRET`) has not been confirmed working end to end on EKS. The
+app/auth/runtime-api hosts and GitHub login use ordinary HTTP-01 per-host certs
+and are the validated surface.

--- a/eks-install/create-cluster.sh
+++ b/eks-install/create-cluster.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Stand up a throwaway EKS cluster wired for an OpenHands Enterprise Helm
+# install: EBS CSI driver (with IRSA), a gp3 default storage class that allows
+# expansion, Traefik behind an NLB, a Route53 wildcard record, and cert-manager.
+#
+# Analogous to local-kind/create-cluster.sh, but on real AWS. Every kubectl/helm
+# call pins --context so an ambient prod context cannot be hit by accident.
+#
+# Required env:
+#   CLUSTER        cluster name (e.g. openhands-eks-install)
+#   REGION         AWS region (e.g. us-east-1)
+#   BASE_DOMAIN    a Route53 hosted zone you own; every host is one label under
+#                  it (app., auth., runtime-api., {id}-runtime.), so a single
+#                  *.$BASE_DOMAIN record covers the whole install
+#   HOSTED_ZONE_ID Route53 zone id for BASE_DOMAIN
+# Optional env:
+#   NODE_TYPE      instance type (default m5.xlarge = 4 vCPU / 16 GiB)
+#   NODES          node count (default 3)
+#   OWNER,PURPOSE  tags, so orphaned volumes/LB are attributable
+set -euo pipefail
+
+: "${CLUSTER:?set CLUSTER}"
+: "${REGION:?set REGION}"
+: "${BASE_DOMAIN:?set BASE_DOMAIN (a Route53 zone you own)}"
+: "${HOSTED_ZONE_ID:?set HOSTED_ZONE_ID}"
+node_type="${NODE_TYPE:-m5.xlarge}"
+nodes="${NODES:-3}"
+owner="${OWNER:-$(whoami)}"
+purpose="${PURPOSE:-eks-install}"
+CTX="${CLUSTER}.${REGION}.eksctl.io"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# 1. cluster (~15 min — EKS control plane + nodegroup CloudFormation). --with-oidc
+#    provisions the IAM OIDC provider that IRSA (EBS CSI, cert-manager) needs.
+eksctl create cluster --name "$CLUSTER" --region "$REGION" \
+  --nodes "$nodes" --node-type "$node_type" \
+  --node-volume-size 100 --node-volume-type gp3 \
+  --with-oidc \
+  --tags "owner=${owner},purpose=${purpose}"
+
+aws eks update-kubeconfig --name "$CLUSTER" --region "$REGION" --alias "$CTX"
+
+# 2. EBS CSI driver via IRSA. Unlike GKE's pd driver, this is NOT installed by
+#    default; without it PVCs stay Pending forever.
+eksctl create iamserviceaccount --cluster "$CLUSTER" --region "$REGION" \
+  --namespace kube-system --name ebs-csi-controller-sa \
+  --role-name "AmazonEKS_EBS_CSI_DriverRole_${CLUSTER}" \
+  --attach-policy-arn arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy \
+  --approve --role-only
+account_id="$(aws sts get-caller-identity --query Account --output text)"
+eksctl create addon --cluster "$CLUSTER" --region "$REGION" \
+  --name aws-ebs-csi-driver \
+  --service-account-role-arn "arn:aws:iam::${account_id}:role/AmazonEKS_EBS_CSI_DriverRole_${CLUSTER}" \
+  --force
+
+# 3. gp3 default storage class WITH allowVolumeExpansion (see the manifest).
+kubectl --context "$CTX" apply -f "$script_dir/gp3-storageclass.yaml"
+# Demote the shipped gp2 class so it is no longer default.
+kubectl --context "$CTX" patch storageclass gp2 \
+  -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}' \
+  2>/dev/null || true
+kubectl --context "$CTX" get sc
+
+# 4. Traefik behind an NLB. NOTE: on AWS the LoadBalancer exposes a *hostname*,
+#    not an IP — this is the key difference from GKE.
+helm repo add traefik https://traefik.github.io/charts >/dev/null
+helm repo update traefik >/dev/null
+helm --kube-context "$CTX" upgrade --install traefik traefik/traefik \
+  --namespace traefik --create-namespace \
+  --set service.type=LoadBalancer \
+  --set 'service.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-type=nlb' \
+  --wait --timeout 10m
+
+echo "Waiting for the NLB hostname..."
+for _ in $(seq 1 60); do
+  LB_HOST="$(kubectl --context "$CTX" -n traefik get svc traefik \
+    -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
+  [ -n "$LB_HOST" ] && break
+  sleep 10
+done
+: "${LB_HOST:?NLB hostname never appeared; check the traefik service}"
+echo "NLB: $LB_HOST"
+
+# 5. One wildcard Route53 record covers every host. Because the NLB is a
+#    hostname, this is a CNAME (an A-record-with-IP cannot point at an ELB).
+#    An apex/alias A record is an alternative but needs the NLB's zone id.
+cat >/tmp/eks-wildcard-rrset.json <<JSON
+{
+  "Comment": "OpenHands EKS test wildcard",
+  "Changes": [{
+    "Action": "UPSERT",
+    "ResourceRecordSet": {
+      "Name": "*.${BASE_DOMAIN}",
+      "Type": "CNAME",
+      "TTL": 300,
+      "ResourceRecords": [{"Value": "${LB_HOST}"}]
+    }
+  }]
+}
+JSON
+aws route53 change-resource-record-sets \
+  --hosted-zone-id "$HOSTED_ZONE_ID" \
+  --change-batch file:///tmp/eks-wildcard-rrset.json
+
+# 6. cert-manager + issuer. Edit letsencrypt-issuer.yaml's email first.
+helm repo add jetstack https://charts.jetstack.io >/dev/null
+helm repo update jetstack >/dev/null
+helm --kube-context "$CTX" upgrade --install cert-manager jetstack/cert-manager \
+  --namespace cert-manager --create-namespace \
+  --set crds.enabled=true --wait --timeout 6m
+kubectl --context "$CTX" apply -f "$script_dir/letsencrypt-issuer.yaml"
+
+cat <<EOF
+
+Cluster '$CLUSTER' ready.
+  context:  $CTX
+  NLB:      $LB_HOST
+  wildcard: *.${BASE_DOMAIN} -> $LB_HOST (allow ~1-2 min for DNS to propagate)
+
+Next:
+  NAMESPACE=openhands \\
+  GITHUB_APP_*=... ANTHROPIC_API_KEY=... \\
+    ../local-kind/create-secrets.sh          # reused as-is
+  BASE_DOMAIN=$BASE_DOMAIN STORAGE_CLASS=gp3 CLUSTER_ISSUER=letsencrypt \\
+  CTX=$CTX ./install.sh
+EOF

--- a/eks-install/delete-cluster.sh
+++ b/eks-install/delete-cluster.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Tear down the EKS test cluster in the RIGHT ORDER. An orphaned NLB and its
+# ENIs/security groups block VPC (and therefore cluster) deletion, so the
+# LoadBalancer service must go BEFORE eksctl delete cluster.
+#
+# Required env:
+#   CLUSTER, REGION, HOSTED_ZONE_ID, BASE_DOMAIN
+set -euo pipefail
+
+: "${CLUSTER:?set CLUSTER}"
+: "${REGION:?set REGION}"
+: "${HOSTED_ZONE_ID:?set HOSTED_ZONE_ID}"
+: "${BASE_DOMAIN:?set BASE_DOMAIN}"
+CTX="${CLUSTER}.${REGION}.eksctl.io"
+
+# Print the exact target and the keep-list before deleting anything — a shared
+# account may hold other people's similarly named clusters.
+echo "Clusters in $REGION:"
+eksctl get cluster --region "$REGION" -o json 2>/dev/null \
+  | python3 -c 'import json,sys,os
+c=os.environ["CLUSTER"]
+for x in json.load(sys.stdin):
+    n=x.get("Name") or x.get("metadata",{}).get("name")
+    print(("TARGET: " if n==c else "KEEP:   ")+str(n))' || true
+
+# 1. Capture the NLB hostname, then delete the ingress + LoadBalancer so AWS
+#    reclaims the NLB/ENIs before the VPC teardown.
+LB_HOST="$(kubectl --context "$CTX" -n traefik get svc traefik \
+  -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)"
+helm --kube-context "$CTX" uninstall openhands -n openhands 2>/dev/null || true
+helm --kube-context "$CTX" uninstall traefik -n traefik 2>/dev/null || true
+echo "Waiting for the NLB to be released..."
+sleep 60
+
+# 2. Remove the wildcard record (needs the current value to DELETE).
+if [ -n "$LB_HOST" ]; then
+  cat >/tmp/eks-wildcard-del.json <<JSON
+{"Changes":[{"Action":"DELETE","ResourceRecordSet":{
+  "Name":"*.${BASE_DOMAIN}","Type":"CNAME","TTL":300,
+  "ResourceRecords":[{"Value":"${LB_HOST}"}]}}]}
+JSON
+  aws route53 change-resource-record-sets --hosted-zone-id "$HOSTED_ZONE_ID" \
+    --change-batch file:///tmp/eks-wildcard-del.json || \
+    echo "Wildcard record delete failed; remove *.${BASE_DOMAIN} by hand."
+fi
+
+# 3. Delete the cluster (VPC, nodegroup, IAM service accounts, addons).
+eksctl delete cluster --name "$CLUSTER" --region "$REGION" --disable-nodegroup-eviction
+
+# 4. EBS volumes from PVCs use reclaimPolicy Delete, so helm uninstall should
+#    have removed them. Confirm none were orphaned (a straight cluster delete
+#    without the uninstall above WILL leave them billing).
+echo "Checking for orphaned EBS volumes tagged for this cluster..."
+aws ec2 describe-volumes --region "$REGION" \
+  --filters "Name=tag:kubernetes.io/cluster/${CLUSTER},Values=owned" \
+  --query 'Volumes[].{id:VolumeId,size:Size,state:State}' --output table || true
+echo "Delete any listed above by hand: aws ec2 delete-volume --region $REGION --volume-id <id>"

--- a/eks-install/gp3-storageclass.yaml
+++ b/eks-install/gp3-storageclass.yaml
@@ -1,0 +1,23 @@
+# gp3 storage class backed by the AWS EBS CSI driver, with expansion enabled.
+#
+# Why not the default "gp2": EKS ships a gp2 StorageClass that uses the
+# deprecated in-tree provisioner (kubernetes.io/aws-ebs) and does NOT set
+# allowVolumeExpansion, so `kubectl patch pvc` to grow a volume is rejected.
+# The EBS CSI driver (installed as an addon) provides real online expansion and
+# enforced capacity, which is the whole point of testing on real cloud.
+#
+# Making this the default class means the chart's PVCs (postgres, minio,
+# keycloak) land on it without touching every subchart. runtime-api sandbox
+# PVCs are named explicitly via runtime-api.env.STORAGE_CLASS in values.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+parameters:
+  type: gp3

--- a/eks-install/install.sh
+++ b/eks-install/install.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Install the openhands chart onto the EKS cluster. Defaults to the public ghcr
+# chart/images (no pull secret, no Replicated license). Set REGISTRY=replicated
+# with LICENSE_EMAIL/LICENSE_ID to install from registry.replicated.com instead.
+#
+# Required env:
+#   BASE_DOMAIN     same value used for create-cluster.sh
+#   CTX             kube context (default: $CLUSTER.$REGION.eksctl.io if CLUSTER/REGION set)
+# Optional env:
+#   NAMESPACE       target namespace (default: openhands)
+#   STORAGE_CLASS   EBS class with expansion (default: gp3)
+#   CLUSTER_ISSUER  cert-manager ClusterIssuer for HTTP-01 (default: letsencrypt)
+#   LLM_MODEL       Anthropic model id (default: claude-sonnet-4-5-20250929)
+#   CHART_VERSION   chart version to install (default: latest)
+#   REGISTRY        "ghcr" (default) or "replicated"
+#   LICENSE_EMAIL, LICENSE_ID  required when REGISTRY=replicated
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+namespace="${NAMESPACE:-openhands}"
+model="${LLM_MODEL:-claude-sonnet-4-5-20250929}"
+export STORAGE_CLASS="${STORAGE_CLASS:-gp3}"
+export CLUSTER_ISSUER="${CLUSTER_ISSUER:-letsencrypt}"
+export AWS_REGION="${AWS_REGION:-us-west-2}"
+registry="${REGISTRY:-ghcr}"
+
+# Bedrock upstream (via LiteLLM IRSA). LLM_MODEL stays the LiteLLM alias
+# (model_name); BEDROCK_INFERENCE_PROFILE_ID is the real upstream, e.g.
+# us.anthropic.claude-sonnet-4-5-20250929-v1:0
+: "${BEDROCK_ROLE_ARN:?set BEDROCK_ROLE_ARN (IAM role ARN for Bedrock IRSA)}"
+: "${BEDROCK_INFERENCE_PROFILE_ID:?set BEDROCK_INFERENCE_PROFILE_ID (e.g. us.anthropic.claude-sonnet-4-5-20250929-v1:0)}"
+export BEDROCK_ROLE_ARN BEDROCK_INFERENCE_PROFILE_ID
+
+: "${BASE_DOMAIN:?set BASE_DOMAIN}"
+if [ -z "${CTX:-}" ]; then
+  : "${CLUSTER:?set CTX or CLUSTER+REGION}"; : "${REGION:?set CTX or CLUSTER+REGION}"
+  CTX="${CLUSTER}.${REGION}.eksctl.io"
+fi
+
+case "$registry" in
+  ghcr)
+    chart="oci://ghcr.io/openhands/helm-charts/openhands" ;;
+  replicated)
+    : "${LICENSE_EMAIL:?}"; : "${LICENSE_ID:?}"
+    helm registry login registry.replicated.com --username "$LICENSE_EMAIL" --password "$LICENSE_ID"
+    chart="oci://registry.replicated.com/openhands/${CHANNEL_SLUG:-unstable}/openhands" ;;
+  *) echo "REGISTRY must be ghcr or replicated" >&2; exit 1 ;;
+esac
+
+version_flag=()
+[ -n "${CHART_VERSION:-}" ] && version_flag=(--version "$CHART_VERSION")
+
+values="$(mktemp)"
+BASE_DOMAIN="$BASE_DOMAIN" LLM_MODEL="$model" \
+  STORAGE_CLASS="$STORAGE_CLASS" CLUSTER_ISSUER="$CLUSTER_ISSUER" \
+  envsubst <"$script_dir/values.yaml.tmpl" >"$values"
+
+helm --kube-context "$CTX" upgrade --install openhands "$chart" \
+  ${version_flag[@]+"${version_flag[@]}"} \
+  --namespace "$namespace" --create-namespace \
+  --values "$values" \
+  --timeout 20m
+
+echo "Waiting for workloads (first install pulls several GB of images)..."
+kubectl --context "$CTX" wait -n "$namespace" --for=condition=ready pod --all --timeout=20m || {
+  echo "Some pods are not ready yet; inspect with: kubectl --context $CTX get pods -n $namespace"
+  exit 1
+}
+
+echo
+echo "OpenHands is up: https://app.$BASE_DOMAIN"

--- a/eks-install/letsencrypt-issuer.yaml
+++ b/eks-install/letsencrypt-issuer.yaml
@@ -1,0 +1,42 @@
+# HTTP-01 ClusterIssuer for the flat per-host certs (app, auth, runtime-api).
+# The solver validates over the Traefik NLB, so *.$BASE_DOMAIN must already
+# resolve to the NLB before this can issue.
+#
+# Replace the email before applying. Swap the server line for the staging
+# endpoint (https://acme-staging-v02.api.letsencrypt.org/directory) while
+# iterating, to avoid Let's Encrypt rate limits.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: you@example.com
+    privateKeySecretRef:
+      name: letsencrypt-account-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: traefik
+---
+# OPTIONAL: DNS-01 ClusterIssuer for the sandbox *wildcard* cert.
+# HTTP-01 cannot issue wildcards, so subdomain sandbox routing
+# ({id}-runtime.$BASE_DOMAIN) needs this. Requires an IRSA-bound service
+# account (or ambient node role) with Route53 change permission on the zone.
+# Fill in region and hostedZoneID. NOT yet validated end to end on EKS.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-dns01
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: you@example.com
+    privateKeySecretRef:
+      name: letsencrypt-dns01-account-key
+    solvers:
+      - dns01:
+          route53:
+            region: us-east-1
+            hostedZoneID: ZXXXXXXXXXXXXX

--- a/eks-install/values.yaml.tmpl
+++ b/eks-install/values.yaml.tmpl
@@ -1,0 +1,213 @@
+# Environment-specific values for an EKS install, rendered via
+# envsubst. TLS terminates at Traefik using a single wildcard certificate served
+# as Traefik's default (a cert-manager Certificate + TLSStore, issued by a
+# Route53 DNS-01 ClusterIssuer). The chart's own TLS is therefore disabled — the
+# same model local-kind uses, but with a real Let's Encrypt wildcard cert. One
+# wildcard covers app/auth/runtime-api AND every sandbox host.
+#
+# Export before rendering:
+#   BASE_DOMAIN    zone you control in Route53 (e.g. openhands.example.dev)
+#   LLM_MODEL      Anthropic model id (e.g. claude-sonnet-4-5-20250929)
+#   STORAGE_CLASS  EBS storage class with allowVolumeExpansion (e.g. gp3)
+ingress:
+  enabled: true
+  host: app.${BASE_DOMAIN}
+  class: traefik
+
+tls:
+  enabled: false # TLS terminates at Traefik's default wildcard certificate
+
+github:
+  enabled: true
+
+# Public ghcr install: the Replicated SDK sidecar has no license to pull and
+# crashloops with "either license ... must be specified". Disable it.
+replicated:
+  enabled: false
+
+# Create the app + runtime_api databases and run migrations on first install.
+databaseMigrations:
+  waitForDatabase: true
+  createDatabases: true
+  migrate: true
+
+# Bundled Postgres. auth.database sets DB_NAME for the app (empty by default,
+# which makes the app's wait-for-db loop forever).
+postgresql:
+  enabled: true
+  auth:
+    database: openhands
+  primary:
+    networkPolicy:
+      enabled: false
+
+redis:
+  networkPolicy:
+    enabled: false
+
+keycloak:
+  enabled: true
+  networkPolicy:
+    enabled: false
+  ingress:
+    enabled: true
+    hostname: auth.${BASE_DOMAIN}
+    tls: false
+
+sandbox:
+  # In-cluster service URL: pods reach the runtime-api by its Service name, not
+  # the external hostname (which resolves to the NLB, outside the cluster).
+  apiHostname: http://openhands-runtime-api:5000
+
+env:
+  # Must agree with runtime-api RUNTIME_BASE_URL / RUNTIME_URL_SEPARATOR below.
+  RUNTIME_URL_PATTERN: "https://{runtime_id}-runtime.${BASE_DOMAIN}"
+  LITELLM_DEFAULT_MODEL: litellm_proxy/${LLM_MODEL}
+
+runtime-api:
+  databaseMigrations:
+    waitForDatabase: true
+    createDatabases: true
+    migrate: true
+  ingress:
+    enabled: true
+    host: runtime-api.${BASE_DOMAIN}
+    tls: false
+  env:
+    RUNTIME_BASE_URL: runtime.${BASE_DOMAIN}
+    # Dash separator keeps each sandbox one label under ${BASE_DOMAIN}
+    # ({id}-runtime.${BASE_DOMAIN}), so the single *.${BASE_DOMAIN} record and
+    # wildcard cert cover every sandbox. Traefik terminates their TLS with the
+    # default cert, so no RUNTIME_CERT_SECRET is needed.
+    RUNTIME_URL_SEPARATOR: "-"
+    RUNTIME_DISABLE_SSL: "false"
+    # EBS-backed class WITH allowVolumeExpansion (see gp3-storageclass.yaml).
+    STORAGE_CLASS: ${STORAGE_CLASS}
+
+# Chart defaults filestore.type to gcs (needs GCP creds this cluster lacks) and
+# ships minio disabled; s3 + bundled MinIO give the file/event store a local
+# target. For production, point filestore at a real S3 bucket via IRSA.
+filestore:
+  type: s3
+minio:
+  enabled: true
+  persistence:
+    enabled: true
+
+# Bedrock upstream via a LiteLLM proxy (approximates a production Bedrock setup). Credentials
+# come from IRSA: the litellm pod runs under a dedicated ServiceAccount annotated
+# with the Bedrock role, so no static AWS keys are needed. model_info is
+# populated so /v1/model/info fully resolves cost + limits (matching a real deployment).
+litellm-helm:
+  enabled: true
+  serviceAccount:
+    create: true
+    name: openhands-litellm-bedrock
+    annotations:
+      eks.amazonaws.com/role-arn: ${BEDROCK_ROLE_ARN}
+  proxy_config:
+    model_list:
+      - model_name: ${LLM_MODEL}
+        litellm_params:
+          # Bedrock inference-profile ID (e.g. us.anthropic.claude-...); the
+          # "us.anthropic..." form is exactly what infer_provider mislabels.
+          model: bedrock/${BEDROCK_INFERENCE_PROFILE_ID}
+          aws_region_name: ${AWS_REGION}
+        model_info:
+          input_cost_per_token: 0.000003
+          output_cost_per_token: 0.000015
+          max_input_tokens: 200000
+          max_output_tokens: 8192
+      # Deliberate model-identity edge case (PLTF-3531): bare "us.anthropic..."
+      # ID with NO bedrock/ prefix (so infer_provider must guess), an alias that
+      # says 4-5 while the upstream is 4.6, and no aws_region_name. Kept verbatim.
+      - model_name: "prod/claude-sonnet-4-5-bedrock"
+        litellm_params:
+          model: "us.anthropic.claude-sonnet-4-6"
+          max_tokens: 8192
+
+# lockToCloud points the UI at this instance's backend so users skip the "Manage
+# Backends" prompt. TLS off because Traefik serves the default wildcard cert.
+agent-canvas:
+  enabled: true
+  ingress:
+    enabled: true
+    host: app.${BASE_DOMAIN}
+    className: traefik
+    path: /canvas
+    tls:
+      enabled: false
+  staticServer:
+    basePath: /canvas
+    authRequired: false
+    lockToCloud: https://app.${BASE_DOMAIN}
+
+# Laminar observability (lmnr-helm subchart). User-supplied values, with two
+# cluster-specific additions required on this EKS/Traefik cluster:
+#   - className: traefik  -> without it, cloudProvider "aws" defaults the
+#     ingressClassName to "alb", which this cluster does not run.
+#   - tls.clusterIssuer: letsencrypt -> cert-manager issues the two TLS secrets
+#     via the existing Route53 DNS-01 issuer (hosts are covered by the wildcard
+#     DNS record, so no new Route53 entries are needed).
+# The OpenHands app reads LMNR_PROJECT_API_KEY/LMNR_BASE_URL from the
+# lmnr-project-api-key / lmnr-base-url secrets (secretKeyRef optional: true), so
+# traces only start flowing once those are populated from a Laminar project.
+laminar:
+  enabled: true
+  global:
+    cloudProvider: "aws"
+
+  # ClickHouse: use local (gp3 PVC) storage. The subchart defaults
+  # clickhouse.s3.enabled=true but ships an EMPTY s3.endpoint, so the default
+  # storage_policy "s3_main" points at a bucketless S3 disk and ClickHouse
+  # aborts at startup (exit 36, BAD_ARGUMENTS). We have no S3 bucket wired for
+  # ClickHouse here, and clickhouse.persistence already provisions a 50Gi PV,
+  # so disable S3 and let ClickHouse use the local volume.
+  clickhouse:
+    s3:
+      enabled: false
+
+  frontend:
+    ingress:
+      enabled: true
+      hostname: "analytics.${BASE_DOMAIN}"
+      className: "traefik"
+      tls:
+        enabled: true
+        secretName: "laminar-frontend-tls"
+        clusterIssuer: "${CLUSTER_ISSUER}"
+    # Auth via the existing Keycloak realm (mirrors saas-deploy production).
+    # Reuses the "allhands" confidential client from the keycloak-realm secret;
+    # its redirect URIs must include https://analytics.${BASE_DOMAIN}/api/auth/callback/keycloak
+    env:
+      nextauthUrl: "https://analytics.${BASE_DOMAIN}"
+      nextPublicUrl: "https://analytics.${BASE_DOMAIN}"
+    extraEnv:
+      - name: AUTH_KEYCLOAK_ID
+        valueFrom:
+          secretKeyRef:
+            name: keycloak-realm
+            key: client-id
+      - name: AUTH_KEYCLOAK_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: keycloak-realm
+            key: client-secret
+      - name: AUTH_KEYCLOAK_ISSUER
+        value: "https://auth.${BASE_DOMAIN}/realms/allhands"
+
+  appServer:
+    # Use an app-server ingress (L7) instead of an NLB on this cluster.
+    ingress:
+      enabled: true
+      hostname: "laminar-api.${BASE_DOMAIN}"
+      className: "traefik"
+      tls:
+        enabled: true
+        secretName: "laminar-app-server-tls"
+        clusterIssuer: "${CLUSTER_ISSUER}"
+
+    # On AWS you could instead front the app-server with an NLB for direct TCP
+    # OTLP ingestion; we use the L7 ingress above, so keep this disabled.
+    loadBalancer:
+      enabled: false


### PR DESCRIPTION
## Summary

Adds the EKS cluster-install skill and its tooling, named `eks-install` for consistency with the existing `local-kind-install` skill and `local-kind/` tooling.

New files:
- `eks-install/` — `create-cluster.sh`, `delete-cluster.sh`, `install.sh`, `values.yaml.tmpl`, `gp3-storageclass.yaml`, `letsencrypt-issuer.yaml`, `README.md`
- `.agents/skills/eks-install.md`

The EKS setup factors its non-obvious AWS steps (EBS CSI IRSA, gp3 storageclass, NLB, cert-manager Route53 DNS-01, Let's Encrypt issuer) into dedicated scripts, mirroring the tracked `local-kind/` layout.

### Generic / public-repo safe
- No account IDs, project IDs, zone IDs, or customer-specific config.
- Account resolved at runtime (`aws sts get-caller-identity`); ARNs via env vars.
- Placeholders only (`you@example.com`, `openhands.example.dev`).

Draft: opened for review.

---
_This PR was created by an AI agent (OpenHands) on behalf of @aivong._
