### PR TITLE
fix(e2e): complete new-user login past the 2FA-settings reminder

### DIFF
--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -26,6 +26,10 @@ jobs:
         run: npm ci
       - name: Lint and type-check
         run: npm run lint
+      - name: Install Chromium for unit tests
+        run: npx playwright install --with-deps chromium
+      - name: Unit tests
+        run: npm run test:unit
       - name: Discover Chromium tests
         env:
           BASE_URL: https://release-under-test.invalid

--- a/e2e_tests/unit-tests/oauth-authorization.spec.ts
+++ b/e2e_tests/unit-tests/oauth-authorization.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { handleOAuthAuthorization } from "../utils/auth-helpers";
+
+/**
+ * Unit tests for handleOAuthAuthorization.
+ *
+ * These drive the real helper against a simulated GitHub OAuth flow served
+ * entirely from route interception (no network), so they exercise the actual
+ * retry/navigation logic rather than a mock of it.
+ *
+ * The scenario mirrors the new-user regression: GitHub renders the first-time
+ * consent page, the harness submits the authorize form, and GitHub redirects
+ * back to the app. The helper must keep retrying until the page actually
+ * leaves the authorize URL — a missing form is a retryable state, not proof
+ * of success.
+ */
+
+const AUTHORIZE_URL = "https://github.com/login/oauth/authorize?client_id=test";
+const APP_URL = "https://app.oauth-test.local/";
+
+/** HTML for GitHub's authorize page, with an optional delay before the form. */
+function authorizePage(formDelayMs = 0): string {
+  const injectForm = `
+    var form = document.createElement('form');
+    form.method = 'POST';
+    form.action = '/login/oauth/authorize';
+    var btn = document.createElement('button');
+    btn.name = 'authorize';
+    btn.value = '1';
+    btn.textContent = 'Authorize';
+    form.appendChild(btn);
+    document.body.appendChild(form);
+  `;
+  const script =
+    formDelayMs > 0
+      ? `setTimeout(function () { ${injectForm} }, ${formDelayMs});`
+      : injectForm;
+  return `<!doctype html><html><body><h1>Authorize application</h1><script>${script}</script></body></html>`;
+}
+
+/**
+ * Route github.com and the fake app so the OAuth flow runs offline.
+ *
+ * @param authorizeHtml HTML served for the authorize GET.
+ * @param grant When true, the authorize POST 302-redirects to the app (grant
+ *   succeeds); when false it re-serves the authorize page (grant never
+ *   completes), reproducing the stuck new-user state.
+ */
+async function routeOAuthFlow(
+  page: Page,
+  authorizeHtml: string,
+  grant: boolean,
+): Promise<void> {
+  await page.route("https://github.com/login/oauth/authorize**", (route) => {
+    // The authorize form POSTs back to this URL. On a successful grant GitHub
+    // redirects to the app; simulate that with a client-side redirect (a
+    // route-fulfilled 302 on a POST navigation renders as a Chrome error
+    // page, so a JS redirect models the "left the authorize URL" transition
+    // more faithfully). On a failed grant, re-serve the authorize page so the
+    // helper stays stuck — reproducing the new-user regression.
+    if (route.request().method() === "POST" && grant) {
+      return route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: `<!doctype html><html><body><script>window.location.replace(${JSON.stringify(
+          APP_URL,
+        )});</script></body></html>`,
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: authorizeHtml,
+    });
+  });
+
+  await page.route(`${APP_URL}**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<!doctype html><html><body><h1>App home</h1></body></html>",
+    }),
+  );
+}
+
+test("grants access on the first-time consent page", async ({ page }) => {
+  await routeOAuthFlow(page, authorizePage(), true);
+  await page.goto(AUTHORIZE_URL);
+
+  await handleOAuthAuthorization(page);
+
+  expect(page.url()).toBe(APP_URL);
+});
+
+test("retries when the consent form renders after the URL settles", async ({
+  page,
+}) => {
+  // Form appears 500ms late: the first submit attempt sees no form and must
+  // retry rather than assume the page already redirected.
+  await routeOAuthFlow(page, authorizePage(500), true);
+  await page.goto(AUTHORIZE_URL);
+
+  await handleOAuthAuthorization(page);
+
+  expect(page.url()).toBe(APP_URL);
+});
+
+test("returns without error when the app was already authorized", async ({
+  page,
+}) => {
+  // No authorize page is shown — GitHub redirected straight back to the app.
+  await routeOAuthFlow(page, authorizePage(), true);
+  await page.goto(APP_URL);
+
+  await handleOAuthAuthorization(page);
+
+  expect(page.url()).toBe(APP_URL);
+});
+
+test("throws instead of silently passing when the grant never completes", async ({
+  page,
+}) => {
+  // Authorize page never has a submittable form and never redirects: the
+  // helper must fail loudly rather than return as a false "bypass".
+  const noFormPage =
+    "<!doctype html><html><body><h1>Authorize application</h1></body></html>";
+  await routeOAuthFlow(page, noFormPage, false);
+  await page.goto(AUTHORIZE_URL);
+
+  await expect(
+    handleOAuthAuthorization(page, { timeoutMs: 2_000 }),
+  ).rejects.toThrow(/OAuth authorization did not complete/);
+});

--- a/e2e_tests/unit-tests/two-factor-reminder.spec.ts
+++ b/e2e_tests/unit-tests/two-factor-reminder.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { dismissTwoFactorReminder } from "../utils/auth-helpers";
+
+/**
+ * Unit tests for dismissTwoFactorReminder.
+ *
+ * GitHub interrupts the login flow with a one-time "Verify your two-factor
+ * authentication (2FA) settings" reminder (served at /sessions/two-factor)
+ * that sits between 2FA entry and the OAuth authorize page. These tests drive
+ * the real helper against a route-intercepted fixture of that page.
+ */
+
+const REMINDER_URL = "https://github.com/sessions/two-factor";
+const RESUMED_URL = "https://github.com/login/oauth/authorize?client_id=test";
+
+/** Fixture of GitHub's "verify your 2FA settings" reminder page. */
+const reminderHtml = `<!doctype html><html><body>
+  <h2>Verify your two-factor authentication (2FA) settings</h2>
+  <button type="button">Verify 2FA now</button>
+  <button type="button" onclick="window.location.replace('${RESUMED_URL}')">skip 2FA verification</button>
+</body></html>`;
+
+async function routeReminder(page: Page): Promise<void> {
+  await page.route("https://github.com/sessions/two-factor**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: reminderHtml,
+    }),
+  );
+  await page.route("https://github.com/login/oauth/authorize**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<!doctype html><html><body><h1>Authorize</h1></body></html>",
+    }),
+  );
+}
+
+test("dismisses the reminder and resumes the interrupted flow", async ({
+  page,
+}) => {
+  await routeReminder(page);
+  await page.goto(REMINDER_URL);
+
+  const dismissed = await dismissTwoFactorReminder(page);
+
+  expect(dismissed).toBe(true);
+  expect(page.url()).toBe(RESUMED_URL);
+});
+
+test("is a no-op when the reminder is not shown", async ({ page }) => {
+  await page.route("https://github.com/login/oauth/authorize**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: '<!doctype html><html><body><form action="/login/oauth/authorize"><button name="authorize" value="1">Authorize</button></form></body></html>',
+    }),
+  );
+  await page.goto(RESUMED_URL);
+
+  const dismissed = await dismissTwoFactorReminder(page);
+
+  expect(dismissed).toBe(false);
+  expect(page.url()).toBe(RESUMED_URL);
+});

--- a/e2e_tests/utils/auth-helpers.ts
+++ b/e2e_tests/utils/auth-helpers.ts
@@ -99,6 +99,10 @@ export async function authenticateWithGitHub(
     await handle2FA(page, creds.totpSecret);
   }
 
+  // GitHub may interrupt with a one-time "verify your 2FA settings" reminder
+  // between 2FA and the OAuth grant; dismiss it so the authorize form renders.
+  await dismissTwoFactorReminder(page);
+
   // Handle OAuth authorization if needed
   await handleOAuthAuthorization(page);
 
@@ -472,6 +476,44 @@ async function generateTOTP(secret: string): Promise<string> {
   return token;
 }
 
+/**
+ * Dismiss GitHub's "Verify your two-factor authentication (2FA) settings"
+ * reminder if it is shown.
+ *
+ * GitHub interrupts the login flow (page `/sessions/two-factor`) with a
+ * one-time reminder to verify recently configured 2FA credentials, offering
+ * "Verify 2FA now" or "skip 2FA verification (we'll remind you again
+ * tomorrow)". It sits between 2FA entry and the OAuth authorize page, so
+ * leaving it up means the authorize form never renders and the grant stalls.
+ * We click "skip": it resumes the interrupted navigation and, unlike "Verify
+ * 2FA now", needs no extra TOTP entry, so it is safe to repeat every run.
+ *
+ * Returns true when the reminder was found and dismissed; false (no-op) when
+ * it is not shown.
+ */
+export async function dismissTwoFactorReminder(page: Page): Promise<boolean> {
+  const skip = page.getByRole("button", { name: "skip 2FA verification" });
+  const shown = await skip
+    .waitFor({ state: "visible", timeout: 3_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!shown) {
+    return false;
+  }
+  console.log(
+    'Dismissing GitHub "verify your 2FA settings" reminder (skip)...',
+  );
+  await skip.click();
+  // Skipping resumes the interrupted flow; wait for GitHub to leave the
+  // reminder page before the caller continues.
+  await page
+    .waitForURL((url) => !url.toString().includes("/sessions/two-factor"), {
+      timeout: 15_000,
+    })
+    .catch(() => {});
+  return true;
+}
+
 /** URL prefix of GitHub's OAuth authorize page. */
 const OAUTH_AUTHORIZE_URL_PREFIX = "https://github.com/login/oauth/authorize";
 
@@ -615,12 +657,18 @@ export async function handleOAuthAuthorization(
         console.log("OAuth authorization complete.");
         return;
       }
-      // Still on the authorize page — fall through and retry.
+      // Still on the authorize page — pause briefly, then retry.
+      await page.waitForTimeout(1_000);
+    } else {
+      // No authorize form yet. GitHub may be showing its one-time "verify your
+      // 2FA settings" reminder in place of the grant; dismiss it and retry
+      // straight away. Otherwise give the consent form a moment to render
+      // before the next attempt.
+      const dismissedReminder = await dismissTwoFactorReminder(page);
+      if (!dismissedReminder) {
+        await page.waitForTimeout(1_000);
+      }
     }
-
-    // Form not present yet (or the submit did not take). Give the consent
-    // page a moment to finish rendering, then retry.
-    await page.waitForTimeout(1_000);
   }
 
   throw new Error(

--- a/e2e_tests/utils/auth-helpers.ts
+++ b/e2e_tests/utils/auth-helpers.ts
@@ -472,17 +472,82 @@ async function generateTOTP(secret: string): Promise<string> {
   return token;
 }
 
+/** URL prefix of GitHub's OAuth authorize page. */
+const OAUTH_AUTHORIZE_URL_PREFIX = "https://github.com/login/oauth/authorize";
+
+/** Overall budget for completing the OAuth authorization grant. */
+const OAUTH_AUTHORIZE_TIMEOUT_MS = 30_000;
+
+/**
+ * Submit the GitHub OAuth authorize form from within the page.
+ *
+ * The authorize page's Authorize button is kept disabled by GitHub's
+ * clickjacking protection (it requires document.hasFocus(), which never
+ * resolves in headless Playwright), so we grant access by submitting the
+ * authorize form directly. The form carries all the server-rendered hidden
+ * fields (client_id, redirect_uri, state, scope); we only set authorize=1.
+ *
+ * Returns "submitted" when the form was found and submitted, or "missing"
+ * when no authorize form is present in the DOM yet. A first-time consent
+ * page can render the form a beat after the URL changes, so "missing" is a
+ * retryable state — not proof that GitHub already redirected.
+ */
+async function submitAuthorizeForm(
+  page: Page,
+): Promise<"submitted" | "missing"> {
+  return page.evaluate(() => {
+    // Prefer the exact relative action GitHub renders, then fall back to a
+    // looser match (absolute action, or any form carrying the authorize
+    // control) so a first-time-grant page variant is still handled.
+    const form =
+      document.querySelector<HTMLFormElement>(
+        'form[action="/login/oauth/authorize"]',
+      ) ??
+      document.querySelector<HTMLFormElement>(
+        'form[action*="/login/oauth/authorize"]',
+      ) ??
+      Array.from(document.querySelectorAll<HTMLFormElement>("form")).find((f) =>
+        f.querySelector('button[name="authorize"], input[name="authorize"]'),
+      ) ??
+      null;
+    if (!form) {
+      return "missing";
+    }
+    let input = form.querySelector<HTMLInputElement>('input[name="authorize"]');
+    if (!input) {
+      input = document.createElement("input");
+      input.type = "hidden";
+      input.name = "authorize";
+      form.appendChild(input);
+    }
+    input.value = "1";
+    form.submit();
+    return "submitted";
+  });
+}
+
 /**
  * Handle the OAuth authorization prompt if it appears.
  *
- * After 2FA, GitHub either lands on the OAuth authorize page (if the app
- * hasn't been authorized yet) or redirects straight back to the app (if it
- * has). The authorize page's Authorize button is kept disabled by GitHub's
- * clickjacking protection, which requires document.hasFocus() — this never
- * resolves in Playwright. So instead of waiting for the button, we submit
- * the form directly via JavaScript.
+ * After 2FA, GitHub either lands on the OAuth authorize page (app not yet
+ * authorized for this account — the first-time / new-user path) or redirects
+ * straight back to the app (app already authorized — the returning-user
+ * path).
+ *
+ * For a new user whose account has no standing grant, GitHub renders the
+ * first-time consent page and the authorize form can appear slightly after
+ * the URL settles. The previous implementation submitted the form once and,
+ * if it was not yet present, assumed GitHub had "already redirected" and
+ * returned — leaving the browser stranded on the authorize page, so the
+ * downstream `completeLoginAndOnboard` wait timed out with a misleading
+ * stack. Instead, retry until the grant actually completes (the page leaves
+ * the authorize URL) and fail loudly with context if it never does.
  */
-async function handleOAuthAuthorization(page: Page): Promise<void> {
+export async function handleOAuthAuthorization(
+  page: Page,
+  options: { timeoutMs?: number } = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? OAUTH_AUTHORIZE_TIMEOUT_MS;
   // Wait for navigation to a stable destination: either the OAuth authorize
   // page (app not yet authorized) or a non-GitHub URL (redirected back to
   // the app). Using a positive condition avoids matching intermediate
@@ -492,7 +557,7 @@ async function handleOAuthAuthorization(page: Page): Promise<void> {
       (url) => {
         const urlString = url.toString();
         return (
-          urlString.startsWith("https://github.com/login/oauth/authorize") ||
+          urlString.startsWith(OAUTH_AUTHORIZE_URL_PREFIX) ||
           !urlString.includes("github.com")
         );
       },
@@ -502,61 +567,66 @@ async function handleOAuthAuthorization(page: Page): Promise<void> {
 
   // If we're not on the OAuth authorize page, GitHub skipped it (the app was
   // previously authorized) and redirected straight back to the app.
-  const currentUrl = page.url();
-  if (!currentUrl.startsWith("https://github.com/login/oauth/authorize")) {
+  if (!page.url().startsWith(OAUTH_AUTHORIZE_URL_PREFIX)) {
     console.log("No OAuth authorization page shown (redirected back to app).");
     return;
   }
 
-  console.log("On OAuth authorization page, submitting form directly...");
+  console.log("On OAuth authorization page, granting access...");
 
-  // Submit the authorize form directly. The form contains all the hidden
-  // fields (client_id, redirect_uri, state, scope) server-rendered; we just
-  // need to set authorize=1 and submit. This bypasses the disabled button
-  // and GitHub's clickjacking protection entirely.
-  //
-  // GitHub may auto-redirect away from the authorize page at any moment
-  // (when the app was recently authorized). In that case the form won't
-  // exist or the execution context will be destroyed — both are handled
-  // below as a bypass.
-  try {
-    await page.evaluate(() => {
-      const form = document.querySelector<HTMLFormElement>(
-        'form[action="/login/oauth/authorize"]',
-      );
-      if (!form) {
-        throw new Error("OAuth authorize form not found on page");
-      }
-      let input = form.querySelector<HTMLInputElement>(
-        'input[name="authorize"]',
-      );
-      if (!input) {
-        input = document.createElement("input");
-        input.type = "hidden";
-        input.name = "authorize";
-        form.appendChild(input);
-      }
-      input.value = "1";
-      form.submit();
-    });
-  } catch (e) {
-    const msg = String(e);
-    // "Execution context was destroyed" means form.submit() triggered a
-    // navigation — the form was submitted successfully.
-    // "form not found" means GitHub already redirected away from the
-    // authorize page (bypass) — nothing to do.
-    if (
-      !msg.includes("Execution context was destroyed") &&
-      !msg.includes("form not found")
-    ) {
-      throw e;
-    }
-    if (msg.includes("form not found")) {
-      console.log(
-        "Authorize page bypassed (form not found, already redirected).",
-      );
+  // Retry submitting the authorize form until the grant completes: success is
+  // defined as GitHub leaving the authorize URL, not merely "form submitted"
+  // (a first-time consent page can re-render, and a submit can race the DOM).
+  const deadline = Date.now() + timeoutMs;
+  let attempt = 0;
+  while (Date.now() < deadline) {
+    // Grant is done once GitHub has taken us off the authorize page.
+    if (!page.url().startsWith(OAUTH_AUTHORIZE_URL_PREFIX)) {
+      console.log("OAuth authorization complete (left authorize page).");
       return;
     }
+
+    attempt += 1;
+    let result: "submitted" | "missing" | "navigated";
+    try {
+      result = await submitAuthorizeForm(page);
+    } catch (e) {
+      // "Execution context was destroyed" means form.submit() triggered a
+      // navigation while page.evaluate was running — the grant went through.
+      if (String(e).includes("Execution context was destroyed")) {
+        result = "navigated";
+      } else {
+        throw e;
+      }
+    }
+
+    if (result === "submitted" || result === "navigated") {
+      console.log(`OAuth authorize form submitted (attempt ${attempt}).`);
+      // Wait for GitHub to redirect away from the authorize page.
+      await page
+        .waitForURL(
+          (url) => !url.toString().startsWith(OAUTH_AUTHORIZE_URL_PREFIX),
+          {
+            timeout: 15_000,
+          },
+        )
+        .catch(() => {});
+      if (!page.url().startsWith(OAUTH_AUTHORIZE_URL_PREFIX)) {
+        console.log("OAuth authorization complete.");
+        return;
+      }
+      // Still on the authorize page — fall through and retry.
+    }
+
+    // Form not present yet (or the submit did not take). Give the consent
+    // page a moment to finish rendering, then retry.
+    await page.waitForTimeout(1_000);
   }
-  console.log("OAuth authorize form submitted.");
+
+  throw new Error(
+    `OAuth authorization did not complete: still on ${page.url()} after ` +
+      `${Math.round(timeoutMs / 1000)}s. GitHub did not redirect back to ` +
+      "the app after submitting the authorize form (the new-user first-time " +
+      "consent page may not have been granted).",
+  );
 }


### PR DESCRIPTION
## Why

The new-user e2e login (`setup/setup-new-user.ts` → "authenticate new user") has been failing while the returning-user path passes. Between 2FA and the OAuth grant, GitHub now shows a one-time "Verify your two-factor authentication (2FA) settings" reminder (`/sessions/two-factor`) for an account whose 2FA was recently configured. The harness never dismissed it, so the authorize form never rendered: the old handler read the missing form as "already redirected", returned, and the run sat on github.com until a 60s wait timed out.

The login now clicks "skip 2FA verification" whenever that reminder appears — after 2FA and again inside the authorize loop, since it can also show at the authorize URL. Skipping resumes the interrupted flow and needs no extra TOTP, so it is safe to repeat on every run. The OAuth step now also retries the authorize-form submit until the page actually leaves the authorize URL, and throws with the current URL if it never does, instead of silently bypassing — a missing form is a retryable state, not success. The change touches only the e2e test harness and its CI check.

A `npm run test:unit` step is added to the E2E Static Checks workflow, which previously only linted and listed tests, so the new-user auth helpers now run in CI.

## Validation

- **Live new-user login** — ran `setup:new-user` against the staging app: it dismissed the 2FA reminder, completed the OAuth grant on the first attempt, accepted Terms of Service, and saved storage state (1 passed).
- **Unit tests** — `npm run test:unit` passed (12), covering reminder dismissal and no-op plus the grant's happy-path, late-rendering-form retry, already-authorized, and stuck-grant cases.
- **Lint and types** — `npm run lint` (tsc, eslint, prettier) clean.

---
This PR was drafted by an AI agent on behalf of the user.
