### PR TITLE
fix: validate embedded storage capacity for bundled MinIO

### DIFF
--- a/charts/openhands/templates/troubleshoot/_shared.tpl
+++ b/charts/openhands/templates/troubleshoot/_shared.tpl
@@ -43,6 +43,19 @@
           message: "At least 4 CPU cores per node is recommended for OpenHands"
       - pass:
           message: "Node resources are sufficient"
+{{- if and .Values.minio.enabled .Values.minio.persistence.enabled (eq (.Values.minio.persistence.storageClass | default "") "openebs-hostpath") }}
+- nodeResources:
+    checkName: "Embedded storage capacity"
+    outcomes:
+      - fail:
+          when: "count() < 1"
+          message: "At least one node is required for bundled object storage"
+      - fail:
+          when: "max(ephemeralStorageCapacity) < 200Gi"
+          message: "At least one node with 200Gi of storage is required when bundled object storage uses OpenEBS hostpath"
+      - pass:
+          message: "Embedded storage capacity meets the 200Gi minimum"
+{{- end }}
 - storageClass:
     checkName: "Default Storage Class"
     storageClassName: ""

--- a/charts/openhands/tests/minio_storage_preflight_test.yaml
+++ b/charts/openhands/tests/minio_storage_preflight_test.yaml
@@ -1,0 +1,55 @@
+suite: bundled MinIO storage preflight
+templates:
+  - troubleshoot/secrets.yaml
+  - troubleshoot/preflights.yaml
+  - troubleshoot/support-bundle.yaml
+  - troubleshoot/_shared.tpl
+  - troubleshoot/_sysbox.tpl
+  - troubleshoot/_tls-hostname.tpl
+  - troubleshoot/_sandbox-nodes.tpl
+tests:
+  - it: checks node storage for OpenEBS-backed bundled MinIO
+    set:
+      minio.enabled: true
+      minio.persistence.enabled: true
+      minio.persistence.storageClass: openebs-hostpath
+    asserts:
+      - template: troubleshoot/secrets.yaml
+        documentIndex: 0
+        matchRegex:
+          path: stringData["preflight.yaml"]
+          pattern: 'checkName: "?Embedded storage capacity"?[\s\S]*max\(ephemeralStorageCapacity\) < 200Gi'
+      - template: troubleshoot/secrets.yaml
+        documentIndex: 1
+        matchRegex:
+          path: stringData["support-bundle-spec"]
+          pattern: 'checkName: "?Embedded storage capacity"?[\s\S]*max\(ephemeralStorageCapacity\) < 200Gi'
+
+  - it: omits the check for non-hostpath storage
+    set:
+      minio.enabled: true
+      minio.persistence.enabled: true
+      minio.persistence.storageClass: standard
+    asserts:
+      - template: troubleshoot/secrets.yaml
+        documentIndex: 0
+        notMatchRegex:
+          path: stringData["preflight.yaml"]
+          pattern: "Embedded storage capacity"
+      - template: troubleshoot/secrets.yaml
+        documentIndex: 1
+        notMatchRegex:
+          path: stringData["support-bundle-spec"]
+          pattern: "Embedded storage capacity"
+
+  - it: omits the check when bundled MinIO persistence is disabled
+    set:
+      minio.enabled: true
+      minio.persistence.enabled: false
+      minio.persistence.storageClass: openebs-hostpath
+    asserts:
+      - template: troubleshoot/secrets.yaml
+        documentIndex: 0
+        notMatchRegex:
+          path: stringData["preflight.yaml"]
+          pattern: "Embedded storage capacity"

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -488,6 +488,7 @@ spec:
       enabled: true
       persistence:
         enabled: true
+        storageClass: openebs-hostpath
       resources:
         requests:
           cpu: "1"

--- a/scripts/test_replicated_minio_storage.py
+++ b/scripts/test_replicated_minio_storage.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_replicated_minio_uses_openebs_hostpath_storage() -> None:
+    chart = yaml.safe_load(
+        (REPO_ROOT / "replicated" / "openhands.yaml").read_text(encoding="utf-8")
+    )
+    persistence = chart["spec"]["values"]["minio"]["persistence"]
+
+    assert persistence["enabled"] is True
+    assert persistence["storageClass"] == "openebs-hostpath"


### PR DESCRIPTION
## Description

- Make the Replicated MinIO storage class explicitly `openebs-hostpath`, matching the Embedded Cluster default already used by deployed installations.
- Add a preflight failure when no node reports the documented 200 GiB minimum while bundled MinIO uses OpenEBS hostpath.
- Include the same analyzer in support bundles so undersized hosts are immediately visible during diagnosis.
- Omit the check for non-hostpath storage and when MinIO persistence is disabled.

## Validation

- `helm unittest charts/openhands` — 136 tests passed
- `python -m pytest scripts -q` — 493 tests passed
- `make lint` — passed with existing informational/warning output
- Added focused Helm tests for preflight and support-bundle inclusion/exclusion
- Added a manifest contract test for the Replicated MinIO storage class

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values (not applicable)

## Additional Notes

This PR does not resize the existing 500 GiB MinIO PVC. Reducing that request requires separate upgrade-safe handling because Kubernetes does not permit shrinking an existing PVC.