### PR TITLE
fix: make bundled MinIO storage capacity preflight a warning

### DIFF
--- a/charts/openhands/templates/troubleshoot/_shared.tpl
+++ b/charts/openhands/templates/troubleshoot/_shared.tpl
@@ -47,12 +47,12 @@
 - nodeResources:
     checkName: "Embedded storage capacity"
     outcomes:
-      - fail:
+      - warn:
           when: "count() < 1"
           message: "At least one node is required for bundled object storage"
-      - fail:
+      - warn:
           when: "max(ephemeralStorageCapacity) < 200Gi"
-          message: "At least one node with 200Gi of storage is required when bundled object storage uses OpenEBS hostpath"
+          message: "At least one node with 200Gi of storage is recommended when bundled object storage uses OpenEBS hostpath"
       - pass:
           message: "Embedded storage capacity meets the 200Gi minimum"
 {{- end }}

--- a/charts/openhands/tests/minio_storage_preflight_test.yaml
+++ b/charts/openhands/tests/minio_storage_preflight_test.yaml
@@ -18,12 +18,12 @@ tests:
         documentIndex: 0
         matchRegex:
           path: stringData["preflight.yaml"]
-          pattern: 'checkName: "?Embedded storage capacity"?[\s\S]*max\(ephemeralStorageCapacity\) < 200Gi'
+          pattern: 'checkName: "?Embedded storage capacity"?[\s\S]*warn:\s+when: "?max\(ephemeralStorageCapacity\) < 200Gi"?'
       - template: troubleshoot/secrets.yaml
         documentIndex: 1
         matchRegex:
           path: stringData["support-bundle-spec"]
-          pattern: 'checkName: "?Embedded storage capacity"?[\s\S]*max\(ephemeralStorageCapacity\) < 200Gi'
+          pattern: 'checkName: "?Embedded storage capacity"?[\s\S]*warn:\s+when: "?max\(ephemeralStorageCapacity\) < 200Gi"?'
 
   - it: omits the check for non-hostpath storage
     set:


### PR DESCRIPTION
## Description

The 200Gi node storage check added in #1220 is a `fail`, so it blocks installs on hosts under the recommendation. It's a sizing guideline, so it shouldn't stop an install - this turns both outcomes into warnings.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values (not applicable)

## Additional Notes

`helm unittest charts/openhands` passes (136 tests). The existing preflight test now asserts the outcome is a warning.