### PR TITLE
fix: stop cert-manager from claiming uploaded LiteLLM TLS secrets

### DIFF
--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -693,7 +693,8 @@ litellm-helm:
   ingress:
     enabled: false
     className: traefik
-    annotations: {}
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-production
     hosts:
     # REQUIRED: Update to a hostname in a DNS domain you own
     # - host: llm-proxy.example.com

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -693,8 +693,7 @@ litellm-helm:
   ingress:
     enabled: false
     className: traefik
-    annotations:
-      cert-manager.io/cluster-issuer: letsencrypt-production
+    annotations: {}
     hosts:
     # REQUIRED: Update to a hostname in a DNS domain you own
     # - host: llm-proxy.example.com

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -253,6 +253,8 @@ spec:
       ingress:
         enabled: true
         className: traefik
+        # Replicated uses the customer-uploaded openhands-tls Secret.
+        annotations: null
         hosts:
           - host: '{{repl ConfigOption "computed_llm_proxy_hostname" }}'
             paths:

--- a/scripts/test_litellm_ingress.py
+++ b/scripts/test_litellm_ingress.py
@@ -1,0 +1,59 @@
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OPENHANDS_CHART = REPO_ROOT / "charts" / "openhands"
+
+
+def render_litellm_ingress(*set_args: str) -> dict:
+    command = [
+        "helm",
+        "template",
+        "openhands",
+        str(OPENHANDS_CHART),
+        "--show-only",
+        "charts/litellm-helm/templates/ingress.yaml",
+        "--set",
+        "litellm-helm.enabled=true",
+        "--set",
+        "litellm-helm.ingress.enabled=true",
+        "--set",
+        "litellm-helm.ingress.hosts[0].host=llm.example.com",
+        "--set",
+        "litellm-helm.ingress.hosts[0].paths[0].path=/",
+        "--set",
+        "litellm-helm.ingress.hosts[0].paths[0].pathType=Prefix",
+    ]
+    for arg in set_args:
+        command.extend(["--set", arg])
+
+    result = subprocess.run(
+        command,
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return yaml.safe_load(result.stdout)
+
+
+def test_litellm_ingress_does_not_request_an_issuer_by_default() -> None:
+    ingress = render_litellm_ingress()
+
+    assert "cert-manager.io/cluster-issuer" not in ingress["metadata"].get(
+        "annotations", {}
+    )
+
+
+def test_litellm_ingress_preserves_an_explicit_issuer() -> None:
+    ingress = render_litellm_ingress(
+        r"litellm-helm.ingress.annotations.cert-manager\.io/cluster-issuer=customer-issuer"
+    )
+
+    assert (
+        ingress["metadata"]["annotations"]["cert-manager.io/cluster-issuer"]
+        == "customer-issuer"
+    )

--- a/scripts/test_litellm_ingress.py
+++ b/scripts/test_litellm_ingress.py
@@ -6,9 +6,10 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 OPENHANDS_CHART = REPO_ROOT / "charts" / "openhands"
+REPLICATED_MANIFEST = REPO_ROOT / "replicated" / "openhands.yaml"
 
 
-def render_litellm_ingress(*set_args: str) -> dict:
+def render_litellm_ingress(*set_args: str, values: dict | None = None) -> dict:
     command = [
         "helm",
         "template",
@@ -29,6 +30,8 @@ def render_litellm_ingress(*set_args: str) -> dict:
     ]
     for arg in set_args:
         command.extend(["--set", arg])
+    if values is not None:
+        command.extend(["--values", "-"])
 
     result = subprocess.run(
         command,
@@ -36,16 +39,33 @@ def render_litellm_ingress(*set_args: str) -> dict:
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        input=yaml.safe_dump(values) if values is not None else None,
     )
     return yaml.safe_load(result.stdout)
 
 
-def test_litellm_ingress_does_not_request_an_issuer_by_default() -> None:
+def test_litellm_ingress_keeps_chart_default_issuer() -> None:
     ingress = render_litellm_ingress()
 
-    assert "cert-manager.io/cluster-issuer" not in ingress["metadata"].get(
-        "annotations", {}
+    assert (
+        ingress["metadata"]["annotations"]["cert-manager.io/cluster-issuer"]
+        == "letsencrypt-production"
     )
+
+
+def test_replicated_removes_litellm_issuer_annotation() -> None:
+    replicated = yaml.safe_load(REPLICATED_MANIFEST.read_text())
+    annotations = replicated["spec"]["values"]["litellm-helm"]["ingress"][
+        "annotations"
+    ]
+
+    assert annotations is None
+
+    ingress = render_litellm_ingress(
+        values={"litellm-helm": {"ingress": {"annotations": annotations}}}
+    )
+
+    assert "annotations" not in ingress["metadata"]
 
 
 def test_litellm_ingress_preserves_an_explicit_issuer() -> None:


### PR DESCRIPTION
## Description

- Preserve the LiteLLM chart's existing `letsencrypt-production` issuer annotation for Helm consumers that rely on it.
- Override the entire LiteLLM ingress annotations map only in Replicated, where the ingress uses the customer-uploaded `openhands-tls` Secret.
- Prevent Replicated installs from creating an unwanted cert-manager Certificate for that Secret while retaining explicit issuer configuration for ordinary Helm installs.

## Validation

- `helm unittest charts/openhands` — 133 tests passed
- Full scripts test suite — 495 tests passed
- Added render coverage proving:
  - the chart's existing issuer default remains unchanged
  - the Replicated override removes the annotations map cleanly
  - an explicit Helm issuer is preserved

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values (not applicable)

## Additional Notes

The behavior change is scoped to Replicated installs. The general Helm chart default remains unchanged.
