### PR TITLE
fix(ci): send the run identifiers the E2E binding selects on [ref PLTF-3540]

### DIFF
--- a/.github/workflows/e2e-replicated.yml
+++ b/.github/workflows/e2e-replicated.yml
@@ -1,5 +1,9 @@
 name: E2E Replicated
 
+# Dispatches the E2E suite for one Replicated instance and returns. It does not
+# wait for the suite: this job going green means "the run started", not "the
+# tests passed".
+
 on:
   workflow_call:
     inputs:
@@ -13,13 +17,16 @@ jobs:
   trigger-e2e:
     environment: e2e-replicated
     runs-on: ubuntu-24.04
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
       - name: Trigger Replicated E2E
+        id: trigger
         shell: bash
         env:
           ARGO_TOKEN: ${{ secrets.ARGO_WORKFLOWS_E2E_TOKEN }}
           INSTANCE: ${{ inputs.instance }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           # Argo answers an event that matches no binding with 200 {}, the same
           # as a dispatched one, so a caller typo would otherwise pass silently.
@@ -28,10 +35,19 @@ jobs:
             *) echo "::error::unknown instance \"$INSTANCE\"" ; exit 1 ;;
           esac
 
+          # Argo names the submitted workflow from these same two values, so the
+          # confirmation below can read back one exact object.
+          workflow="openhands-e2e-${INSTANCE}-gh-${RUN_ID}-${RUN_ATTEMPT}"
+          echo "workflow=${workflow}" >> "$GITHUB_OUTPUT"
+
           payload=$(jq -n \
             --arg instance "$INSTANCE" \
+            --argjson run_id "$RUN_ID" \
+            --argjson run_attempt "$RUN_ATTEMPT" \
             '{
-              instance: $instance
+              instance: $instance,
+              run_id: $run_id,
+              run_attempt: $run_attempt
             }')
           # Deliberately not retried: a second attempt whose first already landed
           # starts a duplicate suite.
@@ -41,3 +57,50 @@ jobs:
             --header "Content-Type: application/json" \
             --data "$payload" \
             https://workflows.dev.all-hands.dev/api/v1/events/openhands-e2e/replicated-deploy
+
+      # The POST returns 200 whether or not a binding matched, so reading the
+      # named Workflow back is the only evidence the run exists.
+      #
+      # Never fatal. This job sits inside release-replicated-unstable.yml, whose
+      # run conclusion drives both the deploy badge and the `last-deploy`
+      # required check - failing here would let a dev-core blip block every open
+      # PR under a message telling people to go fix a deploy that is fine.
+      - name: Confirm the run was created
+        shell: bash
+        env:
+          ARGO_TOKEN: ${{ secrets.ARGO_WORKFLOWS_E2E_TOKEN }}
+          WORKFLOW: ${{ steps.trigger.outputs.workflow }}
+          INSTANCE: ${{ inputs.instance }}
+        run: |
+          ui="https://workflows.dev.all-hands.dev/workflows/openhands-e2e/${WORKFLOW}"
+          url="https://workflows.dev.all-hands.dev/api/v1/workflows/openhands-e2e/${WORKFLOW}"
+          # Wall-clock bounded, not attempt-bounded, so a hanging API cannot run
+          # past the job timeout and fail the release run.
+          deadline=$(( $(date +%s) + 120 ))
+          code=000
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            code=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+              --max-time 10 --header "Authorization: Bearer ${ARGO_TOKEN}" "$url") || code=000
+            [ "$code" = 200 ] && break
+            sleep 6
+          done
+
+          {
+            echo "### E2E dispatched"
+            echo ""
+            echo "| Instance | Workflow | Confirmed |"
+            echo "| --- | --- | --- |"
+            if [ "$code" = 200 ]; then
+              echo "| \`${INSTANCE}\` | [\`${WORKFLOW}\`](${ui}) | yes |"
+              echo ""
+              echo "This job does not wait for the suite. Follow the link for the result."
+            else
+              echo "| \`${INSTANCE}\` | \`${WORKFLOW}\` | **no** (HTTP ${code}) |"
+              echo ""
+              echo "The event matched no binding, or the Argo API is unreachable. No suite is running for this deploy."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$code" != 200 ]; then
+            echo "::warning::${WORKFLOW} never appeared in Argo (last HTTP ${code}) - the event matched no binding, or the API is unreachable. Not failing this job: it would redden the deploy badge for an E2E-side problem."
+          fi

--- a/scripts/test_deploy_replicated_e2e_trigger.py
+++ b/scripts/test_deploy_replicated_e2e_trigger.py
@@ -48,11 +48,16 @@ def test_e2e_workflow_uses_its_environment_token_and_argo_owned_target():
     assert trigger["env"] == {
         "ARGO_TOKEN": "${{ secrets.ARGO_WORKFLOWS_E2E_TOKEN }}",
         "INSTANCE": "${{ inputs.instance }}",
+        "RUN_ID": "${{ github.run_id }}",
+        "RUN_ATTEMPT": "${{ github.run_attempt }}",
     }
 
     command = trigger["run"]
     assert "jq -n" in command
     assert "instance: $instance" in command
+    assert "run_id: $run_id" in command
+    assert "run_attempt: $run_attempt" in command
+    # Identifiers only. A caller still cannot name a URL, a target or a suite.
     assert "run_url" not in command
     assert "target-url" not in command
     assert "test_revision" not in command
@@ -74,6 +79,73 @@ def test_e2e_workflow_rejects_an_instance_no_binding_serves():
 def test_e2e_workflow_never_retries_the_dispatch():
     """A retry whose first attempt already landed starts a second suite."""
     assert "--retry" not in trigger_step()["run"]
+
+
+def test_dispatch_payload_satisfies_the_binding_selector():
+    """The Argo binding selects on run_id and run_attempt being positive
+    numbers. Sending them as JSON strings, or not at all, matches no binding -
+    and an unmatched event is answered 200, so the dispatch fails silently."""
+    command = trigger_step()["run"]
+    assert "--argjson run_id" in command
+    assert "--argjson run_attempt" in command
+    assert "--arg run_id" not in command
+    assert "--arg run_attempt" not in command
+
+
+def confirm_step():
+    steps = load_workflow(E2E_WORKFLOW)["jobs"]["trigger-e2e"]["steps"]
+    return next(
+        step for step in steps if step.get("name") == "Confirm the run was created"
+    )
+
+
+def test_the_dispatched_workflow_name_matches_what_argo_derives():
+    """Argo builds the name from the same run_id and run_attempt it is sent."""
+    command = trigger_step()["run"]
+    assert 'workflow="openhands-e2e-${INSTANCE}-gh-${RUN_ID}-${RUN_ATTEMPT}"' in command
+    assert "${WORKFLOW}" in confirm_step()["run"]
+
+
+def test_dispatch_is_confirmed_by_reading_the_run_back():
+    # The POST returns 200 for an unmatched event too, so only reading the
+    # named object back proves the run exists.
+    command = confirm_step()["run"]
+    assert "/api/v1/workflows/openhands-e2e/${WORKFLOW}" in command
+    # One exact object, never a namespace listing - the submit token has no
+    # list permission.
+    assert "/api/v1/workflows/openhands-e2e?" not in command
+
+
+def test_confirmation_cannot_redden_the_deploy_badge():
+    # This job runs inside release-replicated-unstable.yml, whose run
+    # conclusion drives the deploy badge AND the `last-deploy` required check.
+    # Anything fatal here lets an E2E-side blip block every open PR under a
+    # message telling people to fix a deploy that is fine.
+    command = confirm_step()["run"]
+    assert "::warning::" in command
+    assert "::error::" not in command
+    assert "exit 1" not in command
+
+
+def test_confirmation_cannot_outlive_the_job_timeout():
+    # A wall-clock deadline, not an attempt count: attempt-bounded retries
+    # against a hanging API can exceed timeout-minutes and fail the release
+    # run for an E2E-side problem.
+    job = load_workflow(E2E_WORKFLOW)["jobs"]["trigger-e2e"]
+    command = confirm_step()["run"]
+    assert "deadline=$(( $(date +%s) + 120 ))" in command
+    assert job["timeout-minutes"] * 60 > 120 * 2
+
+
+def test_e2e_workflow_does_not_wait_for_the_suite():
+    """Holding a runner for a 45-minute suite to set a conclusion nothing
+    reads. The result is read from Argo, and from ReportPortal for history."""
+    job = load_workflow(E2E_WORKFLOW)["jobs"]["trigger-e2e"]
+    assert job["timeout-minutes"] <= 10
+    assert [step.get("name") for step in job["steps"]] == [
+        "Trigger Replicated E2E",
+        "Confirm the run was created",
+    ]
 
 
 @pytest.mark.parametrize("instance", sorted(RELEASE_WORKFLOWS))


### PR DESCRIPTION
## Description

**Deploy-triggered E2E has was missing some corrected wiring** The Argo `WorkflowEventBinding` selects on run identifiers this workflow never sends:

```
# saas-deploy app/openhands-e2e/.../ci-trigger.yaml — also confirmed live in dev-core
payload.run_id != nil && payload.run_id > 0 &&
payload.run_attempt != nil && payload.run_attempt > 0
```

```
# this repo, before this PR
payload=$(jq -n --arg instance "$INSTANCE" '{ instance: $instance }')
```

No binding matches. Argo answers an unmatched event with `200 {}` — byte-identical to a dispatched one — so `curl --fail-with-body` succeeds and the job reports success. Both lanes are affected: `release-replicated-unstable.yml` and `release-replicated-beta.yml`.

Observed in dev-core on 2026-09-10:

| | |
| --- | --- |
| Release runs that dispatched E2E on 2026-09-09 | 10 (8 unstable, 2 beta), last at 21:04Z |
| `trigger-e2e` job conclusions | all `success` |
| Workflows in the `openhands-e2e` namespace | **0** |

`ttlStrategy.secondsAfterCompletion` is 24h, so a run from any of those dispatches would still be listed. None is.

### `.github/workflows/e2e-replicated.yml`

Sends `run_id` and `run_attempt` as JSON numbers via `--argjson`. As strings they'd fail `> 0` and match nothing — the same silent failure in a new costume, so a test pins the encoding.

Adds a confirmation step: the POST proves nothing, so the workflow reads back the single object Argo derives from those same two values (`openhands-e2e-<instance>-gh-<run id>-<attempt>`) and writes the outcome to the step summary with a deep link. A `get` by exact name, never a namespace listing — the submit token has no `list`.

**The confirmation warns, it never fails.** This job runs inside `release-replicated-unstable.yml`, whose run conclusion drives both the deploy badge and the `last-deploy` required check. Anything fatal here would let a dev-core blip block every open PR under a message telling people to go fix a deploy that's fine. Same reason the retry loop is bounded by wall clock (120s) instead of an attempt count: attempt-bounded retries against a hanging API can outlive `timeout-minutes` and fail the release run. `timeout-minutes` 2 → 5 to cover it.

### `scripts/test_deploy_replicated_e2e_trigger.py`

Six new tests: payload shape, numeric encoding, the derived workflow name agreeing between the two steps, `get`-not-`list`, non-fatal confirmation, and the deadline fitting inside the job timeout. 14 pass.

## Additional Notes

**This does not wait for the suite or report its result** — that's deliberate and separate. Unstable runs are moving to a schedule in Argo (saas-deploy PLTF-3540), and a scheduled run has no GitHub run at all, so a job conclusion is the wrong place to read a result from. This job going green means "the run started", not "the tests passed".

No companion PR needed. The binding contract shipped weeks ago; this is the missing half of it. Verified against the live `openhands-e2e-unstable-deploy` binding in dev-core, which matches saas-deploy `main` with no sync drift.

Helm chart checklist omitted — no charts touched.

Not verified live: the dispatch itself can't be exercised without merging. After merge, the first unstable release should show a confirmed row in the step summary, and:

```sh
kubectl -n openhands-e2e get workflows
```
