### PR TITLE
fix(ci): stop dispatching E2E for beta releases [ref PLTF-3540]

### DIFF
--- a/.github/workflows/e2e-replicated.yml
+++ b/.github/workflows/e2e-replicated.yml
@@ -30,8 +30,9 @@ jobs:
         run: |
           # Argo answers an event that matches no binding with 200 {}, the same
           # as a dispatched one, so a caller typo would otherwise pass silently.
+          # Must match the instances saas-deploy lists in replicatedInstances.
           case "$INSTANCE" in
-            unstable|beta|stable) ;;
+            unstable|stable) ;;
             *) echo "::error::unknown instance \"$INSTANCE\"" ; exit 1 ;;
           esac
 

--- a/.github/workflows/release-replicated-beta.yml
+++ b/.github/workflows/release-replicated-beta.yml
@@ -171,14 +171,3 @@ jobs:
       kots_cursor: ${{ needs.beta.outputs.kots_cursor }}
     secrets:
       kots_password: ${{ secrets.KOTS_PASSWORD_BETA }}
-
-  e2e:
-    name: E2E Replicated
-    needs: deploy
-    uses: ./.github/workflows/e2e-replicated.yml
-    with:
-      instance: beta
-    # A called workflow gets no secrets unless the call site passes them, and
-    # they reach only the workflow called directly. Nesting this under the
-    # deploy workflow left the environment's Argo token empty at dispatch.
-    secrets: inherit

--- a/scripts/test_deploy_replicated_e2e_trigger.py
+++ b/scripts/test_deploy_replicated_e2e_trigger.py
@@ -10,8 +10,10 @@ E2E_WORKFLOW = ROOT / ".github/workflows/e2e-replicated.yml"
 TEST_WORKFLOW = ROOT / ".github/workflows/test-scripts.yml"
 RELEASE_WORKFLOWS = {
     "unstable": ROOT / ".github/workflows/release-replicated-unstable.yml",
-    "beta": ROOT / ".github/workflows/release-replicated-beta.yml",
 }
+# Beta deploys but does not test: its instance has no `e2e` GitHub user, so
+# saas-deploy no longer lists it and no binding would match the dispatch.
+BETA_WORKFLOW = ROOT / ".github/workflows/release-replicated-beta.yml"
 
 
 def load_workflow(path: Path):
@@ -73,7 +75,7 @@ def test_e2e_workflow_uses_its_environment_token_and_argo_owned_target():
 def test_e2e_workflow_rejects_an_instance_no_binding_serves():
     """A caller typo would otherwise dispatch, match nothing, and pass."""
     command = trigger_step()["run"]
-    assert "unstable|beta|stable" in command
+    assert "unstable|stable" in command
 
 
 def test_e2e_workflow_never_retries_the_dispatch():
@@ -164,6 +166,15 @@ def test_each_release_calls_e2e_only_after_a_successful_deploy(instance):
         "with": {"instance": instance},
         "secrets": "inherit",
     }
+
+
+def test_beta_release_does_not_dispatch_e2e():
+    """Beta has no `e2e` GitHub user, so saas-deploy renders no binding for it.
+    Dispatching anyway would land a 200 that matches nothing, and the
+    confirmation step would warn on every beta release."""
+    workflow = load_workflow(BETA_WORKFLOW)
+    assert "e2e" not in workflow["jobs"]
+    assert "e2e-replicated.yml" not in BETA_WORKFLOW.read_text(encoding="utf-8")
 
 
 def test_deploy_replicated_does_not_call_e2e():


### PR DESCRIPTION
The beta instance has no `e2e` GitHub user. The returning-user Playwright project logs in with the shared account from `openhands-e2e-credentials`, so a run against beta cannot get past login.

saas-deploy [#1000](https://github.com/OpenHands/saas-deploy/pull/1000) drops beta from `replicatedInstances`, which removes its `WorkflowEventBinding`. Once that lands, a beta dispatch matches nothing.

**This matters now specifically because #1228 merged.** Before it, an unmatched event was a silent `200 {}`. Now the dispatch is confirmed by reading the named workflow back, so leaving the job in place would warn on every single beta release about a run that never appears — training people to ignore the one signal that says a dispatch was dropped.

Removing the `e2e` job is the honest version: **beta still deploys, it just no longer claims to test.**

Also narrows the instance allowlist in `e2e-replicated.yml` from `unstable|beta|stable` to `unstable|stable`, matching what saas-deploy renders a binding for.

Worth knowing for whoever configures beta later: the three instances are **three separate GitHub Apps** (`ohe-internal-unstable`, `ohe-internal-beta`, `ohe-internal-stable`, each advertised in the target's own `/api/v1/web-client/config`). Authorizing the shared test accounts against one grants nothing on the others, so enabling beta means an app authorization per account, not just creating a user.

Verification: `scripts/test_deploy_replicated_e2e_trigger.py` 14 pass, with a new test asserting beta dispatches nothing. `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
