### PR TITLE
chore: Bump agent server to 1.47.0

### DIFF
--- a/charts/image-loader/values.yaml
+++ b/charts/image-loader/values.yaml
@@ -1,7 +1,7 @@
 # Agent-server image the loader pre-pulls onto nodes; keep tag in sync with the sandbox runtime.
 image:
   repository: ghcr.io/openhands/agent-server
-  tag: 1.46.0-python
+  tag: 1.47.0-python
   pullPolicy: Always
 
 resources:

--- a/charts/openhands/charts/runtime-api/values.yaml
+++ b/charts/openhands/charts/runtime-api/values.yaml
@@ -358,7 +358,7 @@ global:
   # global wins; this default only applies when rendering the subchart alone.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.46.0-python
+    tag: 1.47.0-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -1333,7 +1333,7 @@ global:
   # either of those for per-use exceptions; set it here to move them together.
   agentServerImage:
     repository: ghcr.io/openhands/agent-server
-    tag: 1.46.0-python
+    tag: 1.47.0-python
   security:
     # This allows using the bitnamilegacy image repo.
     # See: https://github.com/bitnami/containers/issues/83267

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -1329,9 +1329,9 @@ spec:
           required: true
         - name: custom_sandbox_image_tag
           title: Sandbox Image Tag
-          help_text: Image tag, e.g. 1.46.0-python
+          help_text: Image tag, e.g. 1.47.0-python
           type: text
-          default: "1.46.0-python"
+          default: "1.47.0-python"
           when: 'repl{{ ConfigOptionEquals "custom_sandbox_image_enabled" "1" }}'
           required: true
         - name: custom_sandbox_image_registry_server


### PR DESCRIPTION
## Bump agent-server (sandbox) image to 1.47.0

Bumps the agent-server image tag from `1.46.0-python` to `1.47.0-python`, matching the `openhands-agent-server==1.47.0` pin in [OpenHands/enterprise 1.60.0](https://github.com/OpenHands/enterprise/releases/tag/1.60.0).

### Why
The enterprise server imports `openhands-agent-server` as a client and talks to the agent-server image over HTTP in every sandbox. Client and server are the same codebase, so the two pins must match — a version split is a protocol split. `check_agent_server_sync` enforces this on the `openhands` chart release PR, so this bump is required for the chart release carrying enterprise-server `1.60.0` to pass that guard.

### Changes
- `charts/openhands/values.yaml` — `global.agentServerImage.tag` `1.46.0-python` -> `1.47.0-python`
- `charts/openhands/charts/runtime-api/values.yaml` — `global.agentServerImage.tag`
- `charts/image-loader/values.yaml` — `image.tag` (pre-pulled loader image)
- `replicated/config.yaml` — sandbox image tag `help_text` example + `default`

Same pattern as #1211. Image `ghcr.io/openhands/agent-server:1.47.0-python` is published (verified).

### Companion to
- #1235 (`feat(openhands): bump image tag to 1.60.0`) — the enterprise-server image bump, already CI-green.

---
_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._
