### PR TITLE
feat(agent-canvas): route cloud-proxy to Canvas service

### DIFF
--- a/charts/openhands/charts/agent-canvas/README.md
+++ b/charts/openhands/charts/agent-canvas/README.md
@@ -55,6 +55,31 @@ agent-canvas:
       secretName: app-all-hands-dev-tls
 ```
 
+### Exposing the Cloud runtime proxy
+
+Set `cloudProxy.enabled=true` when the same host also needs Canvas browser
+requests to reach the SDK agent-server's `POST /api/cloud-proxy` endpoint.
+The static server starts the bundled SDK agent-server on `cloudProxy.agentServerPort`
+and the umbrella chart adds a same-host ingress path (default `/api/cloud-proxy`)
+to this service. All other `/api` paths remain owned by the OpenHands app.
+
+```yaml
+agent-canvas:
+  enabled: true
+  image:
+    tag: sha-623de56 # image containing the SDK cloud-proxy helper support
+  cloudProxy:
+    enabled: true
+  deployment:
+    resources:
+      requests:
+        memory: 768Mi
+        cpu: 100m
+      limits:
+        memory: 1Gi
+        cpu: 500m
+```
+
 ### Disabling telemetry
 
 `staticServer.disableTelemetry` (default `true`) sets

--- a/charts/openhands/charts/agent-canvas/templates/deployment.yaml
+++ b/charts/openhands/charts/agent-canvas/templates/deployment.yaml
@@ -1,4 +1,15 @@
 {{- $port := int .Values.service.port -}}
+{{- $cloudProxy := .Values.cloudProxy | default dict -}}
+{{- $cloudProxyEnabled := (index $cloudProxy "enabled") | default false -}}
+{{- $cloudProxyPort := (index $cloudProxy "agentServerPort") | default 18000 -}}
+{{- $env := deepCopy (.Values.env | default dict) -}}
+{{- if $cloudProxyEnabled -}}
+{{- $_ := set $env "AGENT_CANVAS_ENABLE_SDK_CLOUD_PROXY" "1" -}}
+{{- $_ := set $env "AGENT_CANVAS_SDK_CLOUD_PROXY_PORT" (toString $cloudProxyPort) -}}
+{{- end -}}
+{{- if .Values.staticServer.disableTelemetry -}}
+{{- $_ := set $env "AGENT_CANVAS_DISABLE_TELEMETRY" "1" -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -64,15 +75,9 @@ spec:
             - name: http
               containerPort: {{ $port }}
               protocol: TCP
-          {{- if or .Values.staticServer.disableTelemetry .Values.env }}
+          {{- with $env }}
           env:
-            {{- if .Values.staticServer.disableTelemetry }}
-            # static-server.mjs reads this and injects
-            # window.__AGENT_CANVAS_DO_NOT_TRACK__ to disable product telemetry.
-            - name: AGENT_CANVAS_DISABLE_TELEMETRY
-              value: "1"
-            {{- end }}
-            {{- range $k, $v := .Values.env }}
+            {{- range $k, $v := . }}
             - name: {{ $k }}
               value: {{ $v | quote }}
             {{- end }}

--- a/charts/openhands/charts/agent-canvas/values.yaml
+++ b/charts/openhands/charts/agent-canvas/values.yaml
@@ -31,6 +31,15 @@ deployment:
 service:
   port: 8000
 
+# Optional cloud runtime proxy. When enabled, the static server starts the
+# bundled SDK agent-server and routes only cloud-proxy envelopes to it; the
+# umbrella chart can then expose /api/cloud-proxy to this service while keeping
+# the rest of /api on the OpenHands app service.
+cloudProxy:
+  enabled: false
+  path: /api/cloud-proxy
+  agentServerPort: 18000
+
 # Ingress for the agent-canvas service. The umbrella `openhands` chart renders
 # this path on the host supplied here when this chart is used as a subchart.
 ingress:

--- a/charts/openhands/templates/ingress-agent-canvas.yaml
+++ b/charts/openhands/templates/ingress-agent-canvas.yaml
@@ -8,6 +8,9 @@
 {{- $agentCanvas := index .Values "agent-canvas" -}}
 {{- if and $agentCanvas.enabled $agentCanvas.ingress.enabled }}
 {{- $ingress := $agentCanvas.ingress -}}
+{{- $cloudProxy := (index $agentCanvas "cloudProxy") | default dict -}}
+{{- $cloudProxyEnabled := (index $cloudProxy "enabled") | default false -}}
+{{- $cloudProxyPath := (index $cloudProxy "path") | default "/api/cloud-proxy" -}}
 {{- $host := required "agent-canvas.ingress.host is required when agent-canvas.ingress.enabled is true" $ingress.host -}}
 {{- $path := default "/canvas" $ingress.path -}}
 apiVersion: networking.k8s.io/v1
@@ -41,4 +44,13 @@ spec:
             name: agent-canvas
             port:
               number: {{ default 8000 (index $agentCanvas "service" "port") }}
+      {{- if $cloudProxyEnabled }}
+      - path: {{ $cloudProxyPath | quote }}
+        pathType: Prefix
+        backend:
+          service:
+            name: agent-canvas
+            port:
+              number: {{ default 8000 (index $agentCanvas "service" "port") }}
+      {{- end }}
 {{- end }}

--- a/charts/openhands/tests/agent_canvas_cloud_proxy_env_test.yaml
+++ b/charts/openhands/tests/agent_canvas_cloud_proxy_env_test.yaml
@@ -1,0 +1,57 @@
+suite: agent canvas cloud proxy env
+# The agent-canvas subchart normally runs as a frontend-only static server. When
+# the umbrella ingress routes /api/cloud-proxy to it, the pod must also enable
+# the static-server's SDK cloud-proxy helper so that path reaches agent-server.
+templates:
+  - charts/agent-canvas/templates/deployment.yaml
+tests:
+  - it: does not enable SDK cloud-proxy helper by default
+    set:
+      agent-canvas.enabled: true
+    asserts:
+      - template: charts/agent-canvas/templates/deployment.yaml
+        notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: AGENT_CANVAS_ENABLE_SDK_CLOUD_PROXY
+
+  - it: enables SDK cloud-proxy helper and port when configured
+    set:
+      agent-canvas.enabled: true
+      agent-canvas.cloudProxy.enabled: true
+      agent-canvas.cloudProxy.agentServerPort: 18080
+    asserts:
+      - template: charts/agent-canvas/templates/deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_CANVAS_ENABLE_SDK_CLOUD_PROXY
+            value: "1"
+      - template: charts/agent-canvas/templates/deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_CANVAS_SDK_CLOUD_PROXY_PORT
+            value: "18080"
+
+  - it: preserves caller env and keeps chart-owned cloud-proxy values authoritative
+    set:
+      agent-canvas.enabled: true
+      agent-canvas.cloudProxy.enabled: true
+      agent-canvas.cloudProxy.agentServerPort: 18080
+      agent-canvas.env.AGENT_CANVAS_SDK_CLOUD_PROXY_PORT: "19090"
+      agent-canvas.env.CUSTOM_ENV: present
+    asserts:
+      - template: charts/agent-canvas/templates/deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CUSTOM_ENV
+            value: present
+      - template: charts/agent-canvas/templates/deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_CANVAS_SDK_CLOUD_PROXY_PORT
+            value: "18080"

--- a/charts/openhands/tests/agent_canvas_ingress_test.yaml
+++ b/charts/openhands/tests/agent_canvas_ingress_test.yaml
@@ -57,6 +57,41 @@ tests:
           path: spec.tls[0].secretName
           value: openhands-tls
 
+  - it: optionally routes /api/cloud-proxy to the agent-canvas service
+    set:
+      agent-canvas.enabled: true
+      agent-canvas.ingress.enabled: true
+      agent-canvas.ingress.host: app.example.com
+      agent-canvas.cloudProxy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.rules[0].http.paths[1].path
+          value: /api/cloud-proxy
+      - equal:
+          path: spec.rules[0].http.paths[1].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[0].http.paths[1].backend.service.name
+          value: agent-canvas
+      - equal:
+          path: spec.rules[0].http.paths[1].backend.service.port.number
+          value: 8000
+
+  - it: uses the configured cloud-proxy path
+    set:
+      agent-canvas.enabled: true
+      agent-canvas.ingress.enabled: true
+      agent-canvas.ingress.host: app.example.com
+      agent-canvas.cloudProxy.enabled: true
+      agent-canvas.cloudProxy.path: /internal/cloud-proxy
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[1].path
+          value: /internal/cloud-proxy
+
+
   - it: omits the TLS block when TLS is disabled
     set:
       agent-canvas.enabled: true

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1564,6 +1564,14 @@ agent-canvas:
     repository: ghcr.io/openhands/agent-canvas
     # tag: supplied at deploy time via the OpenHands deploy workflow.
 
+  # Optional cloud runtime proxy. When enabled, the agent-canvas pod starts the
+  # bundled SDK agent-server and the umbrella ingress exposes only this path to
+  # that service; all other /api routes stay on the OpenHands app service.
+  cloudProxy:
+    enabled: false
+    path: /api/cloud-proxy
+    agentServerPort: 18000
+
   ingress:
     enabled: false
     host: ""


### PR DESCRIPTION
## Summary

Adds first-class chart support for routing Agent Canvas cloud-runtime proxy requests to the Agent Canvas service.

## Why

Agent Canvas feature previews mount the frontend at `/canvas`, while the rest of `/api/*` normally routes to the OpenHands app. The SDK 405 fix lives on the SDK agent-server route `POST /api/cloud-proxy`, not on the enterprise app. Without chart-level routing, a feature preview can still send `/api/cloud-proxy` to the wrong backend and return `405 Method Not Allowed` even when the SDK image contains the fix.

## Changes

- Add `agent-canvas.cloudProxy` values:
  - `enabled`
  - `path` (default `/api/cloud-proxy`)
  - `agentServerPort` (default `18000`)
- When enabled, render `AGENT_CANVAS_ENABLE_SDK_CLOUD_PROXY=1` and `AGENT_CANVAS_SDK_CLOUD_PROXY_PORT=<port>` into the Agent Canvas pod.
- When enabled, add an umbrella ingress path routing `/api/cloud-proxy` to the `agent-canvas` service while leaving all other `/api` paths on the OpenHands app.
- Add Helm unittest coverage for the ingress path and deployment env.
- Document the new chart option and expected resource bump when the Canvas pod starts an SDK agent-server helper.

## Validation

```text
helm dependency build charts/openhands
helm template openhands charts/openhands -n openhands \
  --set agent-canvas.enabled=true \
  --set agent-canvas.ingress.enabled=true \
  --set agent-canvas.ingress.host=app.example.com
# confirmed default render has no /api/cloud-proxy path

helm template openhands charts/openhands -n openhands \
  --set agent-canvas.enabled=true \
  --set agent-canvas.ingress.enabled=true \
  --set agent-canvas.ingress.host=app.example.com \
  --set agent-canvas.cloudProxy.enabled=true \
  --set agent-canvas.cloudProxy.agentServerPort=18080
# confirmed enabled render has /api/cloud-proxy ingress path and AGENT_CANVAS_* env

helm lint charts/openhands
# 1 chart linted, 0 failed
```

Local `helm unittest` was not available in my environment; CI should run the added chart tests.

## Related

- OpenHands/software-agent-sdk#4878
- OpenHands/software-agent-sdk#4914
- OpenHands/OpenHands#17131
- OpenHands/saas-deploy#970

_This PR was created by an AI agent (OpenHands) on behalf of the user._
