### PR TITLE
docs: PLTF-3531 Fix upgrade rollback runbook skill YAML

### DIFF
--- a/.agents/skills/upgrade-rollback-runbook.md
+++ b/.agents/skills/upgrade-rollback-runbook.md
@@ -1,6 +1,17 @@
 ---
 name: upgrade-rollback-runbook
-description: Produce customer-facing upgrade AND rollback notes (with a helm diff review gate) for an OpenHands Enterprise Helm chart bump from an older version X to a newer version Y. Use when the user asks to "write upgrade instructions", "create an upgrade/rollback runbook", "prepare upgrade notes for the customer", "helm diff for an upgrade", "upgrade OpenHands from X to Y", or "how do we roll back a chart upgrade". Pairs with the cluster-provisioning skills (eks-install, gke-install, local-kind-install): those stand up a running OpenHands Enterprise install, and this skill drives the upgrade/rollback on top of whichever one was used. Cloud-agnostic - it operates only through kubectl/helm and favors no provider. Discovers the version-specific facts (image bumps, alembic schema delta, orphan tables) rather than assuming them.
+description: >-
+  Produce customer-facing upgrade AND rollback notes (with a helm diff review gate)
+  for an OpenHands Enterprise Helm chart bump from an older version X to a newer
+  version Y. Use when the user asks to "write upgrade instructions", "create an
+  upgrade/rollback runbook", "prepare upgrade notes for the customer", "helm diff
+  for an upgrade", "upgrade OpenHands from X to Y", or "how do we roll back a chart
+  upgrade". Pairs with the cluster-provisioning skills (eks-install, gke-install,
+  local-kind-install): those stand up a running OpenHands Enterprise install, and
+  this skill drives the upgrade/rollback on top of whichever one was used.
+  Cloud-agnostic - it operates only through kubectl/helm and favors no provider.
+  Discovers the version-specific facts (image bumps, alembic schema delta, orphan
+  tables) rather than assuming them.
 ---
 
 # OpenHands Enterprise upgrade + rollback runbook


### PR DESCRIPTION
## Summary
- Convert the upgrade rollback runbook skill description to a folded YAML scalar
- Preserve the parsed description text while avoiding the unquoted `: ` parse error

## Validation
- `python3 -c "from pathlib import Path; import yaml; p=Path('.agents/skills/upgrade-rollback-runbook.md'); fm=p.read_text().split('---',2)[1]; parsed=yaml.safe_load(fm); print(parsed['name']); print(parsed['description'])"`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@aivong-openhands can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bf74544a-7943-4953-9fab-ab93dec6074b)