### PR TITLE
chore: PLTF-3531 Bump agent server to 1.46.0

### DIFF
--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -1,7 +1,7 @@
 # Agent-server image the loader pre-pulls onto nodes; keep tag in sync with the sandbox runtime.
 image:
   repository: ghcr.io/openhands/agent-server
-  tag: 1.45.0-python
+  tag: 1.46.0-python
   pullPolicy: Always
 
 resources:

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -358,7 +358,7 @@ global:
   # global wins; this default only applies when rendering the subchart alone.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.45.0-python
+    tag: 1.46.0-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1333,7 +1333,7 @@ global:
   # either of those for per-use exceptions; set it here to move them together.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.45.0-python
+    tag: 1.46.0-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1329,9 +1329,9 @@ spec:
           required: true
         - name: custom_sandbox_image_tag
           title: Sandbox Image Tag
-          help_text: Image tag, e.g. 1.45.0-python
+          help_text: Image tag, e.g. 1.46.0-python
           type: text
-          default: "1.45.0-python"
+          default: "1.46.0-python"
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: true
         - name: custom_sandbox_image_registry_server


### PR DESCRIPTION
## Description

Bumps the agent-server / sandbox runtime image tag from `1.45.0-python` to `1.46.0-python`, mirroring #1211.

Files updated:
- `charts/image-loader/values.yaml`
- `charts/openhands/charts/runtime-api/values.yaml`
- `charts/openhands/values.yaml`
- `replicated/config.yaml` (default + help text)

Verified `ghcr.io/openhands/agent-server:1.46.0-python` exists in the registry.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [ ] I have verified backwards compatibility with existing values.yaml configurations
- [ ] I have updated the chart's README.md if there are any breaking changes or new required values

## Additional Notes

Tag-only change; no chart logic or values structure modified.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@aivong-openhands can click here to [continue refining the PR](https://app.beta.staging.all-hands-testing.dev/conversations/0a77db67-f88f-45f1-a51a-52d19de0b102)