### PR TITLE
fix(replicated-deploy): Make the Replicated deploy job re-runnable and its failures more legible

### DIFF
--- a/scripts/replicated_deploy.sh
+++ b/scripts/replicated_deploy.sh
@@ -3,6 +3,9 @@
 #
 #   KOTS_BASE=https://admin.unstable.staging.all-hands-testing.dev:30000 \
 #   KOTS_PASSWORD=... KOTS_CURSOR=418 scripts/replicated_deploy.sh
+#
+# Re-runnable for one cursor: already deployed verifies and exits 0, already
+# downloaded resumes, otherwise it takes the upgrade-service path.
 set -euo pipefail
 
 APP="${APP:-openhands}"
@@ -13,14 +16,19 @@ DEADLINE=$(( $(date +%s) + TIMEOUT_MINUTES * 60 ))
 waiting() { [ "$(date +%s)" -lt "$DEADLINE" ]; }
 
 UP="$KOTS_BASE/api/v1/upgrade-service/app/$APP"
-JAR="$(mktemp)"; trap 'rm -f "$JAR"' EXIT
+DS="$KOTS_BASE/api/v1/app/$APP"
+JAR="$(mktemp)"; ERR="$(mktemp)"; trap 'rm -f "$JAR" "$ERR"' EXIT
 
 fail() { echo "::error::$*"; exit 1; }
-api()  { curl -sS -k --max-time "${TMO:-30}" -b "$JAR" -c "$JAR" "$@"; }
+# %{stderr} keeps the status code out of the body. $ERR holds the last call's
+# code plus any curl error, which is all why() has to go on when a body is empty.
+api()  { curl -sS -k --max-time "${TMO:-30}" -b "$JAR" -c "$JAR" -w '%{stderr}HTTP %{http_code}' "$@" 2>"$ERR"; }
 post() { api -H 'Content-Type: application/json' -X POST "$@"; }
 ok()   { jq -e '.success == true' >/dev/null 2>&1; }
-# KOTS returns its rejection reason in .error; print that, not just "rejected".
-why()  { local b; b="$(cat)"; jq -re '.error // empty' <<<"$b" 2>/dev/null || printf '%s' "${b:-<empty response>}"; }
+# KOTS puts its rejection reason in .error; fall back to the raw body, then to
+# the transport detail. A bare 4xx has no body, so never print just "rejected".
+why()  { local b; b="$(cat)"; jq -re '.error // empty' <<<"$b" 2>/dev/null \
+           || printf '%s' "${b:-$(tr -s '\n' ' ' <"$ERR")}"; }
 
 # A 401 still sets a cookie, so a non-empty jar proves nothing.
 # Retried: kotsadm is often mid-restart when a release lands back-to-back with
@@ -37,111 +45,159 @@ while :; do
   sleep 10
 done
 
-# --- select --------------------------------------------------------------
-# KOTS_CURSOR is the channel sequence; versionLabel is not unique.
-# Never POST /updatecheck here: on embedded cluster it downloads the pending
-# release, which advances the store's update cursor to the target, after which
-# start-upgrade-service can no longer find it upstream. GET /updates fetches
-# live from replicated.app, so there is no cache a check would populate.
-# `// []` keeps an absent key from failing the pipe under pipefail.
-# Capped at 3m: a cursor absent this long is a real problem, not a settling restart.
-TARGET=""
-SELECT_DEADLINE=$(( $(date +%s) + 180 ))
-while :; do
-  TARGET="$( (api "$KOTS_BASE/api/v1/app/$APP/updates" || true) \
-    | jq -c --arg c "$KOTS_CURSOR" '(.updates // [])[] | select(.updateCursor == $c)' || true)"
-  [ -n "$TARGET" ] && break
-  if [ "$(date +%s)" -ge "$SELECT_DEADLINE" ] || ! waiting; then
-    # A downloaded cursor is a pending version and no longer an upstream update;
-    # no wait recovers it. Deploying it needs the console (skips cluster upgrade).
-    SEQ="$( (api "$KOTS_BASE/api/v1/apps" || true) | jq -r --arg c "$KOTS_CURSOR" \
-      '.apps[0].downstream.pendingVersions[]? | select(.updateCursor == $c) | .sequence' | head -1)"
-    [ -n "$SEQ" ] && fail "cursor $KOTS_CURSOR was already downloaded as pending sequence $SEQ, so it is no longer an upstream update — deploy that version from the admin console"
-    fail "cursor $KOTS_CURSOR never became an available update for $APP"
-  fi
-  echo "  cursor $KOTS_CURSOR not in the update list yet, rechecking"
-  sleep 15
-done
-[ "$(jq -r .isDeployable <<<"$TARGET")" = true ] \
-  || fail "cursor $KOTS_CURSOR not deployable: $(jq -r '.nonDeployableCause // "unknown"' <<<"$TARGET")"
+# --- shared stages -------------------------------------------------------
 
-FROM="$(api "$KOTS_BASE/api/v1/apps" | jq -r '.apps[0].downstream.currentVersion | "\(.versionLabel) @ \(.updateCursor)"')"
-echo "budget: ${TIMEOUT_MINUTES}m"
-echo "deploying: $FROM -> $(jq -r .versionLabel <<<"$TARGET") @ $KOTS_CURSOR"
-
-# --- boot the upgrade service -------------------------------------------
-R="$(post --data "$(jq -c '{versionLabel, updateCursor, channelId}' <<<"$TARGET")" \
-  "$KOTS_BASE/api/v1/app/$APP/start-upgrade-service" || true)"
-if ! ok <<<"$R"; then
-  # The reason is a cursor or license-channel mismatch; show both sides.
-  L="$(TMO=30 api "$KOTS_BASE/api/v1/app/$APP/license" || true)"
-  echo "  license: $(jq -c '.license | {channelName, licenseSequence, lastSyncedAt}' <<<"${L:-\{\}}" 2>/dev/null)"
-  echo "  release: $(jq -c '{versionLabel, updateCursor, channelId}' <<<"$TARGET")"
-  fail "start-upgrade-service rejected: $(why <<<"$R")"
-fi
-
-# Task goes "starting" then EMPTY once up. Empty means ready, not pending.
-META=""
-while waiting; do
-  [ "$(TMO=10 api "$KOTS_BASE/api/v1/app/$APP/task/upgrade-service" | jq -r '.status // ""')" = upgrade-failed ] \
-    && fail "upgrade service failed to start"
-  META="$(TMO=10 api "$UP" || true)"; ok <<<"$META" && break
-  META=""; sleep 5
-done
-[ -n "$META" ] || fail "upgrade service never came up"
-
-# --- config: read values, write them straight back -----------------------
-if [ "$(jq -r .isConfigurable <<<"$META")" = true ]; then
-  TMO=60 api "$UP/config" | jq -c '{configGroups}' >/tmp/cfg.json
-  R="$(TMO=60 api -H 'Content-Type: application/json' -X PUT --data-binary @/tmp/cfg.json "$UP/config" || true)"
-  ok <<<"$R" || fail "config rejected: $(why <<<"$R") — new release likely added a required item with no default"
-fi
-
-# --- preflights ----------------------------------------------------------
-if [ "$(jq -r .hasPreflight <<<"$META")" = true ]; then
-  TMO=60 post "$UP/preflight/run" >/dev/null
-  R=""
+# $1 is whichever API base serves preflight/run and preflight/result.
+preflight_gate() {
+  local base="$1" R="" BAD
+  TMO=60 post "$base/preflight/run" >/dev/null
+  # Waits for the record, not for .result: this fleet leaves that an empty
+  # string even on sequences that deployed cleanly.
   while waiting; do
-    R="$(api "$UP/preflight/result")"
-    # .preflightResult.result is a JSON string, null until the run finishes.
-    jq -e '.preflightResult.result' <<<"$R" >/dev/null 2>&1 && break
-    R=""; sleep 5
+    R="$(api "$base/preflight/result" || true)"
+    jq -e '.preflightResult' <<<"${R:-\{\}}" >/dev/null 2>&1 && break
+    sleep 5
   done
-  [ -n "$R" ] || fail "timed out waiting for preflight results"
-  BAD="$(jq -r .preflightResult.result <<<"$R" | jq -c '[.results[] | select(.isPass != true)]')"
-  [ "$(jq -r .preflightResult.hasFailingStrictPreflights <<<"$R")" = true ] && fail "preflights failed: $BAD"
-  echo "preflights ok (non-passing: $BAD)"
-fi
-
-# --- deploy --------------------------------------------------------------
-R="$(TMO=120 post -d '{"isSkipPreflights":false,"continueWithFailedPreflights":false}' "$UP/deploy" || true)"
-ok <<<"$R" || fail "deploy rejected: $(why <<<"$R")"
+  [ -n "$R" ] || fail "no preflight record from $base"
+  [ "$(jq -r '.preflightResult.hasFailingStrictPreflights // false' <<<"$R")" = true ] \
+    && fail "preflights failed: $(jq -r .preflightResult.result <<<"$R" | jq -c '[.results[]? | select(.isPass != true)]')"
+  BAD="$(jq -r '.preflightResult.result // ""' <<<"$R" | jq -c '[.results[]? | select(.isPass != true)]' 2>/dev/null || true)"
+  echo "preflights: ${BAD:-none recorded}"
+}
 
 # The task stays empty for the whole deploy; downstream currentVersion is the
 # only progress signal. An unreachable console means kotsadm is restarting.
-while waiting; do
-  [ "$(TMO=10 api "$KOTS_BASE/api/v1/app/$APP/task/upgrade-service" 2>/dev/null | jq -r '.status // ""')" = upgrade-failed ] \
-    && fail "upgrade-failed"
-  CUR="$(TMO=10 api "$KOTS_BASE/api/v1/apps" 2>/dev/null | jq -c '.apps[0].downstream.currentVersion | {updateCursor, sequence, status}' || true)"
-  echo "  ${CUR:-<console unreachable, waiting>}"
-  case "$(jq -r '"\(.updateCursor) \(.status)"' <<<"${CUR:-\{\}}" 2>/dev/null)" in
-    "$KOTS_CURSOR deployed") DONE=1; break ;;
-    "$KOTS_CURSOR failed")   fail "instance reported the deploy failed — see the admin console version history" ;;
-  esac
-  sleep 10
-done
-[ "${DONE:-}" ] || fail "timed out waiting for cursor $KOTS_CURSOR to deploy"
+wait_deployed() {
+  local DONE="" CUR
+  while waiting; do
+    [ "$(TMO=10 api "$DS/task/upgrade-service" 2>/dev/null | jq -r '.status // ""')" = upgrade-failed ] \
+      && fail "upgrade-failed"
+    CUR="$(TMO=10 api "$KOTS_BASE/api/v1/apps" 2>/dev/null | jq -c '.apps[0].downstream.currentVersion | {updateCursor, sequence, status}' || true)"
+    echo "  ${CUR:-<console unreachable, waiting>}"
+    case "$(jq -r '"\(.updateCursor) \(.status)"' <<<"${CUR:-\{\}}" 2>/dev/null)" in
+      "$KOTS_CURSOR deployed") DONE=1; break ;;
+      "$KOTS_CURSOR failed")   fail "instance reported the deploy failed — see the admin console version history" ;;
+    esac
+    sleep 10
+  done
+  [ "$DONE" ] || fail "timed out waiting for cursor $KOTS_CURSOR to deploy"
+}
 
-# --- verify every statusInformer ----------------------------------------
 # Response key is "appstatus", all lowercase.
-S=""
-while waiting; do
-  S="$(TMO=15 api "$KOTS_BASE/api/v1/app/$APP/status" 2>/dev/null || true)"
-  [ "$(jq -r '.appstatus.state // ""' <<<"${S:-\{\}}")" = ready ] && break
-  sleep 10
-done
-[ -n "$S" ] || fail "timed out waiting for the app to report ready"
-jq -c '.appstatus | {state, sequence, unhealthy: [.resourceStates[] | select(.state != "ready")]}' <<<"$S"
-[ "$(jq -r .appstatus.state <<<"$S")" = ready ] \
-  || fail "deployed but unhealthy: $(jq -c '[.appstatus.resourceStates[] | select(.state != "ready")]' <<<"$S")"
+verify_ready() {
+  local S=""
+  while waiting; do
+    S="$(TMO=15 api "$DS/status" 2>/dev/null || true)"
+    [ "$(jq -r '.appstatus.state // ""' <<<"${S:-\{\}}")" = ready ] && break
+    sleep 10
+  done
+  [ -n "$S" ] || fail "timed out waiting for the app to report ready"
+  jq -c '.appstatus | {state, sequence, unhealthy: [.resourceStates[] | select(.state != "ready")]}' <<<"$S"
+  [ "$(jq -r .appstatus.state <<<"$S")" = ready ] \
+    || fail "deployed but unhealthy: $(jq -c '[.appstatus.resourceStates[] | select(.state != "ready")]' <<<"$S")"
+}
+
+# --- where is this cursor? ----------------------------------------------
+# A cursor is an upstream update until something downloads it, then a pending
+# version, then the current one. Only an upstream update can boot the upgrade
+# service, so the other two need their own paths or a re-run of a deploy that
+# already got somewhere reads as "cursor never became an available update".
+echo "budget: ${TIMEOUT_MINUTES}m"
+# jq yields null with exit 0 on an error body, so an unguarded read here would
+# fail open and spin out the select loop below instead of naming the reason.
+APPS="$(api "$KOTS_BASE/api/v1/apps" || true)"
+D="$(jq -c '.apps[0].downstream // empty' <<<"${APPS:-}" 2>/dev/null || true)"
+[ -n "$D" ] || fail "could not read app state for $APP: $(why <<<"$APPS")"
+FROM="$(jq -r '.currentVersion | "\(.versionLabel) @ \(.updateCursor)"' <<<"$D")"
+
+if [ "$(jq -r '.currentVersion.updateCursor // ""' <<<"$D")" = "$KOTS_CURSOR" ] \
+   && [ "$(jq -r '.currentVersion.status // ""' <<<"$D")" = deployed ]; then
+  echo "cursor $KOTS_CURSOR is already deployed as sequence $(jq -r .currentVersion.sequence <<<"$D"); verifying only"
+  verify_ready
+  echo "cursor $KOTS_CURSOR already deployed, app ready"
+  exit 0
+fi
+
+PENDING_SEQ="$(jq -r --arg c "$KOTS_CURSOR" \
+  '[.pendingVersions[]? | select(.updateCursor == $c) | .sequence] | first // ""' <<<"$D")"
+
+# A superseded cursor is never re-offered upstream, so waiting out the select
+# loop below cannot recover it. Asking for one is a rollback, not a re-run.
+jq -e --arg c "$KOTS_CURSOR" 'any(.pastVersions[]?; .updateCursor == $c)' <<<"$D" >/dev/null 2>&1 \
+  && fail "cursor $KOTS_CURSOR was deployed before and the instance has moved past it — rolling back needs the admin console"
+
+if [ -n "$PENDING_SEQ" ]; then
+  # --- resume an already-downloaded cursor -------------------------------
+  # It is no longer an upstream update, so the upgrade service cannot claim it;
+  # KOTS deploys a downloaded version from its downstream sequence instead.
+  echo "deploying: $FROM -> sequence $PENDING_SEQ @ $KOTS_CURSOR (already downloaded)"
+  preflight_gate "$DS/sequence/$PENDING_SEQ"
+  R="$(TMO=120 post -d '{}' "$DS/sequence/$PENDING_SEQ/deploy" || true)"
+  ok <<<"$R" || fail "deploy of sequence $PENDING_SEQ rejected: $(why <<<"$R")"
+else
+  # --- select --------------------------------------------------------------
+  # KOTS_CURSOR is the channel sequence; versionLabel is not unique.
+  # Never POST /updatecheck here: on embedded cluster it downloads the pending
+  # release, which advances the store's update cursor to the target, after which
+  # start-upgrade-service can no longer find it upstream. GET /updates fetches
+  # live from replicated.app, so there is no cache a check would populate.
+  # `// []` keeps an absent key from failing the pipe under pipefail.
+  # Capped at 3m: a cursor absent this long is a real problem, not a settling restart.
+  TARGET=""
+  SELECT_DEADLINE=$(( $(date +%s) + 180 ))
+  while :; do
+    TARGET="$( (api "$KOTS_BASE/api/v1/app/$APP/updates" || true) \
+      | jq -c --arg c "$KOTS_CURSOR" '(.updates // [])[] | select(.updateCursor == $c)' || true)"
+    [ -n "$TARGET" ] && break
+    if [ "$(date +%s)" -ge "$SELECT_DEADLINE" ] || ! waiting; then
+      fail "cursor $KOTS_CURSOR never became an available update for $APP"
+    fi
+    echo "  cursor $KOTS_CURSOR not in the update list yet, rechecking"
+    sleep 15
+  done
+  [ "$(jq -r .isDeployable <<<"$TARGET")" = true ] \
+    || fail "cursor $KOTS_CURSOR not deployable: $(jq -r '.nonDeployableCause // "unknown"' <<<"$TARGET")"
+
+  echo "deploying: $FROM -> $(jq -r .versionLabel <<<"$TARGET") @ $KOTS_CURSOR"
+
+  # --- boot the upgrade service -------------------------------------------
+  R="$(post --data "$(jq -c '{versionLabel, updateCursor, channelId}' <<<"$TARGET")" \
+    "$KOTS_BASE/api/v1/app/$APP/start-upgrade-service" || true)"
+  if ! ok <<<"$R"; then
+    # Read the reason before the license call below overwrites $ERR.
+    REASON="$(why <<<"$R")"
+    # The reason is a cursor or license-channel mismatch; show both sides.
+    L="$(TMO=30 api "$KOTS_BASE/api/v1/app/$APP/license" || true)"
+    echo "  license: $(jq -c '.license | {channelName, licenseSequence, lastSyncedAt}' <<<"${L:-\{\}}" 2>/dev/null)"
+    echo "  release: $(jq -c '{versionLabel, updateCursor, channelId}' <<<"$TARGET")"
+    fail "start-upgrade-service rejected: $REASON"
+  fi
+
+  # Task goes "starting" then EMPTY once up. Empty means ready, not pending.
+  META=""
+  while waiting; do
+    [ "$(TMO=10 api "$KOTS_BASE/api/v1/app/$APP/task/upgrade-service" | jq -r '.status // ""')" = upgrade-failed ] \
+      && fail "upgrade service failed to start"
+    META="$(TMO=10 api "$UP" || true)"; ok <<<"$META" && break
+    META=""; sleep 5
+  done
+  [ -n "$META" ] || fail "upgrade service never came up"
+
+  # --- config: read values, write them straight back -----------------------
+  if [ "$(jq -r .isConfigurable <<<"$META")" = true ]; then
+    TMO=60 api "$UP/config" | jq -c '{configGroups}' >/tmp/cfg.json
+    R="$(TMO=60 api -H 'Content-Type: application/json' -X PUT --data-binary @/tmp/cfg.json "$UP/config" || true)"
+    ok <<<"$R" || fail "config rejected: $(why <<<"$R") — new release likely added a required item with no default"
+  fi
+
+  # --- preflights ----------------------------------------------------------
+  [ "$(jq -r .hasPreflight <<<"$META")" = true ] && preflight_gate "$UP"
+
+  # --- deploy --------------------------------------------------------------
+  R="$(TMO=120 post -d '{"isSkipPreflights":false,"continueWithFailedPreflights":false}' "$UP/deploy" || true)"
+  ok <<<"$R" || fail "deploy rejected: $(why <<<"$R")"
+fi
+
+wait_deployed
+verify_ready
 echo "deployed cursor $KOTS_CURSOR, app ready"

--- a/scripts/test_replicated_deploy.py
+++ b/scripts/test_replicated_deploy.py
@@ -1,0 +1,173 @@
+"""Contract tests for scripts/replicated_deploy.sh.
+
+Each test runs the real script against a stub KOTS API on localhost, so the
+assertions cover the shell's control flow, not a reimplementation of it.
+"""
+
+import json
+import socket
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/replicated_deploy.sh"
+CURSOR = "491"
+
+
+def free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def make_handler(state):
+    def downstream():
+        c = state["deployed"]
+        pend = [{"updateCursor": CURSOR, "sequence": 110}] if state["pending"] and c != CURSOR else []
+        return {
+            "currentVersion": {"updateCursor": c, "sequence": 110 if c == CURSOR else 109,
+                               "status": "deployed", "versionLabel": "0.67.0"},
+            "pendingVersions": pend,
+            "pastVersions": state["past"],
+        }
+
+    class H(BaseHTTPRequestHandler):
+        def log_message(self, *a):
+            pass
+
+        def reply(self, code, obj):
+            body = b"" if obj is None else json.dumps(obj).encode()
+            self.send_response(code)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_PUT(self):
+            self.reply(200, {"success": True})
+
+        def do_POST(self):
+            if self.path.endswith("/deploy"):
+                state["deploy_paths"].append(self.path)
+                if state["deploy_status"] != 200:
+                    return self.reply(state["deploy_status"], state["deploy_body"])
+                state["deployed"] = CURSOR
+            self.reply(200, {"success": True})
+
+        def do_GET(self):
+            p = self.path
+            if p.endswith("/api/v1/apps"):
+                if state["apps_status"] != 200:
+                    return self.reply(state["apps_status"],
+                                      {"error": "missing authorization token", "success": False})
+                return self.reply(200, {"apps": [{"downstream": downstream()}]})
+            if "/updates" in p:
+                ups = [{"updateCursor": CURSOR, "versionLabel": "0.67.0",
+                        "channelId": "ch1", "isDeployable": True}]
+                return self.reply(200, {"updates": [] if state["pending"] or state["past"] else ups})
+            if p.endswith("/preflight/result"):
+                state["polls"] += 1
+                if state["polls"] <= state["placeholders"]:
+                    # the empty result string KOTS writes before the run finishes
+                    return self.reply(200, {"preflightResult": {"result": "",
+                                                                "hasFailingStrictPreflights": False}})
+                strict = state["strict_fail"]
+                res = {"results": [{"isPass": not strict, "title": "mem"}]}
+                return self.reply(200, {"preflightResult": {
+                    "result": json.dumps(res), "hasFailingStrictPreflights": strict}})
+            if "/task/upgrade-service" in p:
+                return self.reply(200, {"status": ""})
+            if p.endswith("/upgrade-service/app/openhands"):
+                return self.reply(200, {"success": True, "isConfigurable": False, "hasPreflight": True})
+            if p.endswith("/status"):
+                return self.reply(200, {"appstatus": {"state": "ready", "sequence": 110,
+                                                      "resourceStates": []}})
+            return self.reply(200, {"success": True})
+
+    return H
+
+
+@pytest.fixture
+def kots():
+    state = {"deployed": "489", "pending": False, "past": [], "polls": 0,
+             "placeholders": 0, "strict_fail": False, "deploy_status": 200,
+             "deploy_body": None, "deploy_paths": [], "apps_status": 200}
+    port = free_port()
+    server = HTTPServer(("127.0.0.1", port), make_handler(state))
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    state["run"] = lambda: subprocess.run(
+        ["bash", str(SCRIPT)], capture_output=True, text=True, timeout=180,
+        env={"PATH": "/usr/bin:/bin:/usr/local/bin", "KOTS_BASE": f"http://127.0.0.1:{port}",
+             "KOTS_PASSWORD": "x", "KOTS_CURSOR": CURSOR, "TIMEOUT_MINUTES": "1"})
+    yield state
+    server.shutdown()
+
+
+def test_a_cursor_already_deployed_verifies_and_succeeds(kots):
+    """Re-running a finished deploy must be a no-op, not a red job."""
+    kots["deployed"] = CURSOR
+    r = kots["run"]()
+    assert r.returncode == 0, r.stderr
+    assert "already deployed" in r.stdout
+    assert kots["deploy_paths"] == []
+
+
+def test_a_downloaded_cursor_is_resumed_from_its_sequence(kots):
+    """A pending version can't boot the upgrade service, so it deploys downstream."""
+    kots["pending"] = True
+    r = kots["run"]()
+    assert r.returncode == 0, r.stderr
+    assert kots["deploy_paths"] == ["/api/v1/app/openhands/sequence/110/deploy"]
+
+
+def test_a_past_cursor_is_refused_as_a_rollback(kots):
+    kots["past"] = [{"updateCursor": CURSOR, "sequence": 95}]
+    r = kots["run"]()
+    assert r.returncode == 1
+    assert "rolling back needs the admin console" in r.stdout
+
+
+def test_an_empty_preflight_result_does_not_claim_preflights_passed(kots):
+    """Verified against unstable: .result is "" on every sequence, healthy ones
+    included, so the gate must report that rather than printing a pass."""
+    kots["placeholders"] = 10**6
+    r = kots["run"]()
+    assert r.returncode == 0, r.stderr
+    assert "preflights: none recorded" in r.stdout
+    assert kots["deploy_paths"], "an empty result must not block the deploy"
+
+
+def test_a_strict_preflight_failure_blocks_the_deploy(kots):
+    kots["strict_fail"] = True
+    r = kots["run"]()
+    assert r.returncode == 1
+    assert "preflights failed" in r.stdout
+    assert kots["deploy_paths"] == []
+
+
+def test_a_rejection_with_no_body_reports_the_status_code(kots):
+    """A bare 4xx used to surface as "deploy rejected: <empty response>"."""
+    kots["deploy_status"] = 404
+    r = kots["run"]()
+    assert r.returncode == 1
+    assert "HTTP 404" in r.stdout
+
+
+def test_a_rejection_reason_is_surfaced_verbatim(kots):
+    kots["deploy_status"] = 400
+    kots["deploy_body"] = {"error": "preflight checks have not completed"}
+    r = kots["run"]()
+    assert r.returncode == 1
+    assert "preflight checks have not completed" in r.stdout
+
+
+def test_an_unreadable_app_state_names_the_reason(kots):
+    """jq returns null with exit 0 on an error body, so this must not fail open."""
+    kots["apps_status"] = 401
+    r = kots["run"]()
+    assert r.returncode == 1
+    assert "could not read app state" in r.stdout
+    assert "missing authorization token" in r.stdout
+    assert "never became an available update" not in r.stdout


### PR DESCRIPTION
## Description

The unstable deploy job failed with `Error: deploy rejected: <empty response>` and there was no way to act on it — the script never inspects HTTP status, so a bare 4xx from KOTS and a dropped connection produce byte-identical output. Re-running didn't help either: a cursor only appears under `/updates` while it's still an *upstream* update, so any re-run of a deploy that already got somewhere failed with `cursor N never became an available update`, which is not what happened.

Two changes, plus first test coverage for this script.

**`scripts/replicated_deploy.sh`**

Resolve the cursor's state once, up front, from a single `/apps` call and give each state a path:

| Cursor is… | Before | Now |
| --- | --- | --- |
| currently deployed | `never became an available update` | verify health, exit 0 |
| pending (downloaded) | hard fail, "deploy from the console" | resume via `sequence/$SEQ/deploy` |
| an upstream update | upgrade-service path | unchanged |
| a past version | `never became an available update` | refused as a rollback, names the console |

So the job is now idempotent for a given cursor — run it fifty times and it converges instead of going red.

`api()` now captures the response code via `curl -w '%{stderr}…'`, so `why()` always has something to report: `.error` → raw body → `HTTP 404` / `curl: (7) … HTTP 000`. `<empty response>` can't recur, and "KOTS refused" is now distinguishable from "never got a reply".

Also guarded the new up-front `/apps` read — `jq '.apps[0].downstream'` returns `null` with exit 0 on an error body, so without it a transient 401 would skip all three branches and spin out the select loop for three minutes before reporting the wrong thing.

Last, `preflight_gate` no longer prints `preflights ok` when KOTS recorded no results. It says `preflights: none recorded`, because on this fleet `.preflightResult.result` is an empty string on *every* sequence, healthy ones included — the old message was claiming a check that never reported.

**`scripts/test_replicated_deploy.py`** — new. Eight cases, each running the real script against a stub KOTS on localhost, so they cover the shell's control flow rather than a reimplementation of it. Runs in ~5s; `test-scripts.yml` already triggers on `scripts/**`.

## Helm Chart Checklist

N/A — no charts touched.

## Additional Notes

Verified read-only against `unstable` rather than reasoned about: the branching was replayed against the live `/apps` payload (489 → deployed, 491 → upstream, 480 → past), and the downstream `sequence/$SEQ/preflight/result` path was confirmed to exist with the shape the script expects.

Two things worth knowing:

- **This does not explain the original rejection.** It makes the next one legible. My first theory — that the empty preflight result meant the script was deploying mid-run — died when the probe showed that empty result is normal on every sequence here, so the root cause is still open.
- The `POST sequence/$SEQ/deploy` response shape is the one thing I couldn't verify; it needs a real pending version to exercise and there wasn't one. If it answers 204 rather than `{"success":true}`, the run fails with `deploy of sequence N rejected: HTTP 204`, naming the exact fix.