### PR TITLE
fix(e2e): send run_id/run_attempt as strings to Argo dispatch

### DIFF
--- a/.github/workflows/e2e-replicated.yml
+++ b/.github/workflows/e2e-replicated.yml
@@ -40,10 +40,15 @@ jobs:
           workflow="openhands-e2e-${INSTANCE}-gh-${RUN_ID}-${RUN_ATTEMPT}"
           echo "workflow=${workflow}" >> "$GITHUB_OUTPUT"
 
+          # run_id/run_attempt are sent as strings (--arg, not --argjson) so the
+          # receiver cannot reformat them: a numeric run_id is large enough that
+          # the event binding formats it in scientific notation (e.g.
+          # 34620115214 -> 3.4620115214e+10) when building the Argo workflow name,
+          # producing an invalid k8s object name and a 500 on dispatch.
           payload=$(jq -n \
             --arg instance "$INSTANCE" \
-            --argjson run_id "$RUN_ID" \
-            --argjson run_attempt "$RUN_ATTEMPT" \
+            --arg run_id "$RUN_ID" \
+            --arg run_attempt "$RUN_ATTEMPT" \
             '{
               instance: $instance,
               run_id: $run_id,


### PR DESCRIPTION
## Fix: E2E Replicated trigger dispatches an invalid Argo workflow name

### Symptom
The required `last-deploy` check has been failing on **every** open PR since the `run_id`/`run_attempt` fields were added to the E2E Replicated trigger payload. The unstable Replicated deploy's `E2E Replicated / trigger-e2e` job fails:

```
curl: (22) The requested URL returned error: 500
Workflow.argoproj.io "openhands-e2e-unstable-gh-3.4620115214e+10-1" is invalid:
metadata.name: Invalid value: a lowercase RFC 1123 subdomain must consist of
lower case alphanumeric characters, '-' or '.'
```

### Root cause
`e2e-replicated.yml` sends `run_id` as a JSON **number** (`--argjson`). The Argo event binding builds the workflow name from that field and formats large integers in **scientific notation** (`34620115214` → `3.4620115214e+10`), producing an invalid k8s object name (`+` and `e` are illegal) → the receiver returns 500 → the job fails → the `last-deploy` required check goes red on every PR.

This is unrelated to any PR's changes — `last-deploy` inspects the health of the **main** branch's Replicated deploys, not the PR's diff.

### Fix
Send `run_id` and `run_attempt` as JSON **strings** (`--arg` instead of `--argjson`) so the receiver preserves them verbatim. This also makes the receiver-built name match the bash-side `workflow="openhands-e2e-${INSTANCE}-gh-${RUN_ID}-${RUN_ATTEMPT}"` variable the "Confirm the run was created" step reads back.

Two-token change; the workflow logic is otherwise untouched.

### Validation plan
1. Merge this to `main`.
2. Trigger an unstable deploy via `workflow_dispatch` on `release-replicated-unstable.yml` (it's not path-triggered by `.github/` changes, so a manual run is needed to exercise the fix).
3. Confirm `E2E Replicated / trigger-e2e` goes green (receiver returns 200 and the workflow name is `...-gh-34620115214-1`, not scientific notation).
4. `last-deploy` then re-evaluates main as healthy → goes green on #1235 and all other open PRs.

### Out of scope
This does **not** change the agent-server or enterprise-server image tags. It is a CI-only fix to unblock the required deploy gate that #1235 (enterprise-server → 1.60.0) and every other open PR are blocked on.

---
_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._
