### PR TITLE
feat(openhands): add budget preflight and reconciliation gate hook jobs

### DIFF
--- a/.agents/skills/upgrade-rollback-runbook.md
+++ b/.agents/skills/upgrade-rollback-runbook.md
@@ -186,6 +186,97 @@ kubectl rollout status deploy/openhands -n <namespace>
 Verify: images back at X, `alembic_version` back at the X value, pods healthy, no
 `migrate-db` crash-loop.
 
+## Budget policy hooks and LiteLLM external state
+
+Charts that carry `budget-preflight-job.yaml` run two Helm hook Jobs on every
+`helm upgrade` of the `openhands` release (never on install, and never under
+ArgoCD, which renders with `helm template`):
+
+| Job | Hook | Default mode | What it does |
+|---|---|---|---|
+| `<release-name>-budget-preflight` | pre-upgrade | `acknowledge` | Read-only. Runs the new image against the not-yet-migrated database and reports each enabled organization's budget state as found. |
+| `<release-name>-budget-reconcile-gate` | post-upgrade | `strict` | Reconciles every enabled organization's LiteLLM caps and verifies them by readback. |
+
+Modes come from `budgetPreflight.mode` / `budgetReconcileGate.mode` (Replicated
+Config group "Upgrade Checks"). `strict` fails `helm upgrade` on a blocking
+finding; `acknowledge` records the same findings and exits 0, which is the
+explicit availability-recovery mode. Expect both Jobs as substantive lines in
+the step-3 diff the first time a customer upgrades onto such a chart.
+
+Blocking finding codes: `litellm_unreachable`, `last_sync_error`,
+`maintenance_failed`, `member_missing_from_litellm`, `member_baseline_missing`,
+`cap_drift`. Informational: `unmapped_member`, `over_cap_team`,
+`over_cap_member`, `snapshot_stale`, `sync_never_ran`, `schema_missing_columns`.
+On a database that predates app migration 149 every governed member reports
+`member_baseline_missing`; that is expected, the first post-upgrade sync
+recovers those members from live spend (OpenHands/enterprise#347), and it is
+why the preflight defaults to `acknowledge`.
+
+### Capture the before/after artifacts (with step 5)
+
+Both Jobs are retained until the next upgrade, so their logs are readable after
+`helm upgrade` returns, and the support bundle collects them:
+
+```bash
+kubectl logs job/<release-name>-budget-preflight -n <namespace> \
+  | jq -c 'select(.artifact_type=="org_budget_preflight")' > pre<Y>_budget_preflight.json
+kubectl logs job/<release-name>-budget-reconcile-gate -n <namespace> \
+  | jq -c 'select(.artifact_type=="org_budget_preflight")' > post<Y>_budget_reconcile.json
+jq '.summary' post<Y>_budget_reconcile.json
+```
+
+The artifacts hold organization and user UUIDs, cap and spend figures, and sync
+status; no keys or e-mail addresses. Keep both next to the DB dump.
+
+### When the strict gate fails
+
+`helm upgrade` reports `post-upgrade hooks failed`. The Deployments are already
+on the new version and keep serving, but the release (and the Replicated
+version) is marked failed. Read `post<Y>_budget_reconcile.json`, fix what the
+findings point at (add the member to the LiteLLM team, repair the key, restore
+LiteLLM availability), then run the upgrade again (Replicated: Redeploy) so the
+hooks re-run. To accept the state instead, set
+`budgetReconcileGate.mode: acknowledge` (Config item "Post-upgrade Budget
+Reconciliation Gate") and run the upgrade again.
+
+To run the preflight by hand, on a deployment where hooks do not run (ArgoCD)
+or outside an upgrade:
+
+```bash
+kubectl exec deploy/openhands -n <namespace> -- \
+  env BUDGET_PREFLIGHT_MODE=acknowledge python -m run_budget_preflight
+```
+
+### Rolling back LiteLLM-side state
+
+`pg_dump` covers the Enterprise settings rows only; the caps LiteLLM enforces
+live in LiteLLM's own database, and `helm rollback` runs no upgrade hooks. After
+the step-6 restore and rollback, bring LiteLLM back in line with the restored
+settings by either:
+
+1. re-running maintenance on the rolled-back version, which recomputes every
+   cap from the restored baselines:
+
+   ```bash
+   kubectl create job --from=cronjob/<release-name>-budget-maintenance \
+     budget-resync-$(date +%s) -n <namespace>
+   ```
+
+2. or re-applying the caps recorded in `pre<Y>_budget_preflight.json`
+   (`orgs[].litellm.team_max_budget` and
+   `orgs[].litellm.members[<user_id>].max_budget`) with the LiteLLM admin key:
+
+   ```bash
+   curl -sS -X POST "$LITE_LLM_API_URL/team/update" \
+     -H "x-goog-api-key: $LITE_LLM_API_KEY" -H 'Content-Type: application/json' \
+     -d '{"team_id":"<org_id>","max_budget":<team_max_budget>}'
+   curl -sS -X POST "$LITE_LLM_API_URL/team/member_update" \
+     -H "x-goog-api-key: $LITE_LLM_API_KEY" -H 'Content-Type: application/json' \
+     -d '{"team_id":"<org_id>","user_id":"<user_id>","max_budget_in_team":<max_budget>}'
+   ```
+
+Then run the preflight by hand (above) and confirm `summary.blocking` is false.
+
 ## Non-obvious findings to bake into the notes
 
 - **Only `deploy/openhands` needs scaling down** before the restore. Verify no other

--- a/charts/openhands/templates/budget-preflight-job.yaml
+++ b/charts/openhands/templates/budget-preflight-job.yaml
@@ -1,0 +1,74 @@
+{{- /*
+Pre-upgrade budget preflight. A Helm pre-upgrade hook, so it runs on the new
+image before any manifest is applied and before the migrate-db init container:
+it reads the not-yet-migrated database and the live LiteLLM team state and
+prints one JSON artifact line (artifact_type: org_budget_preflight) to its log.
+Gated on .Release.IsUpgrade: `helm template` (ArgoCD) never sets it, and a fresh
+install has no organizations to inspect.
+*/ -}}
+{{- if and .Values.enabled .Values.budgetPreflight.enabled .Release.IsUpgrade }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-budget-preflight
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: budget-preflight
+    app: {{ .Release.Name }}-budget-preflight
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "5"
+    # Keep the last run (and the artifact in its pod log) until the next upgrade.
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ .Values.budgetPreflight.activeDeadlineSeconds }}
+  template:
+    metadata:
+      name: budget-preflight
+      labels:
+        {{- include "openhands.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: budget-preflight
+        app: {{ .Release.Name }}-budget-preflight
+    spec:
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (include "openhands.affinity" .) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.caBundle.enabled }}
+      volumes:
+        {{- include "openhands.caBundle.volume" . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: budget-preflight
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: ["/bin/sh", "-c"]
+          workingDir: /app
+          args:
+            - |
+              echo "Running budget upgrade preflight (mode: ${BUDGET_PREFLIGHT_MODE})..."
+              python -m run_budget_preflight
+          {{- if .Values.caBundle.enabled }}
+          volumeMounts:
+            {{- include "openhands.caBundle.volumeMount" . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "openhands.env" . | nindent 12 }}
+            {{- include "openhands.caBundle.env" . | nindent 12 }}
+            - name: BUDGET_PREFLIGHT_PHASE
+              value: pre
+            - name: BUDGET_PREFLIGHT_MODE
+              value: {{ .Values.budgetPreflight.mode | quote }}
+          resources:
+            {{- toYaml .Values.budgetPreflight.resources | nindent 12 }}
+{{- end }}

--- a/charts/openhands/templates/budget-reconcile-gate-job.yaml
+++ b/charts/openhands/templates/budget-reconcile-gate-job.yaml
@@ -1,0 +1,74 @@
+{{- /*
+Post-upgrade budget reconciliation gate. A Helm post-upgrade hook that
+reconciles every enabled organization's LiteLLM budget policy in-process and
+verifies it by readback. In strict mode a blocking finding exits non-zero, which
+fails `helm upgrade` and is what Replicated and native Helm report as release
+health. Weight 5 keeps it ahead of the laminar retention job (weight 10). Gated
+on .Release.IsUpgrade for the same reasons as budget-preflight-job.yaml.
+*/ -}}
+{{- if and .Values.enabled .Values.budgetReconcileGate.enabled .Release.IsUpgrade }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-budget-reconcile-gate
+  labels:
+    {{- include "openhands.labels" . | nindent 4 }}
+    app.kubernetes.io/component: budget-reconcile-gate
+    app: {{ .Release.Name }}-budget-reconcile-gate
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "5"
+    # Keep the last run (and the artifact in its pod log) until the next upgrade.
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ .Values.budgetReconcileGate.activeDeadlineSeconds }}
+  template:
+    metadata:
+      name: budget-reconcile-gate
+      labels:
+        {{- include "openhands.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: budget-reconcile-gate
+        app: {{ .Release.Name }}-budget-reconcile-gate
+    spec:
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (include "openhands.affinity" .) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.caBundle.enabled }}
+      volumes:
+        {{- include "openhands.caBundle.volume" . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: budget-reconcile-gate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: ["/bin/sh", "-c"]
+          workingDir: /app
+          args:
+            - |
+              echo "Reconciling budgets and verifying LiteLLM policy (mode: ${BUDGET_PREFLIGHT_MODE})..."
+              python -m run_budget_preflight
+          {{- if .Values.caBundle.enabled }}
+          volumeMounts:
+            {{- include "openhands.caBundle.volumeMount" . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "openhands.env" . | nindent 12 }}
+            {{- include "openhands.caBundle.env" . | nindent 12 }}
+            - name: BUDGET_PREFLIGHT_PHASE
+              value: post
+            - name: BUDGET_PREFLIGHT_MODE
+              value: {{ .Values.budgetReconcileGate.mode | quote }}
+          resources:
+            {{- toYaml .Values.budgetReconcileGate.resources | nindent 12 }}
+{{- end }}

--- a/charts/openhands/templates/troubleshoot/support-bundle.yaml
+++ b/charts/openhands/templates/troubleshoot/support-bundle.yaml
@@ -59,6 +59,22 @@ spec:
           - app=openhands-mcp
         limits:
           maxAge: 336h
+    # Budget upgrade hook Jobs. The last run of each is kept until the next
+    # upgrade and its log carries the JSON before/after artifact.
+    - logs:
+        name: app/budget-preflight/logs
+        namespace: {{ .Release.Namespace }}
+        selector:
+          - app={{ .Release.Name }}-budget-preflight
+        limits:
+          maxAge: 336h
+    - logs:
+        name: app/budget-reconcile-gate/logs
+        namespace: {{ .Release.Namespace }}
+        selector:
+          - app={{ .Release.Name }}-budget-reconcile-gate
+        limits:
+          maxAge: 336h
     {{- if .Values.postgresql.enabled }}
     # PostgreSQL logs (Bitnami chart)
     - logs:

--- a/charts/openhands/templates/validations.yaml
+++ b/charts/openhands/templates/validations.yaml
@@ -33,3 +33,14 @@ external-S3/GCS releases are unaffected by whatever sits in .Values.minio.
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Budget upgrade hook modes. An unknown mode would silently run the preflight
+script in its usage-error path, so refuse it at render time instead.
+*/}}
+{{- if and .Values.enabled .Values.budgetPreflight.enabled (not (has (toString .Values.budgetPreflight.mode) (list "strict" "acknowledge"))) -}}
+{{- fail (printf "budgetPreflight.mode must be \"strict\" or \"acknowledge\", got %q." (toString .Values.budgetPreflight.mode)) -}}
+{{- end -}}
+{{- if and .Values.enabled .Values.budgetReconcileGate.enabled (not (has (toString .Values.budgetReconcileGate.mode) (list "strict" "acknowledge"))) -}}
+{{- fail (printf "budgetReconcileGate.mode must be \"strict\" or \"acknowledge\", got %q." (toString .Values.budgetReconcileGate.mode)) -}}
+{{- end -}}

--- a/charts/openhands/tests/budget_preflight_job_test.yaml
+++ b/charts/openhands/tests/budget_preflight_job_test.yaml
@@ -1,0 +1,126 @@
+suite: openhands budget preflight hook job
+templates:
+  - budget-preflight-job.yaml
+tests:
+  - it: renders nothing on install
+    set:
+      enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a pre-upgrade hook Job on upgrade with the acknowledge default
+    release:
+      upgrade: true
+    set:
+      enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-budget-preflight
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: budget-preflight
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "5"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation
+      - equal:
+          path: spec.backoffLimit
+          value: 0
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 300
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Never
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: openhands-sa
+      - equal:
+          path: spec.template.metadata.labels.app
+          value: RELEASE-NAME-budget-preflight
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: budget-preflight
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "python -m run_budget_preflight"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BUDGET_PREFLIGHT_PHASE
+            value: pre
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BUDGET_PREFLIGHT_MODE
+            value: acknowledge
+
+  - it: passes strict mode and the deadline through from values
+    release:
+      upgrade: true
+    set:
+      enabled: true
+      budgetPreflight.mode: strict
+      budgetPreflight.activeDeadlineSeconds: 120
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BUDGET_PREFLIGHT_MODE
+            value: strict
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 120
+
+  - it: sizes the job container from budgetPreflight.resources
+    release:
+      upgrade: true
+    set:
+      enabled: true
+      budgetPreflight.resources:
+        requests:
+          memory: "256Mi"
+          cpu: "100m"
+        limits:
+          memory: "256Mi"
+          cpu: "100m"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "100m"
+
+  - it: renders no resources when budgetPreflight is disabled
+    release:
+      upgrade: true
+    set:
+      enabled: true
+      budgetPreflight.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders no resources when the release is disabled
+    release:
+      upgrade: true
+    set:
+      enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/openhands/tests/budget_reconcile_gate_job_test.yaml
+++ b/charts/openhands/tests/budget_reconcile_gate_job_test.yaml
@@ -1,0 +1,96 @@
+suite: openhands budget reconcile gate hook job
+templates:
+  - budget-reconcile-gate-job.yaml
+tests:
+  - it: renders nothing on install
+    set:
+      enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a post-upgrade hook Job on upgrade with the strict default
+    release:
+      upgrade: true
+    set:
+      enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-budget-reconcile-gate
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: budget-reconcile-gate
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "5"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation
+      - equal:
+          path: spec.backoffLimit
+          value: 0
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 540
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Never
+      - equal:
+          path: spec.template.metadata.labels.app
+          value: RELEASE-NAME-budget-reconcile-gate
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: budget-reconcile-gate
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "python -m run_budget_preflight"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BUDGET_PREFLIGHT_PHASE
+            value: post
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BUDGET_PREFLIGHT_MODE
+            value: strict
+
+  - it: passes acknowledge mode through from values
+    release:
+      upgrade: true
+    set:
+      enabled: true
+      budgetReconcileGate.mode: acknowledge
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BUDGET_PREFLIGHT_MODE
+            value: acknowledge
+
+  - it: renders no resources when budgetReconcileGate is disabled
+    release:
+      upgrade: true
+    set:
+      enabled: true
+      budgetReconcileGate.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders no resources when the release is disabled
+    release:
+      upgrade: true
+    set:
+      enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/openhands/tests/validations_test.yaml
+++ b/charts/openhands/tests/validations_test.yaml
@@ -121,4 +121,19 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-
+  - it: fails when budgetPreflight.mode is not strict or acknowledge
+    set:
+      budgetPreflight.mode: sometimes
+    asserts:
+      - failedTemplate:
+          errorMessage: 'budgetPreflight.mode must be "strict" or "acknowledge", got "sometimes".'
+  - it: fails when budgetReconcileGate.mode is not strict or acknowledge
+    set:
+      budgetReconcileGate.mode: never
+    asserts:
+      - failedTemplate:
+          errorMessage: 'budgetReconcileGate.mode must be "strict" or "acknowledge", got "never".'
+  - it: renders no resources with the default budget hook modes
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -929,6 +929,41 @@ budgetMaintenance:
       memory: "1Gi"
       cpu: "500m"
 
+# Budget upgrade checks. Both run as Helm hook Jobs on the enterprise image
+# around every `helm upgrade` (never on install, and never under ArgoCD, which
+# renders with `helm template`). mode is "strict" (a blocking finding fails the
+# upgrade) or "acknowledge" (findings are recorded and the upgrade proceeds).
+# Each Job prints one JSON artifact line to its log and the last run is kept
+# until the next upgrade.
+budgetPreflight:
+  enabled: true
+  # Pre-upgrade, read-only: reports each enabled organization's budget state
+  # (missing baselines/members, cap drift, last sync) before enforcement changes.
+  mode: acknowledge
+  # Counts image pull time; must stay under Helm's per-hook wait (600s on Replicated).
+  activeDeadlineSeconds: 300
+  resources:
+    requests:
+      memory: "100Mi"
+      cpu: "100m"
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+
+budgetReconcileGate:
+  enabled: true
+  # Post-upgrade: reconciles every enabled organization's LiteLLM caps and
+  # verifies them by readback; strict marks the release failed until it succeeds.
+  mode: strict
+  activeDeadlineSeconds: 540
+  resources:
+    requests:
+      memory: "100Mi"
+      cpu: "100m"
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+
 runtime-api:
   enabled: true
   replicaCount: 1

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1435,6 +1435,31 @@ spec:
             - name: "DEBUG"
               title: "Debug"
 
+    - name: upgrade_checks
+      title: Upgrade Checks
+      description: Budget policy checks that run as Helm hooks around each upgrade. Strict fails the upgrade when problems are found; Acknowledge records them and lets the upgrade proceed.
+      items:
+        - name: budget_preflight_mode
+          title: Pre-upgrade Budget Preflight
+          help_text: Read-only check of each organization's budget state before the upgrade applies. Strict blocks the upgrade on missing baselines, members missing from LiteLLM, cap drift, or a failed last sync; Acknowledge only records the findings.
+          type: select_one
+          default: "acknowledge"
+          items:
+            - name: "acknowledge"
+              title: "Acknowledge (default)"
+            - name: "strict"
+              title: "Strict"
+        - name: budget_reconcile_gate_mode
+          title: Post-upgrade Budget Reconciliation Gate
+          help_text: Reconciles every organization's LiteLLM budget policy after the upgrade and verifies it by readback. Strict marks the upgrade failed until reconciliation succeeds; Acknowledge lets the release proceed and records the findings.
+          type: select_one
+          default: "strict"
+          items:
+            - name: "strict"
+              title: "Strict (default)"
+            - name: "acknowledge"
+              title: "Acknowledge"
+
     - name: experimental
       title: Experimental
       description: Preview features that are still in development. Enable at your own risk.

--- a/replicated/openhands.yaml
+++ b/replicated/openhands.yaml
@@ -41,6 +41,11 @@ spec:
 
     duplicateEmailCheck: repl{{ ConfigOptionEquals "duplicate_email_check" "1" }}
 
+    budgetPreflight:
+      mode: 'repl{{ ConfigOption "budget_preflight_mode" }}'
+    budgetReconcileGate:
+      mode: 'repl{{ ConfigOption "budget_reconcile_gate_mode" }}'
+
     env:
       # Default model for new users/orgs: the first non-empty line of the
       # "Anthropic Models" KOTS textarea (anthropic is the base provider; the


### PR DESCRIPTION
## Description

Adds a budget upgrade preflight and a post-upgrade reconciliation gate to the `openhands` chart, as two Helm hook Jobs on the enterprise image (OHE-3256):

- `<release>-budget-preflight` (`pre-upgrade`, weight 5, default mode `acknowledge`): read-only, runs the new image against the not-yet-migrated database and reports each enabled organization's budget state (missing baselines, members missing from LiteLLM, unmapped identities, cap drift, over-cap state, snapshot age, last sync) before enforcement changes.
- `<release>-budget-reconcile-gate` (`post-upgrade`, weight 5, default mode `strict`): reconciles every enabled organization's LiteLLM caps in-process and verifies them by readback. In `strict` a blocking finding exits non-zero, fails `helm upgrade`, and marks the Replicated version failed; `acknowledge` records the findings and lets the release proceed.

Both Jobs are gated on `.Release.IsUpgrade`, so they never render on install or under ArgoCD (which renders with `helm template`), use `backoffLimit: 0` with `activeDeadlineSeconds` under Helm's per-hook wait (300 s / 540 s against the 600 s Replicated timeout), and keep their last run with `hook-delete-policy: before-hook-creation` so the JSON artifact in the pod log survives until the next upgrade. Each Job prints one `org_budget_preflight` artifact line.

Also included: `budgetPreflight` / `budgetReconcileGate` values blocks, a render-time guard for invalid modes, two support-bundle `logs` collectors, a Replicated Config group "Upgrade Checks" (`budget_preflight_mode`, `budget_reconcile_gate_mode`) mapped into the chart values, helm-unittest suites for both Jobs and the guard, and an upgrade-rollback runbook section covering artifact capture, strict-gate recovery, manual runs, and restoring LiteLLM-side caps after a rollback.

**Depends on** OpenHands/enterprise#362, which adds `run_budget_preflight.py` to the image. This PR must not merge before a release containing that script is the chart's default `image.tag`; with an older image the pre-upgrade Job would fail on the missing module and block upgrades. Kept as a draft until then.

Validation:

- `helm template t charts/openhands --is-upgrade --show-only templates/budget-preflight-job.yaml --show-only templates/budget-reconcile-gate-job.yaml` renders both Jobs with the expected hooks and env; without `--is-upgrade` nothing renders.
- `helm unittest charts/openhands`: 150 passed in 31 suites.
- `helm lint charts/openhands`: passed.
- `make lint` (Replicated): exit 0; only pre-existing warnings on `troubleshoot/secrets.yaml`.

## Helm Chart Checklist

- [ ] I have tested the chart upgrade path from the previous version
- [x] I have verified backwards compatibility with existing values.yaml configurations
- [x] I have updated the chart's README.md if there are any breaking changes or new required values

New keys ship with defaults and `values.schema.json` does not restrict additional top-level keys, so existing values files are unaffected. The README lists no job values, so no README change was needed. A live upgrade on a Replicated test instance has not been run yet.

## Additional Notes

- The strict default on the post-upgrade gate is deliberate: it is what makes "failed reconciliation blocks release health" true out of the box. Customers with a known-dirty organization can select Acknowledge in the "Upgrade Checks" Config group before upgrading.
- Mutual exclusion between the hook and the 15-minute `budget-maintenance` CronJob is tracked separately (OHE-3259); both are idempotent.
- SaaS (ArgoCD) deployments get neither Job; the runbook documents running the preflight by hand there.
