### PR TITLE
docs(skills): PLTF-3531 use --context=0 for helm diff in upgrade-rollback runbook

### DIFF
--- a/.agents/skills/upgrade-rollback-runbook.md
+++ b/.agents/skills/upgrade-rollback-runbook.md
@@ -79,8 +79,14 @@ helm diff upgrade <release-name> \
   oci://ghcr.io/openhands/helm-charts/openhands \
   --namespace <namespace> \
   --values values.yaml \
-  --version <Y>
+  --version <Y> \
+  --context=0
 ```
+
+`--context=0` trims the surrounding unchanged lines so the diff shows only the
+changed lines. Customers routinely find the default output too noisy; use this flag
+to keep the review focused on what actually changed. Drop it (or raise the value) if
+you need surrounding context to interpret a specific hunk.
 
 Split the output into **substantive** (image bumps, added/removed workloads,
 ConfigMap/logic changes) and **cosmetic/artifact**. Known noise to expect and label
@@ -197,7 +203,7 @@ Prereq: the `helm-diff` plugin
 <pg_dump --clean --if-exists command>
 
 ## 2. Review the diff — gate before upgrading
-<helm diff command>
+<helm diff command with --context=0 so only changed lines show>
 Proceed only if the output contains only the changes below; otherwise stop and
 investigate, then send the investigation notes to the OpenHands team.
 Expected — substantive: <discovered image bumps / workload changes>


### PR DESCRIPTION
## Summary

Follow-up to #1204. A customer found the `helm diff` output in the upgrade-rollback runbook very noisy. Passing `--context=0` limits the diff to only the changed lines, which is how the runbook commands are meant to be run.

- Adds `--context=0` to the `helm diff upgrade` command in step 3.
- Adds a short note explaining what the flag does and when you might drop it.
- Updates the output-template placeholder to mention the flag so generated customer notes stay consistent.

Docs-only change to `.agents/skills/upgrade-rollback-runbook.md`; no functional/code changes.

---
_This PR was created by an AI agent (OpenHands) on behalf of @aivong._